### PR TITLE
feat(volcengine): Add support for image editing for Volcengine channel

### DIFF
--- a/dto/dalle.go
+++ b/dto/dalle.go
@@ -16,6 +16,8 @@ type ImageRequest struct {
 	Moderation     string          `json:"moderation,omitempty"`
 	OutputFormat   string          `json:"output_format,omitempty"`
 	Watermark      *bool           `json:"watermark,omitempty"`
+	Seed           int             `json:"seed,omitempty"`
+	GuidanceScale  float64         `json:"guidance_scale,omitempty"`
 }
 
 type ImageResponse struct {


### PR DESCRIPTION
This commit introduces support for the image editing feature (RelayModeImagesEdits) for the Volcengine channel. Previously, this functionality was not implemented.

The key changes include:
- Refactored `ConvertImageRequest` to handle image edit requests by converting them to the `application/json` format required by the Volcengine API, instead of the incorrect `multipart/form-data`.
- Implemented helper functions to process form fields, extract the uploaded image, and encode it to Base64 within the JSON payload.
- Added support for additional Volcengine-specific parameters: `seed`, `guidance_scale`, and `watermark`.
- Updated `dto.ImageRequest` and the `image_handler` to recognize and process these new parameters.
- Corrected the request URL and headers for the image editing endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional seed and guidance scale parameters for more customizable image generation.
  * Image edit requests now use JSON with base64-encoded images for better compatibility.

* **Bug Fixes**
  * Enhanced parsing and validation of watermark, guidance scale, and seed parameters from form data to prevent errors.

* **Chores**
  * Aligned request handling and headers with updated API specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->