### PR TITLE
修改claude system参数为数组，增加通用性

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -274,19 +274,28 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 
 	claudeMessages := make([]dto.ClaudeMessage, 0)
 	isFirstMessage := true
+	// 初始化system消息数组，用于累积多个system消息
+	var systemMessages []dto.ClaudeMediaMessage
+	
 	for _, message := range formatMessages {
 		if message.Role == "system" {
+			// 根据Claude API规范，system字段使用数组格式更有通用性
 			if message.IsStringContent() {
-				claudeRequest.System = message.StringContent()
+				systemMessages = append(systemMessages, dto.ClaudeMediaMessage{
+					Type: "text",
+					Text: common.GetPointer[string](message.StringContent()),
+				})
 			} else {
-				contents := message.ParseContent()
-				content := ""
-				for _, ctx := range contents {
+				// 支持复合内容的system消息（虽然不常见，但需要考虑完整性）
+				for _, ctx := range message.ParseContent() {
 					if ctx.Type == "text" {
-						content += ctx.Text
+						systemMessages = append(systemMessages, dto.ClaudeMediaMessage{
+							Type: "text",
+							Text: common.GetPointer[string](ctx.Text),
+						})
 					}
+					// 未来可以在这里扩展对图片等其他类型的支持
 				}
-				claudeRequest.System = content
 			}
 		} else {
 			if isFirstMessage {
@@ -392,6 +401,12 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 			claudeMessages = append(claudeMessages, claudeMessage)
 		}
 	}
+	
+	// 设置累积的system消息
+	if len(systemMessages) > 0 {
+		claudeRequest.System = systemMessages
+	}
+	
 	claudeRequest.Prompt = ""
 	claudeRequest.Messages = claudeMessages
 	return &claudeRequest, nil


### PR DESCRIPTION
将 openai 格式转换成claude时，如果system参数是一个字符串时，转换成claude格式后，system参数也是一个字符串，现在官方给的参考是字符串或数组皆可，但为了通用性，改为数组

最近，发现一个`Claude`中转站支持`Cherry Studio`的`Anthropic` 类型，但是通过`new api (v0.9.0-alpha.16)`(Anthropic)接入`Cherry Studio`(OpenAi类型)，就系统提示词会失效，经过对比请求参数，发现是`New api`将`OpenAi`格式转为`Anthropic`格式后，`system`参数默认是一个字符串。

查询`Anthropic`文档，发现字符串和数组形式皆可，而`Cherry Studio`的`system`参数是数组，为了通用性，将`system`参数改为数组，哪怕只有一个字符串。

下面是一些请求：

这个是`Cherry Studio`发送的请求
```
POST /v1/chat/completions HTTP/1.1
Host: localhost:3000
Connection: keep-alive
Content-Length: 256
x-stainless-timeout: 600
sec-ch-ua-platform: "Windows"
authorization: Bearer sk-xxx
sec-ch-ua: "Not)A;Brand";v="8", "Chromium";v="138"
x-stainless-retry-count: 0
x-api-key: sk-xxx
sec-ch-ua-mobile: ?0
x-title: Cherry Studio
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.5.7 Chrome/138.0.7204.100 Electron/37.2.3 Safari/537.36
accept: application/json
http-referer: https://cherry-ai.com
content-type: application/json
Sec-Fetch-Site: cross-site
Sec-Fetch-Mode: cors
Sec-Fetch-Dest: empty
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: zh-CN

{"model":"claude-3-7-sonnet-20250219","messages":[{"role":"system","content":"你是一个小精灵鬼，无论什么都想调皮一下"},{"role":"user","content":"你好"}],"temperature":0.7,"top_p":1,"stream":true,"stream_options":{"include_usage":true}}
```

这个是`New api`将上面这个请求转换发后发送的请求
```
POST /claude/v1/messages HTTP/2
host: xxx.com
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.5.7 Chrome/138.0.7204.100 Electron/37.2.3 Safari/537.36
content-type: application/json
accept: application/json
x-api-key: sk-xxx
anthropic-version: 2023-06-01
content-length: 226
accept-encoding: gzip

{"model":"claude-3-7-sonnet-20250219","system":"你是一个小精灵鬼，无论什么都想调皮一下","messages":[{"role":"user","content":"你好"}],"max_tokens":8192,"temperature":0.7,"top_p":1,"stream":true,"tools":[]}
```

这个是`Cherry Studio`通过`Anthropic`类型接入中转站发送的请求
```
POST /claude/v1/messages HTTP/2
host: xxx.com
content-length: 445
sec-ch-ua-platform: "Windows"
x-stainless-os: Unknown
anthropic-dangerous-direct-browser-access: true
anthropic-beta: output-128k-2025-02-19
x-stainless-runtime: browser:chrome
x-stainless-arch: unknown
sec-ch-ua: "Not)A;Brand";v="8", "Chromium";v="138"
x-api-key: sk-xxx
sec-ch-ua-mobile: ?0
anthropic-version: 2023-06-01
x-stainless-lang: js
accept: application/json
content-type: application/json
x-stainless-helper-method: stream
x-stainless-timeout: 600
x-stainless-package-version: 0.41.0
x-stainless-runtime-version: 138.0.7204
x-stainless-retry-count: 0
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.5.7 Chrome/138.0.7204.100 Electron/37.2.3 Safari/537.36
sec-fetch-site: cross-site
sec-fetch-mode: cors
sec-fetch-dest: empty
accept-encoding: gzip, deflate, br, zstd
accept-language: zh-CN
priority: u=1, i

{
  "model": "claude-3-7-sonnet-20250219",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "text",
          "text": "你好"
        }
      ]
    }
  ],
  "max_tokens": 4096,
  "temperature": 0.7,
  "top_p": 1,
  "system": [
    {
      "type": "text",
      "text": "你是一个小精灵鬼，无论什么都想调皮一下"
    }
  ],
  "thinking": {
    "type": "disabled"
  },
  "stream": true
}
```

下面这个是我这个`commit`修改后的请求
```
POST /claude/v1/messages HTTP/2
host: code.newcli.com
user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) CherryStudio/1.5.7 Chrome/138.0.7204.100 Electron/37.2.3 Safari/537.36
content-type: application/json
accept: application/json
x-api-key: sk-xxx
anthropic-version: 2023-06-01
content-length: 226
accept-encoding: gzip

{"model":"claude-3-7-sonnet-20250219","system":[{"text":"你是一个小精灵鬼，无论什么都想调皮一下","type":"text"}],"messages":[{"role":"user","content":[{"text":"你好","type":"text"}]}],"max_tokens":4096,"temperature":0.7,"top_p":1,"stream":true,"thinking":{"type":"disabled"}}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for multiple system messages when using Claude, allowing several system prompts to be included in a single request.
  * Handles composite system content by aggregating multiple text pieces into a unified system context.
  * Lays groundwork for richer media in system prompts in future updates.

* **Improvements**
  * More consistent and reliable processing of system prompts, improving overall response context and quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->