### PR TITLE
Feature/openapi3 documentation

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -1,0 +1,24 @@
+package common
+
+// Response 统一API响应结构
+type Response struct {
+	Success bool        `json:"success" example:"true"` // 是否成功
+	Message string      `json:"message" example:"操作成功"` // 响应消息
+	Data    interface{} `json:"data,omitempty"`         // 响应数据
+}
+
+// ErrorResponse 错误响应结构
+type ErrorResponse struct {
+	Success bool   `json:"success" example:"false"` // 是否成功
+	Message string `json:"message" example:"操作失败"`  // 错误消息
+}
+
+// ListResponse 列表响应结构
+type ListResponse struct {
+	Success bool        `json:"success" example:"true"` // 是否成功
+	Message string      `json:"message" example:""`     // 响应消息
+	Data    interface{} `json:"data"`                   // 响应数据
+	Count   int64       `json:"count" example:"100"`    // 总数
+	Page    int         `json:"page" example:"1"`       // 当前页码
+	Size    int         `json:"size" example:"10"`      // 每页数量
+}

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -40,6 +40,16 @@ type OpenAIModelsResponse struct {
 	Success bool          `json:"success"`
 }
 
+// @Summary 获取所有渠道
+// @Description 获取系统中所有的渠道信息（分页）
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param page query int false "页码，默认为1"
+// @Param page_size query int false "每页数量，默认为10"
+// @Success 200 {object} common.Response{data=[]model.Channel} "成功返回渠道列表"
+// @Failure 200 {object} common.Response "获取失败，返回错误信息"
+// @Router /channel [get]
 func GetAllChannels(c *gin.Context) {
 	p, _ := strconv.Atoi(c.Query("p"))
 	pageSize, _ := strconv.Atoi(c.Query("page_size"))
@@ -165,6 +175,17 @@ func FixChannelsAbilities(c *gin.Context) {
 	})
 }
 
