### PR TITLE
feat: support Azure Comm Service SMTP

### DIFF
--- a/common/email.go
+++ b/common/email.go
@@ -10,21 +10,21 @@ import (
 )
 
 func generateMessageID() (string, error) {
-	split := strings.Split(SMTPAccount, "@")
+	split := strings.Split(SMTPFrom, "@")
 	if len(split) < 2 {
 		return "", fmt.Errorf("invalid SMTP account")
 	}
-	domain := strings.Split(SMTPAccount, "@")[1]
+	domain := strings.Split(SMTPFrom, "@")[1]
 	return fmt.Sprintf("<%d.%s@%s>", time.Now().UnixNano(), GetRandomString(12), domain), nil
 }
 
 func SendEmail(subject string, receiver string, content string) error {
+	if SMTPFrom == "" { // for compatibility
+		SMTPFrom = SMTPAccount
+	}
 	id, err2 := generateMessageID()
 	if err2 != nil {
 		return err2
-	}
-	if SMTPFrom == "" { // for compatibility
-		SMTPFrom = SMTPAccount
 	}
 	if SMTPServer == "" && SMTPAccount == "" {
 		return fmt.Errorf("SMTP 服务器未配置")
@@ -79,11 +79,11 @@ func SendEmail(subject string, receiver string, content string) error {
 		if err != nil {
 			return err
 		}
-	} else if isOutlookServer(SMTPAccount) {
+	} else if isOutlookServer(SMTPAccount) || SMTPServer == "smtp.azurecomm.net" {
 		auth = LoginAuth(SMTPAccount, SMTPToken)
-		err = smtp.SendMail(addr, auth, SMTPAccount, to, mail)
+		err = smtp.SendMail(addr, auth, SMTPFrom, to, mail)
 	} else {
-		err = smtp.SendMail(addr, auth, SMTPAccount, to, mail)
+		err = smtp.SendMail(addr, auth, SMTPFrom, to, mail)
 	}
 	return err
 }


### PR DESCRIPTION
Azure Communication Service SMTP 使用 Login 协议而不是 Plain 协议登陆.

修改点：
1. ACS **只**支持 LOGIN auth，兼容处理
2. ACS smtp 使用特定的用户名结构，并非通常的邮箱地址，因此 message id 生成需要兼容处理
3. ACS 使用 From 字段来区分实际发信人，修改原先使用 Account 为发信人的逻辑，同时兼容不填 From 的场景

https://learn.microsoft.com/en-us/azure/communication-services/quickstarts/email/send-email-smtp/send-email-smtp