### PR TITLE
fix: 转义 Gemini 工具调用中的反斜杠

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -296,7 +296,8 @@ func getToolCall(item *GeminiPart) *dto.ToolCall {
 		ID:   fmt.Sprintf("call_%s", common.GetUUID()),
 		Type: "function",
 		Function: dto.FunctionCall{
-			Arguments: string(argsBytes),
+			// 不好评价，得去转义一下反斜杠，Gemini 的特性好像是，Google 返回的时候本身就会转义“\”
+			Arguments: strings.ReplaceAll(string(argsBytes), "\\\\", "\\"),
 			Name:      item.FunctionCall.FunctionName,
 		},
 	}


### PR DESCRIPTION
测试了一番，其他OpenAI的模型都能正常处理反斜杠，但是Gemini好像还会自动再转义一次
这里手动去掉了