### PR TITLE
feat: 在自用模式下显示密钥

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -7,6 +7,7 @@ import (
 	"one-api/common"
 	"one-api/constant"
 	"one-api/model"
+	"one-api/setting/operation_setting"
 	"strconv"
 	"strings"
 
@@ -364,7 +365,10 @@ func GetChannel(c *gin.Context) {
 		})
 		return
 	}
-	channel, err := model.GetChannelById(id, false)
+
+	// 在自用模式下显示完整信息包括密钥
+	selectAll := operation_setting.SelfUseModeEnabled
+	channel, err := model.GetChannelById(id, selectAll)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -83,6 +83,13 @@ const EditChannel = (props) => {
   const handleCancel = () => {
     props.handleClose();
   };
+
+  // 检测是否为多个key
+  const isMultiLineKey = (keyValue) => {
+    if (!keyValue) return false;
+    // 检测是否包含换行符或多个key（通过换行分隔）
+    return keyValue.includes('\n') || keyValue.split('\n').filter(line => line.trim()).length > 1;
+  };
   const originInputs = {
     name: '',
     type: 1,
@@ -565,27 +572,29 @@ const EditChannel = (props) => {
                     />
                   ) : (
                     <>
-                      {inputs.type === 41 ? (
+                      {(inputs.type === 41 || isMultiLineKey(inputs.key)) ? (
                         <Form.TextArea
                           field='key'
                           label={t('密钥')}
                           placeholder={
-                            '{\n' +
-                            '  "type": "service_account",\n' +
-                            '  "project_id": "abc-bcd-123-456",\n' +
-                            '  "private_key_id": "123xxxxx456",\n' +
-                            '  "private_key": "-----BEGIN PRIVATE KEY-----xxxx\n' +
-                            '  "client_email": "xxx@developer.gserviceaccount.com",\n' +
-                            '  "client_id": "111222333",\n' +
-                            '  "auth_uri": "https://accounts.google.com/o/oauth2/auth",\n' +
-                            '  "token_uri": "https://oauth2.googleapis.com/token",\n' +
-                            '  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",\n' +
-                            '  "client_x509_cert_url": "https://xxxxx.gserviceaccount.com",\n' +
-                            '  "universe_domain": "googleapis.com"\n' +
-                            '}'
+                            inputs.type === 41 
+                              ? '{\n' +
+                                '  "type": "service_account",\n' +
+                                '  "project_id": "abc-bcd-123-456",\n' +
+                                '  "private_key_id": "123xxxxx456",\n' +
+                                '  "private_key": "-----BEGIN PRIVATE KEY-----xxxx\n' +
+                                '  "client_email": "xxx@developer.gserviceaccount.com",\n' +
+                                '  "client_id": "111222333",\n' +
+                                '  "auth_uri": "https://accounts.google.com/o/oauth2/auth",\n' +
+                                '  "token_uri": "https://oauth2.googleapis.com/token",\n' +
+                                '  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",\n' +
+                                '  "client_x509_cert_url": "https://xxxxx.gserviceaccount.com",\n' +
+                                '  "universe_domain": "googleapis.com"\n' +
+                                '}'
+                              : t('请输入密钥，一行一个')
                           }
                           rules={isEdit ? [] : [{ required: true, message: t('请输入密钥') }]}
-                          autosize={{ minRows: 10 }}
+                          autosize={{ minRows: inputs.type === 41 ? 10 : 4 }}
                           autoComplete='new-password'
                           onChange={(value) => handleInputChange('key', value)}
                           extraText={batchExtra}


### PR DESCRIPTION
close #1353
<img width="583" height="443" alt="QQ20250715-140514" src="https://github.com/user-attachments/assets/b680d4c6-b64d-4e4e-aa5f-5221667c9160" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the channel editing form to automatically display a multiline input area when the key contains multiple lines, making it easier to manage multiline keys.
  * The placeholder and input size for the key field now adjust based on the key type and content for better usability.

* **Bug Fixes**
  * Channel details now display full sensitive information (such as keys) when self-use mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->