### PR TITLE
fix: 渠道多分组查询 sqlite 查询兼容

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -108,10 +108,11 @@ func SearchChannels(keyword string, group string, model string) ([]*Channel, err
 	var args []interface{}
 	if group != "" && group != "null" {
 		var groupCondition string
-		if common.UsingPostgreSQL {
-			groupCondition = `(',' || ` + groupCol + ` || ',') LIKE ?`
-		} else {
+		if common.UsingMySQL {
 			groupCondition = `CONCAT(',', ` + groupCol + `, ',') LIKE ?`
+		} else {
+			// sqlite, PostgreSQL
+			groupCondition = `(',' || ` + groupCol + ` || ',') LIKE ?`
 		}
 		whereClause = "(id = ? OR name LIKE ? OR " + keyCol + " = ?) AND " + modelsCol + ` LIKE ? AND ` + groupCondition
 		args = append(args, common.String2Int(keyword), "%"+keyword+"%", keyword, "%"+model+"%", "%,"+group+",%")
@@ -121,7 +122,7 @@ func SearchChannels(keyword string, group string, model string) ([]*Channel, err
 	}
 
 	// 执行查询
-	err := baseQuery.Where(whereClause, args...).Find(&channels).Error
+	err := baseQuery.Where(whereClause, args...).Order("priority desc").Find(&channels).Error
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. 分组搜索经测试兼容， mysql、sqlite、postgresql
2. 搜索时默认排序 priority desc