### PR TITLE
fix: set correct Content-Type for upstream error responses in streaming mode

### DIFF
--- a/common/response.go
+++ b/common/response.go
@@ -1,0 +1,14 @@
+package common
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// JSONError 统一的错误响应函数，自动处理流式请求的Content-Type重置
+func JSONError(c *gin.Context, statusCode int, errorData interface{}) {
+	// 检查是否已经设置了流式响应头，如果是，需要重置为JSON响应头
+	if _, exists := c.Get("event_stream_headers_set"); exists {
+		c.Writer.Header().Del("Content-Type")
+	}
+	c.JSON(statusCode, errorData)
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -108,7 +108,7 @@ func Relay(c *gin.Context) {
 		//	newAPIError.SetMessage("当前分组上游负载已饱和，请稍后再试")
 		//}
 		newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
-		c.JSON(newAPIError.StatusCode, gin.H{
+		common.JSONError(c, newAPIError.StatusCode, gin.H{
 			"error": newAPIError.ToOpenAIError(),
 		})
 	}
@@ -209,7 +209,7 @@ func RelayClaude(c *gin.Context) {
 
 	if newAPIError != nil {
 		newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
-		c.JSON(newAPIError.StatusCode, gin.H{
+		common.JSONError(c, newAPIError.StatusCode, gin.H{
 			"type":  "error",
 			"error": newAPIError.ToClaudeError(),
 		})
@@ -349,7 +349,7 @@ func RelayMidjourney(c *gin.Context) {
 			err.Result = "当前分组负载已饱和，请稍后再试，或升级账户以提升服务质量。"
 			statusCode = http.StatusTooManyRequests
 		}
-		c.JSON(statusCode, gin.H{
+		common.JSONError(c, statusCode, gin.H{
 			"description": fmt.Sprintf("%s %s", err.Description, err.Result),
 			"type":        "upstream_error",
 			"code":        err.Code,
@@ -366,7 +366,7 @@ func RelayNotImplemented(c *gin.Context) {
 		Param:   "",
 		Code:    "api_not_implemented",
 	}
-	c.JSON(http.StatusNotImplemented, gin.H{
+	common.JSONError(c, http.StatusNotImplemented, gin.H{
 		"error": err,
 	})
 }
@@ -378,7 +378,7 @@ func RelayNotFound(c *gin.Context) {
 		Param:   "",
 		Code:    "",
 	}
-	c.JSON(http.StatusNotFound, gin.H{
+	common.JSONError(c, http.StatusNotFound, gin.H{
 		"error": err,
 	})
 }
@@ -421,7 +421,7 @@ func RelayTask(c *gin.Context) {
 		if taskErr.StatusCode == http.StatusTooManyRequests {
 			taskErr.Message = "当前分组上游负载已饱和，请稍后再试"
 		}
-		c.JSON(taskErr.StatusCode, taskErr)
+		common.JSONError(c, taskErr.StatusCode, taskErr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 	server := gin.New()
 	server.Use(gin.CustomRecovery(func(c *gin.Context, err any) {
 		common.SysError(fmt.Sprintf("panic detected: %v", err))
-		c.JSON(http.StatusInternalServerError, gin.H{
+		common.JSONError(c, http.StatusInternalServerError, gin.H{
 			"error": gin.H{
 				"message": fmt.Sprintf("Panic detected, error: %v. Please submit a issue here: https://github.com/Calcium-Ion/new-api", err),
 				"type":    "new_api_panic",

--- a/middleware/recover.go
+++ b/middleware/recover.go
@@ -2,10 +2,11 @@ package middleware
 
 import (
 	"fmt"
-	"github.com/gin-gonic/gin"
 	"net/http"
 	"one-api/common"
 	"runtime/debug"
+
+	"github.com/gin-gonic/gin"
 )
 
 func RelayPanicRecover() gin.HandlerFunc {
@@ -14,7 +15,7 @@ func RelayPanicRecover() gin.HandlerFunc {
 			if err := recover(); err != nil {
 				common.SysError(fmt.Sprintf("panic detected: %v", err))
 				common.SysError(fmt.Sprintf("stacktrace from panic: %s", string(debug.Stack())))
-				c.JSON(http.StatusInternalServerError, gin.H{
+				common.JSONError(c, http.StatusInternalServerError, gin.H{
 					"error": gin.H{
 						"message": fmt.Sprintf("Panic detected, error: %v. Please submit a issue here: https://github.com/Calcium-Ion/new-api", err),
 						"type":    "new_api_panic",


### PR DESCRIPTION
当前向 chat/completions 接口发送请求并启用流式传输的情况下，如果**上游**返回了一个错误，new-api 转发这个错误时会使用不正确的 Content-Type Header `Content-Type: text/event-stream`，这种错误情况返回类型应该是 `application/json`，毕竟实际数据是一个 json 字符串，并不符合流式传输数据的格式。

如果是 new-api 本身产生一个错误应答，比如请求某个不存在的模型或使用不正确的 api key，则不会出现这个问题，Content-Type 是正确的。

这个问题会让 open-webui 无法识别到错误信息，从Web上显示为一个空回复，难以确认具体问题。（暂不确定是否影响其他客户端使用）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error response handling across the application by using a centralized error response method.
  * Updated various components to use the new unified error response for consistent JSON error outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->