### PR TITLE
Continue fixing Ollama embedding return issue

### DIFF
--- a/relay/channel/ollama/dto.go
+++ b/relay/channel/ollama/dto.go
@@ -37,5 +37,5 @@ type OllamaEmbeddingRequest struct {
 type OllamaEmbeddingResponse struct {
 	Error     string    `json:"error,omitempty"`
 	Model     string    `json:"model"`
-	Embedding []float64 `json:"embeddings,omitempty"`
+	Embedding [][]float64 `json:"embeddings,omitempty"`
 }

--- a/relay/channel/ollama/relay-ollama.go
+++ b/relay/channel/ollama/relay-ollama.go
@@ -73,9 +73,10 @@ func ollamaEmbeddingHandler(c *gin.Context, resp *http.Response, promptTokens in
 	if ollamaEmbeddingResponse.Error != "" {
 		return service.OpenAIErrorWrapper(err, "ollama_error", resp.StatusCode), nil
 	}
+	flattenedEmbeddings := flattenEmbeddings(ollamaEmbeddingResponse.Embedding)
 	data := make([]dto.OpenAIEmbeddingResponseItem, 0, 1)
 	data = append(data, dto.OpenAIEmbeddingResponseItem{
-		Embedding: ollamaEmbeddingResponse.Embedding,
+		Embedding: flattenedEmbeddings,
 		Object:    "embedding",
 	})
 	usage := &dto.Usage{
@@ -119,4 +120,12 @@ func ollamaEmbeddingHandler(c *gin.Context, resp *http.Response, promptTokens in
 		return service.OpenAIErrorWrapper(err, "close_response_body_failed", http.StatusInternalServerError), nil
 	}
 	return nil, usage
+}
+
+func flattenEmbeddings(embeddings [][]float64) []float64 {
+flattened := []float64{}
+for _, row := range embeddings {
+	flattened = append(flattened, row...)
+}
+return flattened
 }


### PR DESCRIPTION
Performed a risky operation, converting the two-dimensional array obtained by ollama into a one-dimensional array through loop iteration to achieve openai compatibility.