### PR TITLE
修复自动禁用会对数据库进行多次更新的问题

### DIFF
--- a/model/cache.go
+++ b/model/cache.go
@@ -342,3 +342,14 @@ func CacheGetChannel(id int) (*Channel, error) {
 	}
 	return c, nil
 }
+
+func CacheUpdateChannelStatus(id int, status int) {
+    if (!common.MemoryCacheEnabled) {
+        return
+    }
+    channelSyncLock.Lock()
+    defer channelSyncLock.Unlock()
+    if channel, ok := channelsIDM[id]; ok {
+        channel.Status = status
+    }
+}


### PR DESCRIPTION
开启自动禁用和缓存之后，在缓存更新之前，每一次请求都会触发自动禁用，不断的对数据库进行更新操作，在高并发情况下会对数据库造成巨大压力