### PR TITLE
Support cloudflare llama3.1-8b

### DIFF
--- a/relay/channel/cloudflare/constant.go
+++ b/relay/channel/cloudflare/constant.go
@@ -1,6 +1,7 @@
 package cloudflare
 
 var ModelList = []string{
+	"@cf/meta/llama-3.1-8b-instruct",
 	"@cf/meta/llama-2-7b-chat-fp16",
 	"@cf/meta/llama-2-7b-chat-int8",
 	"@cf/mistral/mistral-7b-instruct-v0.1",


### PR DESCRIPTION
cloudflare已经可以白嫖性能相当优秀的Llama 3.1 8b了，上下文更长更聪明，可以替代目前的量化qwen14b和其他一众小模型，赞美赛博佛祖。