### PR TITLE
chore: 同步gemini模型

### DIFF
--- a/relay/channel/gemini/constant.go
+++ b/relay/channel/gemini/constant.go
@@ -3,17 +3,19 @@ package gemini
 var ModelList = []string{
 	// stable version
 	"gemini-1.5-pro", "gemini-1.5-flash", "gemini-1.5-flash-8b",
+	"gemini-2.0-flash",
 	// latest version
 	"gemini-1.5-pro-latest", "gemini-1.5-flash-latest",
-	// legacy version
-	"gemini-1.5-pro-exp-0827", "gemini-1.5-flash-exp-0827",
-	// exp
-	"gemini-exp-1114", "gemini-exp-1121", "gemini-exp-1206",
+	// preview version
+	"gemini-2.0-flash-lite-preview",
+	// gemini exp
+	"gemini-exp-1206",
 	// flash exp
 	"gemini-2.0-flash-exp",
+	// pro exp
+	"gemini-2.0-pro-exp",
 	// thinking exp
 	"gemini-2.0-flash-thinking-exp",
-	"gemini-2.0-flash-thinking-exp-1219",
 }
 
 var ChannelName = "google gemini"


### PR DESCRIPTION
移除过时、在modelist找不到的模型，默认添加不带版本号的模型(不带版本号自动重定向到最新版本),如需老版本自己加。