### PR TITLE
feat: add thinking summaries option for gemini

### DIFF
--- a/relay/channel/gemini/constant.go
+++ b/relay/channel/gemini/constant.go
@@ -26,6 +26,19 @@ var ModelList = []string{
 	"embedding-001",
 }
 
+// Abilities and limitations
+// See: https://ai.google.dev/gemini-api/docs/thinking#supported-models
+var ModelsWithThoughtsSummarySupport = []string{
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
+	"gemini-2.5-flash-lite",
+}
+
+// Models with minimum thinking budget limits (thinking cannot be completely disabled due to the model's design)
+var ModelsWithMinimumThinkingBudgetLimits = []string{
+	"gemini-2.5-pro",
+}
+
 var SafetySettingList = []string{
 	"HARM_CATEGORY_HARASSMENT",
 	"HARM_CATEGORY_HATE_SPEECH",

--- a/relay/channel/gemini/helper.go
+++ b/relay/channel/gemini/helper.go
@@ -1,0 +1,25 @@
+package gemini
+
+import (
+	"strings"
+)
+
+func IsModelSupportThoughtsSummary(modelName string) bool {
+	for _, supportedModel := range ModelsWithThoughtsSummarySupport {
+		if strings.HasPrefix(modelName, supportedModel) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func IsModelWithMinimumThinkingBudgetLimits(modelName string) bool {
+	for _, specialModel := range ModelsWithMinimumThinkingBudgetLimits {
+		if strings.HasPrefix(modelName, specialModel) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/setting/model_setting/gemini.go
+++ b/setting/model_setting/gemini.go
@@ -11,6 +11,7 @@ type GeminiSettings struct {
 	SupportedImagineModels                []string          `json:"supported_imagine_models"`
 	ThinkingAdapterEnabled                bool              `json:"thinking_adapter_enabled"`
 	ThinkingAdapterBudgetTokensPercentage float64           `json:"thinking_adapter_budget_tokens_percentage"`
+	IncludeThoughtsSummaryEnabled         bool              `json:"include_thoughts_summary_enabled"`
 }
 
 // 默认配置
@@ -29,6 +30,7 @@ var defaultGeminiSettings = GeminiSettings{
 	},
 	ThinkingAdapterEnabled:                false,
 	ThinkingAdapterBudgetTokensPercentage: 0.6,
+	IncludeThoughtsSummaryEnabled:         true,
 }
 
 // 全局实例

--- a/web/src/components/settings/ModelSetting.js
+++ b/web/src/components/settings/ModelSetting.js
@@ -22,6 +22,7 @@ const ModelSetting = () => {
     'general_setting.ping_interval_seconds': 60,
     'gemini.thinking_adapter_enabled': false,
     'gemini.thinking_adapter_budget_tokens_percentage': 0.6,
+    'gemini.include_thoughts_summary_enabled': true,
   });
 
   let [loading, setLoading] = useState(false);

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -1691,6 +1691,8 @@
   "请先选择同步渠道": "Please select the synchronization channel first",
   "与本地相同": "Same as local",
   "未找到匹配的模型": "No matching model found",
+  "包含思考摘要": "Include thinking summaries",
+  "开启思考过程摘要并将收到的摘要包含在回复中。仅在模型支持和和思考预算不为0时生效。": "Enable thinking summaries and include the received summaries in the reply. Only effective when the model supports it and thinking budget is not 0.",
   "暴露倍率接口": "Expose ratio API",
   "支付设置": "Payment Settings",
   "（当前仅支持易支付接口，默认使用上方服务器地址作为回调地址！）": "(Currently only supports Epay interface, the default callback address is the server address above!)",

--- a/web/src/pages/Setting/Model/SettingGeminiModel.js
+++ b/web/src/pages/Setting/Model/SettingGeminiModel.js
@@ -30,6 +30,7 @@ export default function SettingGeminiModel(props) {
     'gemini.supported_imagine_models': '',
     'gemini.thinking_adapter_enabled': false,
     'gemini.thinking_adapter_budget_tokens_percentage': 0.6,
+    'gemini.include_thoughts_summary_enabled': true,
   });
   const refForm = useRef();
   const [inputsRow, setInputsRow] = useState(inputs);
@@ -216,6 +217,21 @@ export default function SettingGeminiModel(props) {
                     setInputs({
                       ...inputs,
                       'gemini.thinking_adapter_budget_tokens_percentage': value,
+                    })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col span={16}>
+                <Form.Switch
+                  label={t('包含思考摘要')}
+                  field={'gemini.include_thoughts_summary_enabled'}
+                  extraText={t('开启思考过程摘要并将收到的摘要包含在回复中。仅在模型支持和思考预算不为0时生效。')}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      'gemini.include_thoughts_summary_enabled': value,
                     })
                   }
                 />


### PR DESCRIPTION
This pull request decouples the thoughts summary feature from the thinking budget mechanism. The primary goal is to provide users with greater flexibility by treating these as two independent settings, which aligns with their underlying design.

#### The Problem

Previously, enabling the thoughts summary was tightly coupled with the thinking budget. This created a situation where users who wanted a summary were forced to use the `-thinking` suffix.

This forced coupling becomes problematic when a user wants to see the thinking summary and the client also passes a `max_completion_tokens` value. The `-thinking` suffix would then also trigger its specific thinking budget behavior. This meant the model's default, automatic thinking budget behavior would be overridden in favozr of a calculated value. 

This approach limited flexibility, as it was impossible to request a summary while ensuring the default thinking budget strategy remained untouched.

#### The Solution

This PR introduces an independent toggle for the thoughts summary. The implementation details are as follows:

*   **New Setting**: A new `IncludeThoughtsSummaryEnabled` setting is added. It is only active when the main `ThinkingAdapterEnabled` feature is also turned on. If the adapter is disabled, there is no change in behavior.
*   **Default Behavior**: When the adapter is enabled, users will receive a thoughts summary by default with standard model names (without needing the `-thinking` suffix). They can explicitly disable this by turning the new toggle off.

By decoupling these two features, users can get a thinking summary without using the suffix. This ensures that unless the user explicitly chooses the `-thinking` suffix, the thinking budget is not interfered with, aligning the behavior with Google's official automatic thinking strategy.

#### A Note on Models with Minimum Thinking Budgets

For models with a minimum thinking budget limit (like `gemini-2.5-pro`), `includeThoughts` is still sent when the summary toggle is on, even if the `-nothinking` suffix is used. This is by design and aligns with Google's official API behavior, reflecting that these models' thinking processes cannot be fully disabled. The summary is returned in the dedicated `reasoning_content` field and does not affect response compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**  
  - Added a setting to enable or disable inclusion of a "thoughts summary" in Gemini model replies, accessible in the Gemini model settings UI.  
  - Introduced a switch control in the settings interface to toggle this feature, with clear labels and descriptions.  
  - Enhanced thinking budget handling for Gemini models with refined controls based on model capabilities and suffixes.  
- **Localization**  
  - Added English translations for the new "Include thinking summaries" option and its description in the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->