### PR TITLE
fix: update model name filtering to be case-sensitive

### DIFF
--- a/web/src/pages/Setting/Ratio/ModelRationNotSetEditor.jsx
+++ b/web/src/pages/Setting/Ratio/ModelRationNotSetEditor.jsx
@@ -131,7 +131,7 @@ export default function ModelRatioNotSetEditor(props) {
   // 在 return 语句之前，先处理过滤和分页逻辑
   const filteredModels = models.filter((model) =>
     searchText
-      ? model.name.toLowerCase().includes(searchText.toLowerCase())
+      ? model.name.includes(searchText)
       : true,
   );
 

--- a/web/src/pages/Setting/Ratio/ModelSettingsVisualEditor.jsx
+++ b/web/src/pages/Setting/Ratio/ModelSettingsVisualEditor.jsx
@@ -99,7 +99,7 @@ export default function ModelSettingsVisualEditor(props) {
   // 在 return 语句之前，先处理过滤和分页逻辑
   const filteredModels = models.filter((model) => {
     const keywordMatch = searchText
-      ? model.name.toLowerCase().includes(searchText.toLowerCase())
+      ? model.name.includes(searchText)
       : true;
     const conflictMatch = conflictOnly ? model.hasConflict : true;
     return keywordMatch && conflictMatch;


### PR DESCRIPTION
fix: https://github.com/QuantumNous/new-api/issues/1632

<img width="1095" height="427" alt="image" src="https://github.com/user-attachments/assets/5eb5caa5-71f6-48e3-80a4-a80ee3a44328" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Behavior Updates
  * Search in model lists is now case-sensitive in Ratio settings editors, affecting how results match uppercase/lowercase input.
  * Applies to: “Model Ratio Not Set” editor and “Model Settings” visual editor.
  * When the search box is empty, all models continue to be shown as before.
  * Expect differences in search results if your query’s casing does not exactly match the model names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->