### PR TITLE
增加了一个超链聊天跳转

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -21,6 +21,7 @@ var Footer = ""
 var Logo = ""
 var TopUpLink = ""
 var ChatLink = ""
+var ChatLink2 = ""
 var QuotaPerUnit = 500 * 1000.0 // $0.002 / 1K tokens
 var DisplayInCurrencyEnabled = true
 var DisplayTokenStatEnabled = true

--- a/controller/misc.go
+++ b/controller/misc.go
@@ -31,6 +31,7 @@ func GetStatus(c *gin.Context) {
 			"turnstile_site_key":       common.TurnstileSiteKey,
 			"top_up_link":              common.TopUpLink,
 			"chat_link":                common.ChatLink,
+			"chat_link2":               common.ChatLink2,
 			"quota_per_unit":           common.QuotaPerUnit,
 			"display_in_currency":      common.DisplayInCurrencyEnabled,
 			"enable_batch_update":      common.BatchUpdateEnabled,

--- a/model/option.go
+++ b/model/option.go
@@ -76,6 +76,7 @@ func InitOptionMap() {
 	common.OptionMap["GroupRatio"] = common.GroupRatio2JSONString()
 	common.OptionMap["TopUpLink"] = common.TopUpLink
 	common.OptionMap["ChatLink"] = common.ChatLink
+	common.OptionMap["ChatLink2"] = common.ChatLink2
 	common.OptionMap["QuotaPerUnit"] = strconv.FormatFloat(common.QuotaPerUnit, 'f', -1, 64)
 	common.OptionMap["RetryTimes"] = strconv.Itoa(common.RetryTimes)
 	common.OptionMap["DataExportInterval"] = strconv.Itoa(common.DataExportInterval)
@@ -241,6 +242,8 @@ func updateOptionMap(key string, value string) (err error) {
 		common.TopUpLink = value
 	case "ChatLink":
 		common.ChatLink = value
+	case "ChatLink2":
+		common.ChatLink2 = value
 	case "ChannelDisableThreshold":
 		common.ChannelDisableThreshold, _ = strconv.ParseFloat(value, 64)
 	case "QuotaPerUnit":

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -57,6 +57,11 @@ function App() {
       } else {
         localStorage.removeItem('chat_link');
       }
+      if (data.chat_link2) {
+        localStorage.setItem('chat_link2', data.chat_link2);
+      } else {
+        localStorage.removeItem('chat_link2');
+      }
       // if (
       //   data.version !== process.env.REACT_APP_VERSION &&
       //   data.version !== 'v0.0.0' &&

--- a/web/src/components/OperationSetting.js
+++ b/web/src/components/OperationSetting.js
@@ -15,6 +15,7 @@ const OperationSetting = () => {
         GroupRatio: '',
         TopUpLink: '',
         ChatLink: '',
+        ChatLink2: '', // 添加的新状态变量
         QuotaPerUnit: 0,
         AutomaticDisableChannelEnabled: '',
         ChannelDisableThreshold: 0,
@@ -141,6 +142,9 @@ const OperationSetting = () => {
                 if (originInputs['ChatLink'] !== inputs.ChatLink) {
                     await updateOption('ChatLink', inputs.ChatLink);
                 }
+                if (originInputs['ChatLink2'] !== inputs.ChatLink2) {
+                    await updateOption('ChatLink2', inputs.ChatLink2);
+                }
                 if (originInputs['QuotaPerUnit'] !== inputs.QuotaPerUnit) {
                     await updateOption('QuotaPerUnit', inputs.QuotaPerUnit);
                 }
@@ -184,6 +188,15 @@ const OperationSetting = () => {
                             onChange={handleInputChange}
                             autoComplete='new-password'
                             value={inputs.ChatLink}
+                            type='link'
+                            placeholder='例如 ChatGPT Next Web 的部署地址'
+                        />
+                        <Form.Input
+                            label='聊天页面2链接'
+                            name='ChatLink2'
+                            onChange={handleInputChange}
+                            autoComplete='new-password'
+                            value={inputs.ChatLink2}
                             type='link'
                             placeholder='例如 ChatGPT Next Web 的部署地址'
                         />

--- a/web/src/components/TokensTable.js
+++ b/web/src/components/TokensTable.js
@@ -26,12 +26,12 @@ const {Column} = Table;
 
 const COPY_OPTIONS = [
     {key: 'next', text: 'ChatGPT Next Web', value: 'next'},
-    {key: 'ama', text: 'AMA 问天', value: 'ama'},
+    {key: 'ama', text: 'ChatGPT Web & Midjourney', value: 'ama'},
     {key: 'opencat', text: 'OpenCat', value: 'opencat'},
 ];
 
 const OPEN_LINK_OPTIONS = [
-    {key: 'ama', text: 'AMA 问天', value: 'ama'},
+    {key: 'ama', text: 'ChatGPT Web & Midjourney', value: 'ama'},
     {key: 'opencat', text: 'OpenCat', value: 'opencat'},
 ];
 
@@ -66,7 +66,7 @@ const TokensTable = () => {
 
     const link_menu = [
         {node: 'item', key: 'next', name: 'ChatGPT Next Web', onClick: () => {onOpenLink('next')}},
-        {node: 'item', key: 'ama', name: 'AMA 问天', value: 'ama'},
+        {node: 'item', key: 'ama', name: 'ChatGPT Web & Midjourney', value: 'ama'},
         {node: 'item', key: 'opencat', name: 'OpenCat', value: 'opencat'},
     ];
 
@@ -155,7 +155,7 @@ const TokensTable = () => {
                         <Dropdown trigger="click" position="bottomRight" menu={
                             [
                                 {node: 'item', key: 'next', name: 'ChatGPT Next Web', onClick: () => {onOpenLink('next', record.key)}},
-                                {node: 'item', key: 'ama', name: 'AMA 问天（BotGrem）', onClick: () => {onOpenLink('ama', record.key)}},
+                                {node: 'item', key: 'ama', name: 'ChatGPT Web & Midjourney', onClick: () => {onOpenLink('ama', record.key)}},
                                 {node: 'item', key: 'opencat', name: 'OpenCat', onClick: () => {onOpenLink('opencat', record.key)}},
                             ]
                         }
@@ -289,6 +289,7 @@ const TokensTable = () => {
         }
         let encodedServerAddress = encodeURIComponent(serverAddress);
         const nextLink = localStorage.getItem('chat_link');
+        const mjLink = localStorage.getItem('chat_link2');
         let nextUrl;
 
         if (nextLink) {
@@ -300,7 +301,7 @@ const TokensTable = () => {
         let url;
         switch (type) {
             case 'ama':
-                url = `ama://set-api-key?server=${encodedServerAddress}&key=sk-${key}`;
+                url = mjLink + `/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
                 break;
             case 'opencat':
                 url = `opencat://team/join?domain=${encodedServerAddress}&token=sk-${key}`;
@@ -351,7 +352,7 @@ const TokensTable = () => {
         let url;
         switch (type) {
             case 'ama':
-                url = `ama://set-api-key?server=${encodedServerAddress}&key=sk-${key}`;
+                url = `https://mjgpt.grqnas.cn/#/?settings={"key":"sk-${key}","url":"${serverAddress}"}`;
                 break;
 
             case 'opencat':


### PR DESCRIPTION
在“运营设置里面”增加了“聊天页面2链接”，方便将项目（https://github.com/Dooy/chatgpt-web-midjourney-proxy） 替换掉原来的AMA问天。这样可以部署多个聊天前端。

Changes to be committed:
    modified:   common/constants.go
    modified:   controller/misc.go
    modified:   model/option.go
    modified:   web/src/App.js
    modified:   web/src/components/OperationSetting.js
    modified:   web/src/components/TokensTable.js