### PR TITLE
fix: typo in oidc_enabled field (previously oidc)

### DIFF
--- a/web/src/pages/Home/index.js
+++ b/web/src/pages/Home/index.js
@@ -158,7 +158,7 @@ const Home = () => {
                   </p>
                   <p>
                     {t('OIDC 身份验证')}：
-                    {statusState?.status?.oidc === true
+                    {statusState?.status?.oidc_enabled === true
                       ? t('已启用')
                       : t('未启用')}
                   </p>


### PR DESCRIPTION
oidc_enabled字段拼写错误,导致oidc无法正确显示启用状态