### PR TITLE
修改了用户注册使用临时邮箱验证的问题

### DIFF
--- a/controller/misc.go
+++ b/controller/misc.go
@@ -120,18 +120,28 @@ func SendEmailVerification(c *gin.Context) {
 		})
 		return
 	}
-	if common.EmailDomainRestrictionEnabled {
+	if config.EmailDomainRestrictionEnabled {
+		parts := strings.Split(email, "@")
+		localPart := parts[0]
+		domainPart := parts[1]
+
+		containsSpecialSymbols := strings.Contains(localPart, "+") || strings.Count(localPart, ".") > 1
 		allowed := false
-		for _, domain := range common.EmailDomainWhitelist {
-			if strings.HasSuffix(email, "@"+domain) {
+		for _, domain := range config.EmailDomainWhitelist {
+			if domainPart == domain {
 				allowed = true
 				break
 			}
 		}
-		if !allowed {
+		if allowed && !containsSpecialSymbols {
+			c.JSON(http.StatusOK, gin.H{
+				"success": true,
+				"message": "Your email address is allowed.",
+			})
+		} else {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
-				"message": "管理员启用了邮箱域名白名单，您的邮箱地址的域名不在白名单中",
+				"message": "The administrator has enabled the email domain name whitelist, and your email address is not allowed due to special symbols or it's not in the whitelist.",
 			})
 			return
 		}


### PR DESCRIPTION
当前的对于注册邮箱的验证，对于[aaaa+aa@xx.com](mailto:aaaa+aa@xx.com)或者[aaaa.aa@xx.com](mailto:aaaa.aa@xx.com)是可以检验的，但是对于[a.s.h.l.eynu.ej.a3@gmail.com](mailto:a.s.h.l.eynu.ej.a3@gmail.com)这种谷歌的临时邮箱就无法检验，因此进行修改。
应用场景：限制注册用户无休止的薅羊毛
![318512004-749bc2cb-c155-4e7d-9658-2804a768b72a](https://github.com/Calcium-Ion/new-api/assets/137054651/af889784-2cbb-4804-a197-02d722b93943)
