### PR TITLE
增加验证是否是邮箱登录及注册用户名验证。

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"one-api/common"
+	"regexp"
 	"strings"
 	"time"
 
@@ -172,6 +173,14 @@ func (user *User) Insert(inviterId int) error {
 			return err
 		}
 	}
+
+	// 在这里添加对用户名的正则表达式检查
+	regExp := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	if !regExp.MatchString(user.Username) {
+		return errors.New("用户名包含非法字符，仅支持字母、数字、下划线(_)和横杠(-)")
+	}
+
+	// 用户名通过检查后，继续其他注册逻辑
 	user.Quota = common.QuotaForNewUser
 	user.AccessToken = common.GetUUID()
 	user.AffCode = common.GetRandomString(4)
@@ -233,12 +242,13 @@ func (user *User) HardDelete() error {
 
 // ValidateAndFill check password & user status
 func (user *User) ValidateAndFill() (err error) {
-	// When querying with struct, GORM will only query with non-zero fields,
-	// that means if your field’s value is 0, '', false or other zero values,
-	// it won’t be used to build query conditions
 	password := user.Password
 	if user.Username == "" || password == "" {
 		return errors.New("用户名或密码为空")
+	}
+	// 检查是否使用邮箱作为用户名
+	if strings.Contains(user.Username, "@") {
+		return errors.New("本站仅支持使用用户名登录，不支持使用邮箱登录")
 	}
 	DB.Where(User{Username: user.Username}).First(user)
 	okay := common.ValidatePasswordAndHash(password, user.Password)


### PR DESCRIPTION
如题，增加两个功能：
1.注册时，判断注册用户名是否为字母或数字。
2.登录时判断是否为邮箱登录，提示使用用户名登录。
![79C21CC5162D8DC06CFCC7482BA55023](https://github.com/Calcium-Ion/new-api/assets/61670021/dd66726b-dd94-4b47-9f0b-32fd38d03387)
![2904E485E80120E8648541C02C2E2AEA](https://github.com/Calcium-Ion/new-api/assets/61670021/f571b46b-4d30-431c-aef9-8df8375bbbf7)
