### PR TITLE
feat: add original password verification when changing password

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -592,7 +592,14 @@ func UpdateSelf(c *gin.Context) {
 		user.Password = "" // rollback to what it should be
 		cleanUser.Password = ""
 	}
-	updatePassword := user.Password != ""
+	updatePassword, err := checkUpdatePassword(user.OriginalPassword, user.Password, cleanUser.Id)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
 	if err := cleanUser.Update(updatePassword); err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
@@ -605,6 +612,23 @@ func UpdateSelf(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
+	return
+}
+
+func checkUpdatePassword(originalPassword string, newPassword string, userId int) (updatePassword bool, err error) {
+	if newPassword == "" {
+		return
+	}
+	var currentUser *model.User
+	currentUser, err = model.GetUserById(userId, true)
+	if err != nil {
+		return
+	}
+	if !common.ValidatePasswordAndHash(originalPassword, currentUser.Password) {
+		err = fmt.Errorf("原密码错误")
+		return
+	}
+	updatePassword = true
 	return
 }
 

--- a/model/user.go
+++ b/model/user.go
@@ -18,6 +18,7 @@ type User struct {
 	Id               int            `json:"id"`
 	Username         string         `json:"username" gorm:"unique;index" validate:"max=12"`
 	Password         string         `json:"password" gorm:"not null;" validate:"min=8,max=20"`
+	OriginalPassword string         `json:"original_password" gorm:"-:all"` // this field is only for Password change verification, don't save it to database!
 	DisplayName      string         `json:"display_name" gorm:"index" validate:"max=20"`
 	Role             int            `json:"role" gorm:"type:int;default:1"`   // admin, common
 	Status           int            `json:"status" gorm:"type:int;default:1"` // enabled, disabled

--- a/web/src/components/PersonalSetting.js
+++ b/web/src/components/PersonalSetting.js
@@ -57,6 +57,7 @@ const PersonalSetting = () => {
     email_verification_code: '',
     email: '',
     self_account_deletion_confirmation: '',
+    original_password: '',
     set_new_password: '',
     set_new_password_confirmation: '',
   });
@@ -239,11 +240,20 @@ const PersonalSetting = () => {
   };
 
   const changePassword = async () => {
+    if (inputs.original_password === '') {
+      showError(t('请输入原密码！'));
+      return;
+    }
+    if (inputs.original_password === inputs.set_new_password) {
+      showError(t('新密码需要和原密码不一致！'));
+      return;
+    }
     if (inputs.set_new_password !== inputs.set_new_password_confirmation) {
       showError(t('两次输入的密码不一致！'));
       return;
     }
     const res = await API.put(`/api/user/self`, {
+      original_password: inputs.original_password,
       password: inputs.set_new_password,
     });
     const { success, message } = res.data;
@@ -1118,6 +1128,16 @@ const PersonalSetting = () => {
             >
               <div style={{ marginTop: 20 }}>
                 <Input
+                  name='original_password'
+                  placeholder={t('原密码')}
+                  type='password'
+                  value={inputs.original_password}
+                  onChange={(value) =>
+                    handleInputChange('original_password', value)
+                  }
+                />
+                <Input
+                  style={{ marginTop: 20 }}
                   name='set_new_password'
                   placeholder={t('新密码')}
                   value={inputs.set_new_password}


### PR DESCRIPTION
    This PR introduces a new feature to enhance the security of the password - changing process. A verification step has been added to check the correctness of the original password before allowing the user to change their password. Prevent unauthorized password changes and provides a more secure user experience.
   Please review the code and let me know if there are any concerns or suggestions.