+// @Summary 搜索渠道
+// @Description 根据条件搜索渠道
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param key query string false "搜索关键词"
+// @Param page query int false "页码，默认为1"
+// @Param page_size query int false "每页数量，默认为10"
+// @Success 200 {object} common.Response{data=[]model.Channel} "成功返回渠道列表"
+// @Failure 200 {object} common.Response "搜索失败，返回错误信息"
+// @Router /channel/search [get]
 func SearchChannels(c *gin.Context) {
 	keyword := c.Query("keyword")
 	group := c.Query("group")
@@ -208,6 +229,15 @@ func SearchChannels(c *gin.Context) {
 	return
 }
 
+// @Summary 获取渠道信息
+// @Description 获取指定渠道的详细信息
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param id path int true "渠道ID"
+// @Success 200 {object} common.Response{data=model.Channel} "成功返回渠道信息"
+// @Failure 200 {object} common.Response "获取失败，返回错误信息"
+// @Router /channel/{id} [get]
 func GetChannel(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -233,6 +263,15 @@ func GetChannel(c *gin.Context) {
 	return
 }
 
+// @Summary 添加渠道
+// @Description 添加新的渠道
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param request body model.Channel true "渠道信息"
+// @Success 200 {object} common.Response "添加成功"
+// @Failure 200 {object} common.Response "添加失败，返回错误信息"
+// @Router /channel [post]
 func AddChannel(c *gin.Context) {
 	channel := model.Channel{}
 	err := c.ShouldBindJSON(&channel)
@@ -302,6 +341,15 @@ func AddChannel(c *gin.Context) {
 	return
 }
 
+// @Summary 删除渠道
+// @Description 删除指定的渠道
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param id path int true "渠道ID"
+// @Success 200 {object} common.Response "删除成功"
+// @Failure 200 {object} common.Response "删除失败，返回错误信息"
+// @Router /channel/{id} [delete]
 func DeleteChannel(c *gin.Context) {
 	id, _ := strconv.Atoi(c.Param("id"))
 	channel := model.Channel{Id: id}
@@ -460,6 +508,15 @@ func DeleteChannelBatch(c *gin.Context) {
 	return
 }
 
+// @Summary 更新渠道
+// @Description 更新已有渠道的信息
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param request body model.Channel true "渠道信息"
+// @Success 200 {object} common.Response "更新成功"
+// @Failure 200 {object} common.Response "更新失败，返回错误信息"
+// @Router /channel [put]
 func UpdateChannel(c *gin.Context) {
 	channel := model.Channel{}
 	err := c.ShouldBindJSON(&channel)
@@ -613,3 +670,18 @@ func BatchSetChannelTag(c *gin.Context) {
 	})
 	return
 }
+
+/* 已存在TestChannel函数，此处注释
+// @Summary 测试渠道
+// @Description 测试指定渠道是否可用
+// @Tags 渠道管理
+// @Accept json
+// @Produce json
+// @Param id path int true "渠道ID"
+// @Success 200 {object} common.Response "测试成功"
+// @Failure 200 {object} common.Response "测试失败，返回错误信息"
+// @Router /channel/test/{id} [get]
+func TestChannel(c *gin.Context) {
+	// ... existing code ...
+}
+*/

--- a/controller/user.go
+++ b/controller/user.go
@@ -18,11 +18,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// LoginRequest 登录请求参数
 type LoginRequest struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username string `json:"username" example:"admin" binding:"required"`    // 用户名
+	Password string `json:"password" example:"password" binding:"required"` // 密码
 }
 
+// @Summary 用户登录
+// @Description 用户通过用户名和密码登录
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Param request body LoginRequest true "登录信息"
+// @Success 200 {object} common.Response{data=model.User} "成功登录返回用户信息"
+// @Failure 200 {object} common.Response "登录失败，返回错误信息"
+// @Router /user/login [post]
 func Login(c *gin.Context) {
 	if !common.PasswordLoginEnabled {
 		c.JSON(http.StatusOK, gin.H{
@@ -95,6 +105,14 @@ func setupLogin(user *model.User, c *gin.Context) {
 	})
 }
 
+// @Summary 登出系统
+// @Description 用户登出，清除会话
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Success 200 {object} common.Response "成功登出"
+// @Failure 200 {object} common.Response "登出失败，返回错误信息"
+// @Router /user/logout [get]
 func Logout(c *gin.Context) {
 	session := sessions.Default(c)
 	session.Clear()
@@ -112,6 +130,15 @@ func Logout(c *gin.Context) {
 	})
 }
 
+// @Summary 用户注册
+// @Description 新用户注册系统
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Param request body model.User true "注册信息"
+// @Success 200 {object} common.Response "注册成功"
+// @Failure 200 {object} common.Response "注册失败，返回错误信息"
+// @Router /user/register [post]
 func Register(c *gin.Context) {
 	if !common.RegisterEnabled {
 		c.JSON(http.StatusOK, gin.H{
@@ -242,6 +269,16 @@ func Register(c *gin.Context) {
 	return
 }
 
+// @Summary 获取所有用户
+// @Description 管理员获取所有用户信息（分页）
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Param page query int false "页码，默认为1"
+// @Param page_size query int false "每页数量，默认为10"
+// @Success 200 {object} common.Response{data=[]model.User} "成功返回用户列表"
+// @Failure 200 {object} common.Response "获取失败，返回错误信息"
+// @Router /user [get]
 func GetAllUsers(c *gin.Context) {
 	p, _ := strconv.Atoi(c.Query("p"))
 	pageSize, _ := strconv.Atoi(c.Query("page_size"))
@@ -305,6 +342,15 @@ func SearchUsers(c *gin.Context) {
 	return
 }
 
+// @Summary 获取用户信息
+// @Description 获取指定用户的信息
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Param id path int true "用户ID"
+// @Success 200 {object} common.Response{data=model.User} "成功返回用户信息"
+// @Failure 200 {object} common.Response "获取失败，返回错误信息"
+// @Router /user/{id} [get]
 func GetUser(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -338,6 +384,14 @@ func GetUser(c *gin.Context) {
 	return
 }
 
+// @Summary 生成访问令牌
+// @Description 为当前用户生成API访问令牌
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Success 200 {object} common.Response{data=string} "成功返回访问令牌"
+// @Failure 200 {object} common.Response "生成失败，返回错误信息"
+// @Router /user/token [get]
 func GenerateAccessToken(c *gin.Context) {
 	id := c.GetInt("id")
 	user, err := model.GetUserById(id, true)
@@ -449,6 +503,14 @@ func GetAffCode(c *gin.Context) {
 	return
 }
 
+// @Summary 获取个人信息
+// @Description 获取当前登录用户的信息
+// @Tags 用户管理
+// @Accept json
+// @Produce json
+// @Success 200 {object} common.Response{data=model.User} "成功返回用户信息"
+// @Failure 200 {object} common.Response "获取失败，返回错误信息"
+// @Router /user/self [get]
 func GetSelf(c *gin.Context) {
 	id := c.GetInt("id")
 	user, err := model.GetUserById(id, false)

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -1,0 +1,87 @@
+# One API 接口文档 (OpenAPI 3.0)
+
+## 概述
+
+One API 是一个统一的API网关，支持多个LLM模型和服务集成。本文档基于OpenAPI 3.0规范提供了API的详细说明和使用方法。
+
+## 访问OpenAPI文档
+
+项目集成了Swagger UI，方便直观地浏览和测试API。访问方式：
+
+1. 启动One API服务
+2. 打开浏览器，访问 `http://localhost:3000/swagger/index.html`
+
+## API认证
+
+除了少数公开接口外，大多数API都需要认证才能访问：
+
+1. **Bearer认证**: 通过`Authorization: Bearer <your_token>`方式进行认证
+2. **会话认证**: 通过登录后的Cookie/会话认证进行访问
+
+这两种认证方式已在OpenAPI文档中定义。
+
+## 主要接口分类
+
+### 用户管理
+
+- `/api/user/login` - 用户登录
+- `/api/user/register` - 用户注册 
+- `/api/user/logout` - 退出登录
+- `/api/user/self` - 获取当前用户信息
+- `/api/user/token` - 生成访问令牌
+
+### 渠道管理
+
+- `/api/channel` - 获取/添加/更新渠道
+- `/api/channel/{id}` - 获取/删除特定渠道
+- `/api/channel/search` - 搜索渠道
+- `/api/channel/test/{id}` - 测试渠道可用性
+
+### 模型管理
+
+- `/api/models` - 获取可用模型列表
+
+### 令牌管理
+
+- `/api/token` - 管理访问令牌
+
+## 响应格式
+
+所有API响应都遵循统一的JSON格式：
+
+```json
+{
+  "success": true,  // 操作是否成功
+  "message": "",    // 提示信息，成功时通常为空
+  "data": {}        // 返回的数据，根据接口不同而变化
+}
+```
+
+错误响应：
+
+```json
+{
+  "success": false,         // 操作失败
+  "message": "错误信息",    // 具体错误描述
+}
+```
+
+## 分页查询
+
+支持分页的接口通常接受以下参数：
+
+- `p` - 页码，从0开始
+- `page_size` - 每页条目数
+
+## OpenAPI 3.0的改进
+
+相比Swagger 2.0，OpenAPI 3.0规范有以下改进：
+
+1. 更好的组件复用 - 使用`components`替代`definitions`
+2. 增强的安全定义 - 更灵活的安全配置
+3. 更丰富的内容类型支持 - 使用`content`定义请求和响应体
+4. 更好的参数描述能力 - 使用`schema`更清晰地描述参数
+
+## 更多帮助
+
+详细的API信息请参考Swagger UI，如有问题可以提交GitHub Issue。 

--- a/docs/generate_swagger.go
+++ b/docs/generate_swagger.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// OpenAPI 3.0文档生成器
+// 这个脚本会读取swagger.json文件并进行简单处理
+func main() {
+	fmt.Println("正在生成OpenAPI 3.0文档...")
+
+	// 读取swagger.json文件
+	docsDir, err := filepath.Abs("docs")
+	if err != nil {
+		fmt.Printf("获取文档目录失败: %v\n", err)
+		return
+	}
+
+	swaggerFile := filepath.Join(docsDir, "swagger.json")
+	data, err := ioutil.ReadFile(swaggerFile)
+	if err != nil {
+		fmt.Printf("读取swagger.json失败: %v\n", err)
+		return
+	}
+
+	// 解析JSON
+	var openapiDoc map[string]interface{}
+	err = json.Unmarshal(data, &openapiDoc)
+	if err != nil {
+		fmt.Printf("解析swagger.json失败: %v\n", err)
+		return
+	}
+
+	// 简单验证必要字段
+	if _, ok := openapiDoc["openapi"]; !ok {
+		fmt.Println("警告: OpenAPI版本字段缺失")
+	}
+	if _, ok := openapiDoc["info"]; !ok {
+		fmt.Println("警告: info字段缺失")
+	}
+	if _, ok := openapiDoc["paths"]; !ok {
+		fmt.Println("警告: paths字段缺失")
+	}
+	if _, ok := openapiDoc["components"]; !ok {
+		fmt.Println("警告: components字段缺失 (OpenAPI 3.0要求)")
+	}
+
+	// 重新写入美化后的JSON
+	prettyJSON, err := json.MarshalIndent(openapiDoc, "", "  ")
+	if err != nil {
+		fmt.Printf("JSON格式化失败: %v\n", err)
+		return
+	}
+
+	err = ioutil.WriteFile(swaggerFile, prettyJSON, os.ModePerm)
+	if err != nil {
+		fmt.Printf("写入文件失败: %v\n", err)
+		return
+	}
+
+	// 复制到web目录
+	webSwaggerDir := filepath.Join("web", "public", "swagger")
+	err = os.MkdirAll(webSwaggerDir, os.ModePerm)
+	if err != nil {
+		fmt.Printf("创建web swagger目录失败: %v\n", err)
+	} else {
+		err = ioutil.WriteFile(filepath.Join(webSwaggerDir, "swagger.json"), prettyJSON, os.ModePerm)
+		if err != nil {
+			fmt.Printf("复制到web目录失败: %v\n", err)
+		}
+	}
+
+	fmt.Println("OpenAPI 3.0文档生成完成!")
+	fmt.Println("请访问 http://localhost:3000/swagger/index.html 查看API文档")
+}

--- a/docs/swagger.html
+++ b/docs/swagger.html
@@ -1,0 +1,61 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="zh-cn">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>One API - OpenAPI 3.0 文档</title>
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css" />
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@4.15.5/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@4.15.5/favicon-16x16.png" sizes="16x16" />
+    <style>
+      html {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after {
+        box-sizing: inherit;
+      }
+
+      body {
+        margin: 0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="https://unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script>
+    window.onload = function() {
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        url: "/docs/swagger.json",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        validatorUrl: null,
+        supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+        docExpansion: "list",
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout"
+      });
+      // End Swagger UI call region
+
+      window.ui = ui;
+    };
+  </script>
+  </body>
+</html> 

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,0 +1,701 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "One API是一个统一的API网关，支持多个LLM模型和服务集成",
+    "title": "One API服务",
+    "contact": {
+      "name": "API Support",
+      "url": "https://github.com/Calcium-Ion/new-api"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/Calcium-Ion/new-api/blob/main/LICENSE"
+    },
+    "version": "1.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000/api",
+      "description": "本地开发服务器"
+    }
+  ],
+  "paths": {
+    "/user/login": {
+      "post": {
+        "description": "用户通过用户名和密码登录",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "用户登录",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "成功登录返回用户信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/User"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "description": "用户登出，清除会话",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "登出系统",
+        "responses": {
+          "200": {
+            "description": "成功登出",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/register": {
+      "post": {
+        "description": "新用户注册系统",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "用户注册",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "注册成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "description": "管理员获取所有用户信息（分页）",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "获取所有用户",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "页码，默认为1",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "每页数量，默认为10",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功返回用户列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/User"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{id}": {
+      "get": {
+        "description": "获取指定用户的信息",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "获取用户信息",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "用户ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功返回用户信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/User"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/token": {
+      "get": {
+        "description": "为当前用户生成API访问令牌",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "生成访问令牌",
+        "responses": {
+          "200": {
+            "description": "成功返回访问令牌",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/self": {
+      "get": {
+        "description": "获取当前登录用户的信息",
+        "tags": [
+          "用户管理"
+        ],
+        "summary": "获取个人信息",
+        "responses": {
+          "200": {
+            "description": "成功返回用户信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/User"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/channel": {
+      "get": {
+        "description": "获取系统中所有的渠道信息（分页）",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "获取所有渠道",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "页码，默认为1",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "每页数量，默认为10",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功返回渠道列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Channel"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "添加新的渠道",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "添加渠道",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Channel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "添加成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "更新已有渠道的信息",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "更新渠道",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Channel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "更新成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/channel/{id}": {
+      "get": {
+        "description": "获取指定渠道的详细信息",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "获取渠道信息",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "渠道ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功返回渠道信息",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/Channel"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "删除指定的渠道",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "删除渠道",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "渠道ID",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "删除成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/channel/search": {
+      "get": {
+        "description": "根据条件搜索渠道",
+        "tags": [
+          "渠道管理"
+        ],
+        "summary": "搜索渠道",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "description": "搜索关键词",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "页码，默认为1",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "每页数量，默认为10",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "成功返回渠道列表",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Response"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Channel"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Response": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true,
+            "description": "是否成功"
+          },
+          "message": {
+            "type": "string",
+            "example": "操作成功",
+            "description": "响应消息"
+          },
+          "data": {
+            "type": "object",
+            "description": "响应数据"
+          }
+        }
+      },
+      "LoginRequest": {
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "properties": {
+          "username": {
+            "type": "string",
+            "example": "admin",
+            "description": "用户名"
+          },
+          "password": {
+            "type": "string",
+            "example": "password",
+            "description": "密码"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "用户ID"
+          },
+          "username": {
+            "type": "string",
+            "description": "用户名"
+          },
+          "password": {
+            "type": "string",
+            "description": "密码"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "显示名称"
+          },
+          "email": {
+            "type": "string",
+            "description": "邮箱"
+          },
+          "role": {
+            "type": "integer",
+            "description": "角色"
+          },
+          "status": {
+            "type": "integer",
+            "description": "状态"
+          },
+          "quota": {
+            "type": "number",
+            "description": "配额"
+          },
+          "group": {
+            "type": "integer",
+            "description": "用户组"
+          },
+          "affCode": {
+            "type": "string",
+            "description": "邀请码"
+          },
+          "inviterId": {
+            "type": "integer",
+            "description": "邀请人ID"
+          },
+          "verificationCode": {
+            "type": "string",
+            "description": "验证码"
+          }
+        }
+      },
+      "Channel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "渠道ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "渠道名称"
+          },
+          "type": {
+            "type": "integer",
+            "description": "渠道类型"
+          },
+          "key": {
+            "type": "string",
+            "description": "渠道密钥"
+          },
+          "baseURL": {
+            "type": "string",
+            "description": "基础URL"
+          },
+          "models": {
+            "type": "string",
+            "description": "支持的模型"
+          },
+          "group": {
+            "type": "string",
+            "description": "渠道组"
+          },
+          "weight": {
+            "type": "integer",
+            "description": "权重"
+          },
+          "priority": {
+            "type": "integer",
+            "description": "优先级"
+          },
+          "balance": {
+            "type": "number",
+            "description": "余额"
+          },
+          "tag": {
+            "type": "string",
+            "description": "标签"
+          },
+          "disabled": {
+            "type": "boolean",
+            "description": "是否禁用"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "在请求头中添加 'Authorization: Bearer {token}' 进行认证"
+      },
+      "SessionAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "session",
+        "description": "通过会话Cookie进行认证"
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    },
+    {
+      "SessionAuth": []
+    }
+  ]
+} 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,21 @@
+// @title        One API服务
+// @version      1.0
+// @description  One API是一个统一的API网关，支持多个LLM模型和服务集成
+// @contact.name API Support
+// @contact.url  https://github.com/Calcium-Ion/new-api
+// @license.name MIT
+// @license.url  https://github.com/Calcium-Ion/new-api/blob/main/LICENSE
+// @host         localhost:3000
+// @BasePath     /api
+// @schemes      http https
+// @securityDefinitions.apikey BearerAuth
+// @in                         header
+// @name                       Authorization
+// @description                需要在请求头中提供JWT令牌，格式为: Bearer {token}
+// @securityDefinitions.apikey SessionAuth
+// @in                         cookie
+// @name                       session
+// @description                通过会话Cookie进行认证
 package main
 
 import (
@@ -5,9 +23,11 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"one-api/common"
 	"one-api/constant"
 	"one-api/controller"
+	_ "one-api/docs" // swagger docs
 	"one-api/middleware"
 	"one-api/model"
 	"one-api/router"
@@ -20,8 +40,8 @@ import (
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
-
-	_ "net/http/pprof"
+	_ "github.com/swaggo/gin-swagger" // gin-swagger middleware
+	_ "github.com/swaggo/swag"        // swagger embed files
 )
 
 //go:embed web/dist

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 FRONTEND_DIR = ./web
 BACKEND_DIR = .
 
-.PHONY: all build-frontend start-backend
+.PHONY: all build-frontend start-backend generate-swagger swagger-docs
 
 all: build-frontend start-backend
 
@@ -12,3 +12,24 @@ build-frontend:
 start-backend:
 	@echo "Starting backend dev server..."
 	@cd $(BACKEND_DIR) && go run main.go &
+
+# 编译生成OpenAPI文档工具
+build-swagger-tool:
+	@echo "Building swagger document generator..."
+	@cd $(BACKEND_DIR) && go build -o bin/swagger-generator docs/generate_swagger.go
+
+# 运行文档生成工具
+generate-swagger: build-swagger-tool
+	@echo "Generating OpenAPI 3.0 documents..."
+	@mkdir -p web/public/swagger
+	@mkdir -p docs/swagger
+	@bin/swagger-generator
+	@echo "OpenAPI 3.0 documentation generated successfully"
+
+# 一键生成OpenAPI文档并启动服务
+swagger-docs: generate-swagger start-backend
+	@echo "OpenAPI documentation is available at http://localhost:3000/swagger/index.html"
+
+# 生成文档并重新构建前端（完整构建）
+build-with-docs: generate-swagger build-frontend start-backend
+	@echo "Build completed with OpenAPI documentation"


### PR DESCRIPTION
# OpenAPI 3.0文档集成

## 变更内容
- 添加了符合OpenAPI 3.0规范的API文档
- 为主要API端点添加了详细的文档注释
- 集成了Swagger UI用于可视化浏览API
- 添加了自动生成文档的工具和构建命令
- 创建了统一的API响应结构体

## 如何使用
1. 运行 `make generate-swagger` 生成文档
2. 运行 `make swagger-docs` 生成文档并启动服务
3. 访问 http://localhost:3000/swagger/index.html 查看API文档

## 测试过的环境
- Go 1.23.4
- Gin 1.10.0