### PR TITLE
Update relay-xunfei.go

### DIFF
--- a/relay/channel/xunfei/relay-xunfei.go
+++ b/relay/channel/xunfei/relay-xunfei.go
@@ -245,7 +245,7 @@ func xunfeiMakeRequest(textRequest dto.GeneralOpenAIRequest, domain, authUrl, ap
 func apiVersion2domain(apiVersion string) string {
 	switch apiVersion {
 	case "v1.1":
-		return "general"
+		return "lite"
 	case "v2.1":
 		return "generalv2"
 	case "v3.1":


### PR DESCRIPTION
按照讯飞的最新文档，Spark Lite请求地址，对应的domain参数为lite
参考来源：https://www.xfyun.cn/doc/spark/Web.html#_1-接口说明

关联issue：https://github.com/Calcium-Ion/new-api/issues/316