### PR TITLE
fix: openai_organization not working

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -155,6 +155,9 @@ func Distribute() func(c *gin.Context) {
 				if channel.AutoBan != nil && *channel.AutoBan == 0 {
 					ban = false
 				}
+				if nil != channel.OpenAIOrganization {
+					c.Request.Header.Set("OpenAI-Organization", *channel.OpenAIOrganization)
+				}
 				c.Set("auto_ban", ban)
 				c.Set("model_mapping", channel.GetModelMapping())
 				c.Request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", channel.Key))

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -156,7 +156,7 @@ func Distribute() func(c *gin.Context) {
 					ban = false
 				}
 				if nil != channel.OpenAIOrganization {
-					c.Request.Header.Set("OpenAI-Organization", *channel.OpenAIOrganization)
+					c.Set("channel_organization", *channel.OpenAIOrganization)
 				}
 				c.Set("auto_ban", ban)
 				c.Set("model_mapping", channel.GetModelMapping())

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -49,11 +49,8 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, info *re
 		req.Header.Set("api-key", info.ApiKey)
 		return nil
 	}
-	if info.ChannelType == common.ChannelTypeOpenAI {
-		orgId := c.GetHeader("OpenAI-Organization")
-		if "" != orgId {
-			req.Header.Set("OpenAI-Organization", orgId)
-		}
+	if info.ChannelType == common.ChannelTypeOpenAI && "" != info.Organization {
+		req.Header.Set("OpenAI-Organization", info.Organization)
 	}
 	req.Header.Set("Authorization", "Bearer "+info.ApiKey)
 	//if info.ChannelType == common.ChannelTypeOpenRouter {

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -49,6 +49,12 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, info *re
 		req.Header.Set("api-key", info.ApiKey)
 		return nil
 	}
+	if info.ChannelType == common.ChannelTypeOpenAI {
+		orgId := c.GetHeader("OpenAI-Organization")
+		if "" != orgId {
+			req.Header.Set("OpenAI-Organization", orgId)
+		}
+	}
 	req.Header.Set("Authorization", "Bearer "+info.ApiKey)
 	//if info.ChannelType == common.ChannelTypeOpenRouter {
 	//	req.Header.Set("HTTP-Referer", "https://github.com/songquanpeng/one-api")

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -24,6 +24,7 @@ type RelayInfo struct {
 	ApiVersion        string
 	PromptTokens      int
 	ApiKey            string
+	Organization      string
 	BaseUrl           string
 }
 
@@ -52,6 +53,7 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 		ApiType:        apiType,
 		ApiVersion:     c.GetString("api_version"),
 		ApiKey:         strings.TrimPrefix(c.Request.Header.Get("Authorization"), "Bearer "),
+		Organization:   c.GetString("channel_organization"),
 	}
 	if info.BaseUrl == "" {
 		info.BaseUrl = common.ChannelBaseURLs[channelType]


### PR DESCRIPTION
目前 `openai_organization` （组织ID）设置只在渠道设置中写入/读取，并不会真正使用在 OpenAI API 调用时。
根据官方文档描述，这个值需要通过 `OpenAI-Organization` 头传递。

<img width="795" alt="image" src="https://github.com/Calcium-Ion/new-api/assets/8010600/ec9227d6-af29-4a29-a439-62213c78e578">
