### PR TITLE
fix: save OIDC settings

### DIFF
--- a/web/src/components/SystemSetting.js
+++ b/web/src/components/SystemSetting.js
@@ -619,7 +619,7 @@ const SystemSetting = () => {
                       允许通过 Telegram 进行登录
                     </Form.Checkbox>
                     <Form.Checkbox
-                      field='oidc.enabled'
+                      field="['oidc.enabled']"
                       noLabel
                       onChange={(e) => handleCheckboxChange('oidc.enabled', e)}
                     >
@@ -721,14 +721,14 @@ const SystemSetting = () => {
                 <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.well_known'
+                      field="['oidc.well_known']"
                       label='Well-Known URL'
                       placeholder='请输入 OIDC 的 Well-Known URL'
                     />
                   </Col>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.client_id'
+                      field="['oidc.client_id']"
                       label='Client ID'
                       placeholder='输入 OIDC 的 Client ID'
                     />
@@ -737,7 +737,7 @@ const SystemSetting = () => {
                 <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.client_secret'
+                      field="['oidc.client_secret']"
                       label='Client Secret'
                       type='password'
                       placeholder='敏感信息不会发送到前端显示'
@@ -745,7 +745,7 @@ const SystemSetting = () => {
                   </Col>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.authorization_endpoint'
+                      field="['oidc.authorization_endpoint']"
                       label='Authorization Endpoint'
                       placeholder='输入 OIDC 的 Authorization Endpoint'
                     />
@@ -754,14 +754,14 @@ const SystemSetting = () => {
                 <Row gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.token_endpoint'
+                      field="['oidc.token_endpoint']"
                       label='Token Endpoint'
                       placeholder='输入 OIDC 的 Token Endpoint'
                     />
                   </Col>
                   <Col xs={24} sm={24} md={12} lg={12} xl={12}>
                     <Form.Input
-                      field='oidc.user_info_endpoint'
+                      field="['oidc.user_info_endpoint']"
                       label='User Info Endpoint'
                       placeholder='输入 OIDC 的 Userinfo Endpoint'
                     />


### PR DESCRIPTION
由于 OIDC 相关配置 key 含有 `.`，原先前端保存配置时会出错:

期望:
```json
{
    "oidc.well_known": "https://...."
}
```

实际情况:
```json
{
    "oidc": {
        "well_known": "https://...."
    }
}
````

该 PR 尝试修复这一问题.