### PR TITLE
优先使用模型重定向前的价格和倍率

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -173,7 +173,7 @@ func UpdateModelRatioByJSONString(jsonStr string) error {
 	return json.Unmarshal([]byte(jsonStr), &modelRatio)
 }
 
-func GetModelRatio(name string) float64 {
+func GetModelRatio(name string) (float64, bool) {
 	if modelRatio == nil {
 		modelRatio = DefaultModelRatio
 	}
@@ -183,9 +183,9 @@ func GetModelRatio(name string) float64 {
 	ratio, ok := modelRatio[name]
 	if !ok {
 		SysError("model ratio not found: " + name)
-		return 30
+		return 30, false
 	}
-	return ratio
+	return ratio, true
 }
 
 func GetCompletionRatio(name string) float64 {

--- a/relay/relay-audio.go
+++ b/relay/relay-audio.go
@@ -73,7 +73,7 @@ func AudioHelper(c *gin.Context, relayMode int) *dto.OpenAIErrorWithStatusCode {
 		}
 		preConsumedTokens = promptTokens
 	}
-	modelRatio := common.GetModelRatio(audioRequest.Model)
+	modelRatio, _ := common.GetModelRatio(audioRequest.Model)
 	groupRatio := common.GetGroupRatio(group)
 	ratio := modelRatio * groupRatio
 	preConsumedQuota := int(float64(preConsumedTokens) * ratio)


### PR DESCRIPTION
你好，这边遇到模型经过重定向之后走的倍率是重定向后的倍率

场景是
我对接了渠道A，他的GPT-4模型调用是每次0.1RMB
我在我的站点新增了模型GPT-4-COUNT（因为我已经有倍率计算的渠道占用GPT-4了），并设置了GPT-4-COUNT价格是0.1，同时重定向到渠道A的GPT-4。
但发现调用之后走的倍率是默认GPT-4的，而不是我设置的GPT-4-COUNT
所以想改成优先获取重定向前的倍率或价格