### PR TITLE
增加对于gemini-exp-1114模型的支持，映射到v1beta

### DIFF
--- a/constant/env.go
+++ b/constant/env.go
@@ -30,6 +30,7 @@ var GeminiModelMap = map[string]string{
 	"gemini-1.5-flash-001":      "v1beta",
 	"gemini-1.5-flash":          "v1beta",
 	"gemini-ultra":              "v1beta",
+	"gemini-exp-1114":           "v1beta",
 }
 
 func InitEnv() {

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -30,22 +30,13 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
-	var version string
-	
-	// 为特定模型指定版本
-	switch info.UpstreamModelName {
-	case "gemini-exp-1114":
-		version = "v1beta"
-	default:
-		// 从映射中获取模型名称对应的版本，如果找不到就使用 info.ApiVersion 或默认的版本 "v1"
-		var beta bool
-		version, beta = constant.GeminiModelMap[info.UpstreamModelName]
-		if !beta {
-			if info.ApiVersion != "" {
-				version = info.ApiVersion
-			} else {
-				version = "v1"
-			}
+	// 从映射中获取模型名称对应的版本，如果找不到就使用 info.ApiVersion 或默认的版本 "v1"
+	version, beta := constant.GeminiModelMap[info.UpstreamModelName]
+	if !beta {
+		if info.ApiVersion != "" {
+			version = info.ApiVersion
+		} else {
+			version = "v1"
 		}
 	}
 

--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -30,13 +30,22 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
-	// 从映射中获取模型名称对应的版本，如果找不到就使用 info.ApiVersion 或默认的版本 "v1"
-	version, beta := constant.GeminiModelMap[info.UpstreamModelName]
-	if !beta {
-		if info.ApiVersion != "" {
-			version = info.ApiVersion
-		} else {
-			version = "v1"
+	var version string
+	
+	// 为特定模型指定版本
+	switch info.UpstreamModelName {
+	case "gemini-exp-1114":
+		version = "v1beta"
+	default:
+		// 从映射中获取模型名称对应的版本，如果找不到就使用 info.ApiVersion 或默认的版本 "v1"
+		var beta bool
+		version, beta = constant.GeminiModelMap[info.UpstreamModelName]
+		if !beta {
+			if info.ApiVersion != "" {
+				version = info.ApiVersion
+			} else {
+				version = "v1"
+			}
 		}
 	}
 

--- a/relay/channel/gemini/constant.go
+++ b/relay/channel/gemini/constant.go
@@ -7,6 +7,7 @@ const (
 var ModelList = []string{
 	"gemini-1.0-pro-latest", "gemini-1.0-pro-001", "gemini-1.5-pro-latest", "gemini-1.5-flash-latest", "gemini-ultra",
 	"gemini-1.0-pro-vision-latest", "gemini-1.0-pro-vision-001", "gemini-1.5-pro-exp-0827", "gemini-1.5-flash-exp-0827",
+	"gemini-exp-1114",
 }
 
 var ChannelName = "google gemini"


### PR DESCRIPTION
   # feat(gemini): add support for gemini-exp-1114 model
   
   ## 更改内容
   - 添加 gemini-exp-1114 到 ModelList
   - 更新 GetRequestURL 以支持 gemini-exp-1114 使用 v1beta API
   - 保持其他模型的兼容性不变
   
   ## 测试
   - [x] 已测试 gemini-exp-1114 模型调用
   - [x] 确认其他模型功能正常
   
   ## 相关问题
   - 修复了 gemini-exp-1114 模型 404 错误的问题

feat(gemini): add support for gemini-exp-1114 model

- Add gemini-exp-1114 to ModelList in constant.go
- Update GetRequestURL in adaptor.go to use v1beta API version for gemini-exp-1114
- Keep backward compatibility for other models

This change enables the use of the experimental gemini-exp-1114 model by correctly routing its requests to the v1beta API endpoint while maintaining existing functionality for other models.