### PR TITLE
fix: Fix Ollama channel authentication

### DIFF
--- a/relay/channel/ollama/adaptor.go
+++ b/relay/channel/ollama/adaptor.go
@@ -39,6 +39,7 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
 	channel.SetupApiRequestHeader(info, c, req)
+	header.Set("Authorization", "Bearer "+info.ApiKey)
 	return nil
 }
 


### PR DESCRIPTION
his PR fixes authentication for the Ollama channel. Previously, the API key was not being correctly set in the request header. Now, the `Authorization` header is properly set with the `Bearer` token.