### PR TITLE
fix: default request ID to 'SYSTEM' for background tasks

### DIFF
--- a/common/logger.go
+++ b/common/logger.go
@@ -75,6 +75,9 @@ func logHelper(ctx context.Context, level string, msg string) {
 		writer = gin.DefaultWriter
 	}
 	id := ctx.Value(RequestIdKey)
+	if id == nil {
+		id = "SYSTEM"
+	}
 	now := time.Now()
 	_, _ = fmt.Fprintf(writer, "[%s] %v | %s | %s \n", level, now.Format("2006/01/02 - 15:04:05"), id, msg)
 	logCount++ // we don't need accurate count, so no lock here


### PR DESCRIPTION
修复系统调用的日志, 比如定量任务, 打印时requestID为nil的问题