### PR TITLE
修改图标样式和聊天按钮的位置，子页面切换主题

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
     4. Telegram Bot 名称是bot username 去掉@后的字符串
 13. 添加 [Suno API](https://github.com/Suno-API/Suno-API)接口的支持，[对接文档](Suno.md)
 14. 支持Rerank模型，目前仅兼容Cohere和Jina，可接入Dify，[对接文档](Rerank.md)
+15. 支持使用路由/chat2link 进入聊天界面
 
 ## 模型支持
 此版本额外支持以下模型：

--- a/web/src/components/HeaderBar.js
+++ b/web/src/components/HeaderBar.js
@@ -12,6 +12,7 @@ import {
   IconHelpCircle,
   IconHome,
   IconHomeStroked,
+  IconComment,
   IconKey,
   IconNoteMoneyStroked,
   IconPriceTag,
@@ -37,6 +38,28 @@ let buttons = [
     itemKey: 'home',
     to: '/',
     icon: <IconHomeStroked />,
+    onMouseEnter: (e) => {
+      e.currentTarget.querySelector('svg').style.color = '#0064FA';
+    },
+    onMouseLeave: (e) => {
+      e.currentTarget.querySelector('svg').style.color = 'black';
+    },
+  },
+  // 增加 聊天 按钮
+  {
+    text: '聊天',
+    itemKey: 'chat',
+    to: '/chat',
+    icon: <IconComment />,
+    onMouseEnter: (e) => {
+      e.currentTarget.querySelector('svg').style.color = '#0064FA';
+    },
+    onMouseLeave: (e) => {
+      e.currentTarget.querySelector('svg').style.color = 'black';
+    },
+    className: localStorage.getItem('chat_link')
+      ? 'semi-navigation-item-normal'
+      : 'tableHiddle',
   },
   // {
   //   text: '模型价格',
@@ -115,6 +138,7 @@ const HeaderBar = () => {
                 login: '/login',
                 register: '/register',
                 home: '/',
+                chat: '/chat',
               };
               return (
                 <Link

--- a/web/src/components/HeaderBar.js
+++ b/web/src/components/HeaderBar.js
@@ -118,13 +118,19 @@ const HeaderBar = () => {
   useEffect(() => {
     if (theme === 'dark') {
       document.body.setAttribute('theme-mode', 'dark');
+    } else {
+      document.body.removeAttribute('theme-mode');
+    }
+    // 发送当前主题模式给子页面
+    const iframe = document.querySelector('iframe');
+    if (iframe) {
+      iframe.contentWindow.postMessage({ themeMode: theme }, '*');
     }
 
     if (isNewYear) {
       console.log('Happy New Year!');
     }
-  }, []);
-
+  }, [theme]); // 监听 theme-mode 的变化
   return (
     <>
       <Layout>

--- a/web/src/components/HeaderBar.js
+++ b/web/src/components/HeaderBar.js
@@ -57,7 +57,7 @@ let buttons = [
     onMouseLeave: (e) => {
       e.currentTarget.querySelector('svg').style.color = 'black';
     },
-    className: localStorage.getItem('chat_link')
+    className: localStorage.getItem('chat_link') && !isMobile() //移动端不显示
       ? 'semi-navigation-item-normal'
       : 'tableHiddle',
   },

--- a/web/src/components/LoginForm.js
+++ b/web/src/components/LoginForm.js
@@ -170,7 +170,7 @@ const LoginForm = () => {
                   <Form.Input
                     field={'username'}
                     label={'用户名'}
-                    placeholder='用户名'
+                    placeholder='请输入用户名或邮箱'
                     name='username'
                     onChange={(value) => handleChange('username', value)}
                   />

--- a/web/src/components/LoginForm.js
+++ b/web/src/components/LoginForm.js
@@ -170,7 +170,7 @@ const LoginForm = () => {
                   <Form.Input
                     field={'username'}
                     label={'用户名'}
-                    placeholder='请输入用户名或邮箱'
+                    placeholder='用户名'
                     name='username'
                     onChange={(value) => handleChange('username', value)}
                   />

--- a/web/src/components/SiderBar.js
+++ b/web/src/components/SiderBar.js
@@ -86,16 +86,16 @@ const SiderBar = () => {
         icon: <IconLayers />,
         className: isAdmin() ? 'semi-navigation-item-normal' : 'tableHiddle',
       },
-      // 去掉侧边栏的聊天，换到HeaderBar
-      // {
-      //   text: '聊天',
-      //   itemKey: 'chat',
-      //   to: '/chat',
-      //   icon: <IconComment />,
-      //   className: localStorage.getItem('chat_link')
-      //     ? 'semi-navigation-item-normal'
-      //     : 'tableHiddle',
-      // },
+      // 修改侧边栏的聊天按钮，当移动端的时候才显示。
+      {
+        text: '聊天',
+        itemKey: 'chat',
+        to: '/chat',
+        icon: <IconComment />,
+        className: isMobile() && localStorage.getItem('chat_link')
+          ? 'semi-navigation-item-normal'
+          : 'tableHiddle',
+      },
       {
         text: '令牌',
         itemKey: 'token',

--- a/web/src/components/SiderBar.js
+++ b/web/src/components/SiderBar.js
@@ -86,15 +86,16 @@ const SiderBar = () => {
         icon: <IconLayers />,
         className: isAdmin() ? 'semi-navigation-item-normal' : 'tableHiddle',
       },
-      {
-        text: '聊天',
-        itemKey: 'chat',
-        to: '/chat',
-        icon: <IconComment />,
-        className: localStorage.getItem('chat_link')
-          ? 'semi-navigation-item-normal'
-          : 'tableHiddle',
-      },
+      // 去掉侧边栏的聊天，换到HeaderBar
+      // {
+      //   text: '聊天',
+      //   itemKey: 'chat',
+      //   to: '/chat',
+      //   icon: <IconComment />,
+      //   className: localStorage.getItem('chat_link')
+      //     ? 'semi-navigation-item-normal'
+      //     : 'tableHiddle',
+      // },
       {
         text: '令牌',
         itemKey: 'token',

--- a/web/src/pages/Home/index.js
+++ b/web/src/pages/Home/index.js
@@ -35,6 +35,19 @@ const Home = () => {
       }
       setHomePageContent(content);
       localStorage.setItem('home_page_content', content);
+
+        // 如果内容是 URL，则发送主题模式
+        if (data.startsWith('https://')) {
+            const iframe = document.querySelector('iframe');
+            if (iframe) {
+                const theme = localStorage.getItem('theme-mode') || 'light';
+                // 测试是否正确传递theme-mode给iframe
+                // console.log('Sending theme-mode to iframe:', theme); 
+                iframe.onload = () => {
+                    iframe.contentWindow.postMessage({ themeMode: theme }, '*');
+                };
+            }
+        }
     } else {
       showError(message);
       setHomePageContent('加载首页内容失败...');


### PR DESCRIPTION
主要修改：
1、将聊天改到HeaderBar上面，方便小白直接使用聊天功能。（移动端的界面保持原来的样式。）
2、给HeaderBar上的主页和聊天按钮增加了鼠标悬停效果，增加视觉反馈。（移动端的界面不增加聊天按钮。）
3、使用postMessage向iframe传参theme-mode，实现切换子页面主题的功能
子页面的js示例
```
<script>
    // 接收父页面的主题模式
    window.addEventListener('message', function(event) {
        if (event.data.themeMode) {
            var theme = event.data.themeMode;
            // 测试是否正确接受到theme-mode的值
            // console.log('Received theme mode from parent:', theme);
            applyTheme(theme);
        }
    });

    // 定义一个函数来应用主题
    function applyTheme(theme) {
        var body = document.body;
        if (theme === 'dark') {
            body.classList.add("dark-mode");
            document.getElementById("darkModeToggle").checked = true;
        } else {
            body.classList.remove("dark-mode");
            document.getElementById("darkModeToggle").checked = false;
        }
    }
</script>
```