### PR TITLE
feat: support Azure Comm Service SMTP

### DIFF
--- a/common/email-outlook-auth.go
+++ b/common/email-outlook-auth.go
@@ -36,5 +36,5 @@ func isOutlookServer(server string) bool {
 	// 兼容多地区的outlook邮箱和ofb邮箱
 	// 其实应该加一个Option来区分是否用LOGIN的方式登录
 	// 先临时兼容一下
-	return strings.Contains(server, "outlook") || strings.Contains(server, "onmicrosoft")
+	return strings.Contains(server, "outlook") || strings.Contains(server, "onmicrosoft") || server == "smtp.azurecomm.net"
 }


### PR DESCRIPTION
Azure Communication Service SMTP need Login instead of Plain Auth.

https://learn.microsoft.com/en-us/azure/communication-services/quickstarts/email/send-email-smtp/send-email-smtp