### PR TITLE
Update Gemini 2.5 Pro ratio

### DIFF
--- a/setting/operation_setting/model-ratio.go
+++ b/setting/operation_setting/model-ratio.go
@@ -439,7 +439,7 @@ func getHardcodedCompletionModelRatio(name string) (float64, bool) {
 		} else if strings.HasPrefix(name, "gemini-2.0") {
 			return 4, true
 		} else if strings.HasPrefix(name, "gemini-2.5-pro-preview") {
-			return 6, true
+			return 8, true
 		}
 		return 4, false
 	}


### PR DESCRIPTION
修正倍率为10/1.25=8
![64c2de640375e7384ec492f42184edd4_720](https://github.com/user-attachments/assets/1ce64b3f-953c-4854-b36e-09d5de2636ee)
倍率6是200ktoken以上的计费，目前谷歌尚未开放该长度的上下文