### PR TITLE
chore: 修正chatgpt-4o-latest补全倍率

### DIFF
--- a/common/model-ratio.go
+++ b/common/model-ratio.go
@@ -351,7 +351,7 @@ func GetCompletionRatio(name string) float64 {
 		return 4
 	}
 	if name == "chatgpt-4o-latest" {
-		return 4
+		return 3
 	}
 	if strings.Contains(name, "claude-instant-1") {
 		return 3


### PR DESCRIPTION
fix wrong model ratio about chatgpt-4o-latest
补全倍率应该是3,修改错误值4。

用户: 卧槽怎么4olatest比0513还贵？

点名批评.jpg

![image](https://github.com/user-attachments/assets/a17bae53-a2a6-4c48-a348-0883860b304f)
