### PR TITLE
添加同步上游模型列表按钮

### DIFF
--- a/router/api-router.go
+++ b/router/api-router.go
@@ -90,6 +90,8 @@ func SetApiRouter(router *gin.Engine) {
 			channelRoute.DELETE("/:id", controller.DeleteChannel)
 			channelRoute.POST("/batch", controller.DeleteChannelBatch)
 			channelRoute.POST("/fix", controller.FixChannelsAbilities)
+			channelRoute.GET("/fetch_models/:id", controller.FetchUpstreamModels)
+
 		}
 		tokenRoute := apiRouter.Group("/token")
 		tokenRoute.Use(middleware.UserAuth())


### PR DESCRIPTION
在模型编辑侧边栏添加一个快速同步上游渠道商模型列表的按钮。用于快速操作。