### PR TITLE
fix: 修复aws claude渠道panic的问题

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -222,9 +222,11 @@ func awsStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 		}
 	}
 	service.Done(c)
-	err = resp.Body.Close()
-	if err != nil {
-		return service.OpenAIErrorWrapperLocal(err, "close_response_body_failed", http.StatusInternalServerError), nil
+	if resp != nil {
+		err = resp.Body.Close()
+		if err != nil {
+			return service.OpenAIErrorWrapperLocal(err, "close_response_body_failed", http.StatusInternalServerError), nil
+		}
 	}
 	return nil, &usage
 }


### PR DESCRIPTION
aws渠道的adaptor.go文件DoRequest函数返回了nil，然后awsStreamHandler函数将其作为resp，调用resp.Body.Close()导致panic