### PR TITLE
fix: enabled hot reload SyncOptions

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,9 +105,11 @@ func main() {
 			model.InitChannelCache()
 		}()
 
-		go model.SyncOptions(common.SyncFrequency)
 		go model.SyncChannelCache(common.SyncFrequency)
 	}
+
+	// 热更新配置
+	go model.SyncOptions(common.SyncFrequency)
 
 	// 数据看板
 	go model.UpdateQuotaData()


### PR DESCRIPTION
当前平台如果不启用缓存则不会热更新配置
实际上热更新配置从数据库定时拉取并不依赖缓存
所以应该放在外面跟`数据看板`一样, 无论缓存是否开启都是可以定时更新的

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of options synchronization, ensuring it always runs in the background regardless of memory cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->