### PR TITLE
feat: imagen for vertex channel

### DIFF
--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -59,15 +59,22 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 		return nil, errors.New("not supported model for image generation")
 	}
 
-	// convert size to aspect ratio
+	// convert size to aspect ratio but allow user to specify aspect ratio
 	aspectRatio := "1:1" // default aspect ratio
-	switch request.Size {
-	case "1024x1024":
-		aspectRatio = "1:1"
-	case "1024x1792":
-		aspectRatio = "9:16"
-	case "1792x1024":
-		aspectRatio = "16:9"
+	size := strings.TrimSpace(request.Size)
+	if size != "" {
+		if strings.Contains(size, ":") {
+			aspectRatio = size
+		} else {
+			switch size {
+			case "1024x1024":
+				aspectRatio = "1:1"
+			case "1024x1792":
+				aspectRatio = "9:16"
+			case "1792x1024":
+				aspectRatio = "16:9"
+			}
+		}
 	}
 
 	// build gemini imagen request


### PR DESCRIPTION
该 pr 包含以下更改：
- 为 vertex 渠道支持了 gemini imagen ，由于 vertex 请求格式与 gemini 一致，复用了 gemini 渠道中的方法
- 支持使用分辨率和比例两种不同的格式通过 imagen 生成图片
- 没了

<img width="400" height="399" alt="698696DA29A0DDB7188F1B7F33841E30" src="https://github.com/user-attachments/assets/fb059f60-0fcc-47ec-90ee-a2da673c3edf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable image generation on Vertex “Imagen” models via the Gemini path.
  * Support explicit aspect ratios (e.g., 1:1, 16:9, 9:16) in requests; existing size presets still work.
  * Honor overrides for number of images and size/aspect ratio from request payloads.

* **Bug Fixes**
  * Normalize model names with thinking/nothinking budget suffixes for correct routing.
  * Use the correct “predict” endpoint for Imagen image generation, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->