### PR TITLE
fix: gemini test MaxTokens

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -193,7 +193,7 @@ func buildTestRequest(model string) *dto.GeneralOpenAIRequest {
 			testRequest.MaxTokens = 50
 		}
 	} else if strings.Contains(model, "gemini") {
-		testRequest.MaxTokens = 500
+		testRequest.MaxTokens = 50
 	} else {
 		testRequest.MaxTokens = 10
 	}

--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -192,6 +192,8 @@ func buildTestRequest(model string) *dto.GeneralOpenAIRequest {
 		if !strings.Contains(model, "claude") {
 			testRequest.MaxTokens = 50
 		}
+	} else if strings.Contains(model, "gemini") {
+		testRequest.MaxTokens = 500
 	} else {
 		testRequest.MaxTokens = 10
 	}


### PR DESCRIPTION
#933 渠道测试逻辑，修改Gemini模型中的请求报文的maxOutputTokens值为500，避免出现响应报文中无candidates内容