### PR TITLE
bugfix: 配置文件 .env.example 示例配置错误

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,9 @@
 
 # 数据库相关配置
 # 数据库连接字符串
-# SQL_DSN=mysql://user:password@tcp(127.0.0.1:3306)/dbname?parseTime=true
+# SQL_DSN=user:password@tcp(127.0.0.1:3306)/dbname?parseTime=true
 # 日志数据库连接字符串
-# LOG_SQL_DSN=mysql://user:password@tcp(127.0.0.1:3306)/logdb?parseTime=true
+# LOG_SQL_DSN=user:password@tcp(127.0.0.1:3306)/logdb?parseTime=true
 # SQLite数据库路径
 # SQLITE_PATH=/path/to/sqlite.db
 # 数据库最大空闲连接数


### PR DESCRIPTION
修复示例配置中MySQL的DSN错误问题，mysql driver 无法识别 mysql:// 字段，删除后driver正常识别