### PR TITLE
fix: adapting return format for openrouter think content (#793)

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -99,6 +99,7 @@ type Message struct {
 	Name                *string         `json:"name,omitempty"`
 	Prefix              *bool           `json:"prefix,omitempty"`
 	ReasoningContent    string          `json:"reasoning_content,omitempty"`
+	Reasoning           string          `json:"reasoning,omitempty"`
 	ToolCalls           json.RawMessage `json:"tool_calls,omitempty"`
 	ToolCallId          string          `json:"tool_call_id,omitempty"`
 	parsedContent       []MediaContent

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -64,6 +64,7 @@ type ChatCompletionsStreamResponseChoice struct {
 type ChatCompletionsStreamResponseChoiceDelta struct {
 	Content          *string            `json:"content,omitempty"`
 	ReasoningContent *string            `json:"reasoning_content,omitempty"`
+	Reasoning        *string            `json:"reasoning,omitempty"`
 	Role             string             `json:"role,omitempty"`
 	ToolCalls        []ToolCallResponse `json:"tool_calls,omitempty"`
 }
@@ -80,14 +81,18 @@ func (c *ChatCompletionsStreamResponseChoiceDelta) GetContentString() string {
 }
 
 func (c *ChatCompletionsStreamResponseChoiceDelta) GetReasoningContent() string {
-	if c.ReasoningContent == nil {
+	if c.ReasoningContent == nil && c.Reasoning == nil {
 		return ""
 	}
-	return *c.ReasoningContent
+	if c.ReasoningContent != nil {
+		return *c.ReasoningContent
+	}
+	return *c.Reasoning
 }
 
 func (c *ChatCompletionsStreamResponseChoiceDelta) SetReasoningContent(s string) {
 	c.ReasoningContent = &s
+	c.Reasoning = &s
 }
 
 type ToolCallResponse struct {

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -4,10 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/bytedance/gopkg/util/gopool"
-	"github.com/gin-gonic/gin"
-	"github.com/gorilla/websocket"
-	"github.com/pkg/errors"
 	"io"
 	"math"
 	"mime/multipart"
@@ -21,6 +17,11 @@ import (
 	"one-api/service"
 	"os"
 	"strings"
+
+	"github.com/bytedance/gopkg/util/gopool"
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/pkg/errors"
 )
 
 func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, forceFormat bool, thinkToContent bool) error {
@@ -55,7 +56,8 @@ func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, fo
 			response := lastStreamResponse.Copy()
 			for i := range response.Choices {
 				response.Choices[i].Delta.SetContentString("<think>\n")
-				response.Choices[i].Delta.SetReasoningContent("")
+				response.Choices[i].Delta.ReasoningContent = nil
+				response.Choices[i].Delta.Reasoning = nil
 			}
 			info.ThinkingContentInfo.IsFirstThinkingContent = false
 			return helper.ObjectData(c, response)
@@ -74,8 +76,9 @@ func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, fo
 		if len(choice.Delta.GetContentString()) > 0 && !info.ThinkingContentInfo.SendLastThinkingContent {
 			response := lastStreamResponse.Copy()
 			for j := range response.Choices {
-				response.Choices[j].Delta.SetContentString("\n</think>\n\n")
-				response.Choices[j].Delta.SetReasoningContent("")
+				response.Choices[j].Delta.SetContentString("\n</think>")
+				response.Choices[j].Delta.ReasoningContent = nil
+				response.Choices[j].Delta.Reasoning = nil
 			}
 			info.ThinkingContentInfo.SendLastThinkingContent = true
 			helper.ObjectData(c, response)
@@ -84,7 +87,8 @@ func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, fo
 		// Convert reasoning content to regular content
 		if len(choice.Delta.GetReasoningContent()) > 0 {
 			lastStreamResponse.Choices[i].Delta.SetContentString(choice.Delta.GetReasoningContent())
-			lastStreamResponse.Choices[i].Delta.SetReasoningContent("")
+			lastStreamResponse.Choices[i].Delta.ReasoningContent = nil
+			lastStreamResponse.Choices[i].Delta.Reasoning = nil
 		}
 	}
 
@@ -178,7 +182,10 @@ func OaiStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 					//}
 					for _, choice := range streamResponse.Choices {
 						responseTextBuilder.WriteString(choice.Delta.GetContentString())
+
+						// handle both reasoning_content and reasoning
 						responseTextBuilder.WriteString(choice.Delta.GetReasoningContent())
+
 						if choice.Delta.ToolCalls != nil {
 							if len(choice.Delta.ToolCalls) > toolCount {
 								toolCount = len(choice.Delta.ToolCalls)
@@ -199,7 +206,7 @@ func OaiStreamHandler(c *gin.Context, resp *http.Response, info *relaycommon.Rel
 				//}
 				for _, choice := range streamResponse.Choices {
 					responseTextBuilder.WriteString(choice.Delta.GetContentString())
-					responseTextBuilder.WriteString(choice.Delta.GetReasoningContent())
+					responseTextBuilder.WriteString(choice.Delta.GetReasoningContent()) // This will handle both reasoning_content and reasoning
 					if choice.Delta.ToolCalls != nil {
 						if len(choice.Delta.ToolCalls) > toolCount {
 							toolCount = len(choice.Delta.ToolCalls)
@@ -291,7 +298,7 @@ func OpenaiHandler(c *gin.Context, resp *http.Response, promptTokens int, model 
 	if simpleResponse.Usage.TotalTokens == 0 || (simpleResponse.Usage.PromptTokens == 0 && simpleResponse.Usage.CompletionTokens == 0) {
 		completionTokens := 0
 		for _, choice := range simpleResponse.Choices {
-			ctkm, _ := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent, model)
+			ctkm, _ := service.CountTextToken(choice.Message.StringContent()+choice.Message.ReasoningContent+choice.Message.Reasoning, model)
 			completionTokens += ctkm
 		}
 		simpleResponse.Usage = dto.Usage{


### PR DESCRIPTION
## 主要修改
添加了 issue (#793) 中提到的对 OpenRouter 供应商思考字段的支持（即思考字段为 `reasoning` 而非 `reasoning_content` ）

## 可能没必要的修改
https://github.com/Sh1n3zZ/new-api/commit/b95142bbacbd3d4b3775393a5b0b2f2d12c2684c#diff-695e2ea0345b4003d32ed4cc7d6d8a1bebcff70f6bff10db0d9c2499b7a6f34dR59-R60
https://github.com/Sh1n3zZ/new-api/commit/b95142bbacbd3d4b3775393a5b0b2f2d12c2684c#diff-695e2ea0345b4003d32ed4cc7d6d8a1bebcff70f6bff10db0d9c2499b7a6f34dR78-R82
- 删除了当 `thinking_to_content` 标识启用时的 `reasoning` 和 `reasoning_content` 字段。因为内容都被转换为 `content` 了没有留下空值的必要。可能会导致部分客户端会通过这相关字段判断返回的内容中是否包含思考内容并进行错误的二次解析。修改后发现思考到主内容的过渡阶段还是会出现类似的字段，于是新增了 `hasContent` 标记用于跟踪响应是否包含主内容。

https://github.com/Sh1n3zZ/new-api/commit/894dce7366f98bac58e39da24a3465305ebe7298#diff-695e2ea0345b4003d32ed4cc7d6d8a1bebcff70f6bff10db0d9c2499b7a6f34dR63-R64
- 修复了思考内容的前几条会很奇怪的被吞掉的问题。在返回 `<think>` 标记时一并返回第一条思考内容、添加 `thinkingContent` 缓冲区用于收集初始思考内容。测试时发现思考内容的前几条会很奇怪的被吞掉，原来是被 `sendStreamData` 函数里面的逻辑忽略了，太坏了。

- 炫了一碗饺子