### PR TITLE
Fix: CompletionRatio is not working for openrouter.ai

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -206,11 +206,11 @@ func GetCompletionRatio(name string) float64 {
 		}
 		return 2
 	}
-	if strings.HasPrefix(name, "claude-instant-1") {
+	if strings.Contains(name, "claude-instant-1") {
 		return 3
-	} else if strings.HasPrefix(name, "claude-2") {
+	} else if strings.Contains(name, "claude-2") {
 		return 3
-	} else if strings.HasPrefix(name, "claude-3") {
+	} else if strings.Contains(name, "claude-3") {
 		return 5
 	}
 	if strings.HasPrefix(name, "mistral-") {


### PR DESCRIPTION
https://openrouter.ai/docs#models
Model name of openrouter is prefix with company name, e.g. "model": "anthropic/claude-3-opus:beta", therefore, CompletionRatio will not working, which is only work for prefix with claude-xxx