### PR TITLE
fix: prevent redirect loop by FRONTEND_BASE_URL configuration

### DIFF
--- a/router/main.go
+++ b/router/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"net/http"
+	"net/url"
 	"one-api/common"
 	"os"
 	"strings"
@@ -24,6 +25,16 @@ func SetRouter(router *gin.Engine, buildFS embed.FS, indexPage []byte) {
 	} else {
 		frontendBaseUrl = strings.TrimSuffix(frontendBaseUrl, "/")
 		router.NoRoute(func(c *gin.Context) {
+			if frontendURL, err := url.Parse(frontendBaseUrl); err == nil {
+				if frontendURL.Host == c.Request.Host {
+					common.LogWarn(c, "Misconfiguration detected: FRONTEND_BASE_URL is set to the address of the slave node itself, which would cause a redirect loop. Please set FRONTEND_BASE_URL to the address of the master node.")
+					c.JSON(http.StatusInternalServerError, gin.H{
+						"success": false,
+						"message": "The service is temporarily unavailable due to a configuration issue. Please contact the administrator.",
+					})
+					return
+				}
+			}
 			c.Redirect(http.StatusMovedPermanently, fmt.Sprintf("%s%s", frontendBaseUrl, c.Request.RequestURI))
 		})
 	}


### PR DESCRIPTION
当节点配置为slave(NODE_TYPE=slave), 且FRONTEND_BASE_URL配置为当前请求url的话
请求首页会导致无限循环重定向
增加一个判断提前返回给用户一个友好提示并在后端记录警告日志

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent redirect loops when the frontend base URL is misconfigured, now displaying a clear error message instead of redirecting endlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->