### PR TITLE
fix: ratelimit style error

### DIFF
--- a/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
+++ b/web/src/pages/Setting/RateLimit/SettingsRequestRateLimit.js
@@ -175,7 +175,7 @@ export default function RequestRateLimit(props) {
                 ]}
                   extraText={
                     <div>
-                      <p style={{ marginBottom: -15 }}>{t('说明：')}</p>
+                      <p>{t('说明：')}</p>
                       <ul>
                         <li>{t('使用 JSON 对象格式，格式为：{"组名": [最多请求次数, 最多请求完成次数]}')}</li>
                       <li>{t('示例：{"default": [200, 100], "vip": [0, 1000]}。')}</li>


### PR DESCRIPTION
修复速率限制说明文字，新版UI中的样式错误。

修改前：
![screenshot_20250626_213307](https://github.com/user-attachments/assets/f482d55f-c3ef-4954-b7f3-3b4b21d861fc)

修改后：
![screenshot_20250626_213332](https://github.com/user-attachments/assets/2a295141-a8de-4273-a64e-4219dd01d8aa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated spacing for the "说明：" label in the rate limit settings to use default margins, improving visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->