### PR TITLE
Fix/disable-gemini-ping

### DIFF
--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -120,6 +120,9 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	action := "generateContent"
 	if info.IsStream {
 		action = "streamGenerateContent?alt=sse"
+		if info.RelayMode == constant.RelayModeGemini {
+			info.DisablePing = true
+		}
 	}
 	return fmt.Sprintf("%s/%s/models/%s:%s", info.BaseUrl, version, info.UpstreamModelName, action), nil
 }
@@ -193,7 +196,6 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, request
 func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
 	if info.RelayMode == constant.RelayModeGemini {
 		if info.IsStream {
-			info.DisablePing = true
 			return GeminiTextGenerationStreamHandler(c, info, resp)
 		} else {
 			return GeminiTextGenerationHandler(c, info, resp)


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

之前的实现 https://github.com/QuantumNous/new-api/pull/1398 对DisablePing 标志位的设置时机过晚，设置时心跳保活已经启动。

本次修改做出了如下调整：

从`relay/channel/gemini/adaptor.go` 的 DoResponse 方法中移除了 info.DisablePing = true。
将 info.DisablePing = true 的逻辑移动到了GetRequestURL 方法中，确保设置时机有效

修复前：
<img width="1412" height="404" alt="图片" src="https://github.com/user-attachments/assets/abd3a109-fdee-4870-bb4f-0c705ade2645" />

修复后：
<img width="1312" height="498" alt="图片" src="https://github.com/user-attachments/assets/a9ea48bd-53b9-4663-914c-7b2718a92305" />
