### PR TITLE
feat: Pass extra_body in OpenAI request to the backend

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -47,6 +47,7 @@ type GeneralOpenAIRequest struct {
 	Dimensions          int             `json:"dimensions,omitempty"`
 	Modalities          any             `json:"modalities,omitempty"`
 	Audio               any             `json:"audio,omitempty"`
+	ExtraBody           any             `json:"extra_body,omitempty"`
 }
 
 type OpenAITools struct {


### PR DESCRIPTION
Many backends depend on the `extra_body` field to implement additional features such as [sglang](https://docs.sglang.ai/backend/structured_outputs.html#EBNF), [siliconflow](https://docs.siliconflow.cn/en/userguide/guides/prefix#4-usage-examples) 

This should address https://github.com/Calcium-Ion/new-api/issues/640