### PR TITLE
Feat: 日志查询增加渠道名称显示

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -27,6 +27,7 @@ type Log struct {
 	UseTime          int    `json:"use_time" gorm:"default:0"`
 	IsStream         bool   `json:"is_stream" gorm:"default:false"`
 	ChannelId        int    `json:"channel" gorm:"index"`
+	ChannelName      string `json:"channel_name" gorm:"->"`
 	TokenId          int    `json:"token_id" gorm:"default:0;index"`
 	Group            string `json:"group" gorm:"index"`
 	Other            string `json:"other"`
@@ -130,6 +131,10 @@ func GetAllLogs(logType int, startTimestamp int64, endTimestamp int64, modelName
 	} else {
 		tx = LOG_DB.Where("type = ?", logType)
 	}
+
+	tx = tx.Joins("LEFT JOIN channels ON logs.channel_id = channels.id")
+	tx = tx.Select("logs.*, channels.name as channel_name")
+
 	if modelName != "" {
 		tx = tx.Where("model_name like ?", modelName)
 	}
@@ -169,6 +174,10 @@ func GetUserLogs(userId int, logType int, startTimestamp int64, endTimestamp int
 	} else {
 		tx = LOG_DB.Where("user_id = ? and type = ?", userId, logType)
 	}
+
+	tx = tx.Joins("LEFT JOIN channels ON logs.channel_id = channels.id")
+	tx = tx.Select("logs.*, channels.name as channel_name")
+
 	if modelName != "" {
 		tx = tx.Where("model_name like ?", modelName)
 	}

--- a/web/src/components/LogsTable.js
+++ b/web/src/components/LogsTable.js
@@ -157,13 +157,15 @@ const LogsTable = () => {
           record.type === 0 || record.type === 2 ? (
             <div>
               {
-                <Tag
-                  color={colors[parseInt(text) % colors.length]}
-                  size='large'
-                >
-                  {' '}
-                  {text}{' '}
-                </Tag>
+                <Tooltip content={record.channel_name || '[未知]'}>
+                  <Tag
+                    color={colors[parseInt(text) % colors.length]}
+                    size='large'
+                  >
+                    {' '}
+                    {text}{' '}
+                  </Tag>
+                </Tooltip>
               }
             </div>
           ) : (
@@ -543,6 +545,12 @@ const LogsTable = () => {
         //   key: '渠道重试',
         //   value: content,
         // })
+      }      
+      if (isAdminUser && (logs[i].type === 0 || logs[i].type === 2)) {
+        expandDataLocal.push({
+          key: t('渠道信息'),
+          value: `${logs[i].channel} - ${logs[i].channel_name || '[未知]'}`
+        });
       }
       if (other?.ws || other?.audio) {
         expandDataLocal.push({
@@ -595,13 +603,12 @@ const LogsTable = () => {
           key: t('计费过程'),
           value: content,
         });
-      }
 
+      }
       expandDatesLocal[logs[i].key] = expandDataLocal;
     }
 
     setExpandData(expandDatesLocal);
-
     setLogs(logs);
   };
 

--- a/web/src/components/LogsTable.js
+++ b/web/src/components/LogsTable.js
@@ -236,7 +236,12 @@ const LogsTable = () => {
               </>
             );
          } else {
-           let other = JSON.parse(record.other);
+           let other = null;
+           try {
+             other = JSON.parse(record.other);
+           } catch (e) {
+             console.error(`Failed to parse record.other: "${record.other}".`, e);
+           }
            if (other === null) {
              return <></>;
            }


### PR DESCRIPTION
1. 日志查询增加渠道名称显示：对 渠道ID 增加 tooltip，鼠标悬停时显示渠道名称；点击打开日志详情时增加 `渠道ID - 渠道名称` 内容。 #506
2. 修复历史日志数据 `logs.other` 为空时，前端尝试将空字符串作为JSON解析，报错导致显示空白页的问题
