### PR TITLE
feat: video priority use origin model name

### DIFF
--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -37,9 +37,9 @@ func RelayTaskSubmit(c *gin.Context, relayMode int) (taskErr *dto.TaskError) {
 		return
 	}
 
-	modelName := service.CoverTaskActionToModelName(platform, relayInfo.Action)
-	if platform == constant.TaskPlatformKling {
-		modelName = relayInfo.OriginModelName
+	modelName := relayInfo.OriginModelName
+	if modelName == "" {
+		modelName = service.CoverTaskActionToModelName(platform, relayInfo.Action)
 	}
 	modelPrice, success := ratio_setting.GetModelPrice(modelName, true)
 	if !success {


### PR DESCRIPTION
优化: 视频渠道模型名称,优先使用分发器设置的模型名称
取不到才需要用平台+action保底

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the logic for determining the model name when submitting relay tasks to prioritize the original model name if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->