### PR TITLE
fix testAllChannels nil pointer panic

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -222,16 +222,18 @@ func testAllChannels(notify bool) error {
 			if channel.AutoBan != nil && *channel.AutoBan == 0 {
 				ban = false
 			}
-			openAiErrWithStatus := dto.OpenAIErrorWithStatusCode{
-				StatusCode: -1,
-				Error:      *openaiErr,
-				LocalError: false,
-			}
-			if isChannelEnabled && service.ShouldDisableChannel(&openAiErrWithStatus) && ban {
-				service.DisableChannel(channel.Id, channel.Name, err.Error())
-			}
-			if !isChannelEnabled && service.ShouldEnableChannel(err, openaiErr, channel.Status) {
-				service.EnableChannel(channel.Id, channel.Name)
+			if openaiErr != nil {
+				openAiErrWithStatus := dto.OpenAIErrorWithStatusCode{
+					StatusCode: -1,
+					Error:      *openaiErr,
+					LocalError: false,
+				}
+				if isChannelEnabled && service.ShouldDisableChannel(&openAiErrWithStatus) && ban {
+					service.DisableChannel(channel.Id, channel.Name, err.Error())
+				}
+				if !isChannelEnabled && service.ShouldEnableChannel(err, openaiErr, channel.Status) {
+					service.EnableChannel(channel.Id, channel.Name)
+				}
 			}
 			channel.UpdateResponseTime(milliseconds)
 			time.Sleep(common.RequestInterval)


### PR DESCRIPTION
修复由于没有编写测试成功的处理逻辑，导致openaiErr为空产生的空指针错误

```
{"id":"xxxxxxxxxxxxxxxx","object":"chat.completion","created":1719456755,"choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"max_tokens"}],"usage":{"prompt_tokens":8,"completion_tokens":1,"total_tokens":9}} 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xda7802]

goroutine 1425 [running]:
one-api/controller.testAllChannels.func1()
        /build/controller/channel-test.go:227 +0x3e2
created by one-api/controller.testAllChannels in goroutine 58
        /build/controller/channel-test.go:204 +0x1c5
```
