### PR TITLE
fix: model name not trimmed

### DIFF
--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -454,7 +454,7 @@ const EditChannel = (props) => {
                             placeholder='输入自定义模型名称'
                             value={customModel}
                             onChange={(value) => {
-                                setCustomModel(value);
+                                setCustomModel(value.trim());
                             }}
                         />
                     </div>

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -241,7 +241,7 @@ const EditChannel = (props) => {
 
     const addCustomModel = () => {
         if (customModel.trim() === '') return;
-        if (inputs.models.includes(customModel)) return;
+        if (inputs.models.includes(customModel)) return showError("该模型已存在！");
         let localModels = [...inputs.models];
         localModels.push(customModel);
         let localModelOptions = [];


### PR DESCRIPTION
1. [fix: model names must not contain spaces at both ends](https://github.com/Calcium-Ion/new-api/commit/d160736a4957c6e82cd20eb58c02d8b5b83ae2be)
2. [perf: prompt when the name of the custom model input already exists](https://github.com/Calcium-Ion/new-api/commit/92c1ed7f1dfc7e2f31379f8b9e9191de5abf185e)