### PR TITLE
feat: 渠道级别限制每分钟最大请求数

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -31,6 +31,7 @@ const (
 	ContextKeyChannelIsMultiKey        ContextKey = "channel_is_multi_key"
 	ContextKeyChannelMultiKeyIndex     ContextKey = "channel_multi_key_index"
 	ContextKeyChannelKey               ContextKey = "channel_key"
+	ContextKeyChannelRateLimit         ContextKey = "channel_rate_limit"
 
 	/* user related keys */
 	ContextKeyUserId      ContextKey = "id"

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -267,6 +267,7 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	common.SetContextKey(c, constant.ContextKeyChannelAutoBan, channel.GetAutoBan())
 	common.SetContextKey(c, constant.ContextKeyChannelModelMapping, channel.GetModelMapping())
 	common.SetContextKey(c, constant.ContextKeyChannelStatusCodeMapping, channel.GetStatusCodeMapping())
+	common.SetContextKey(c, constant.ContextKeyChannelRateLimit, channel.GetRateLimit())
 
 	key, index, newAPIError := channel.GetNextEnabledKey()
 	if newAPIError != nil {

--- a/model/channel.go
+++ b/model/channel.go
@@ -44,6 +44,7 @@ type Channel struct {
 	Tag               *string `json:"tag" gorm:"index"`
 	Setting           *string `json:"setting" gorm:"type:text"` // 渠道额外设置
 	ParamOverride     *string `json:"param_override" gorm:"type:text"`
+	RateLimit         *int    `json:"rate_limit" gorm:"default:0"`
 	// add after v0.8.5
 	ChannelInfo ChannelInfo `json:"channel_info" gorm:"type:json"`
 }
@@ -395,6 +396,13 @@ func (channel *Channel) GetStatusCodeMapping() string {
 		return ""
 	}
 	return *channel.StatusCodeMapping
+}
+
+func (channel *Channel) GetRateLimit() int {
+	if channel.RateLimit == nil || *channel.RateLimit <= 0 {
+		return 0
+	}
+	return *channel.RateLimit
 }
 
 func (channel *Channel) Insert() error {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -62,6 +62,7 @@ type ResponsesUsageInfo struct {
 type RelayInfo struct {
 	ChannelType       int
 	ChannelId         int
+	ChannelRateLimit  int
 	TokenId           int
 	TokenKey          string
 	UserId            int
@@ -215,6 +216,7 @@ func GenRelayInfoImage(c *gin.Context) *RelayInfo {
 func GenRelayInfo(c *gin.Context) *RelayInfo {
 	channelType := common.GetContextKeyInt(c, constant.ContextKeyChannelType)
 	channelId := common.GetContextKeyInt(c, constant.ContextKeyChannelId)
+	channelRateLimit := common.GetContextKeyInt(c, constant.ContextKeyChannelRateLimit)
 	paramOverride := common.GetContextKeyStringMap(c, constant.ContextKeyChannelParamOverride)
 
 	tokenId := common.GetContextKeyInt(c, constant.ContextKeyTokenId)
@@ -235,6 +237,7 @@ func GenRelayInfo(c *gin.Context) *RelayInfo {
 		RequestURLPath:    c.Request.URL.String(),
 		ChannelType:       channelType,
 		ChannelId:         channelId,
+		ChannelRateLimit:  channelRateLimit,
 		TokenId:           tokenId,
 		TokenKey:          tokenKey,
 		UserId:            userId,

--- a/web/src/pages/Channel/EditChannel.js
+++ b/web/src/pages/Channel/EditChannel.js
@@ -102,6 +102,7 @@ const EditChannel = (props) => {
     groups: ['default'],
     priority: 0,
     weight: 0,
+    rate_limit: 0,
     tag: '',
     multi_key_mode: 'random',
   };
@@ -1368,6 +1369,16 @@ const EditChannel = (props) => {
                         placeholder={t('渠道权重')}
                         min={0}
                         onNumberChange={(value) => handleInputChange('weight', value)}
+                        style={{ width: '100%' }}
+                      />
+                    </Col>
+                    <Col span={12}>
+                      <Form.InputNumber
+                        field='rate_limit'
+                        label={t('每分钟最大请求数')}
+                        placeholder={t('每分钟最大请求数')}
+                        min={0}
+                        onNumberChange={(value) => handleInputChange('rate_limit', value)}
                         style={{ width: '100%' }}
                       />
                     </Col>


### PR DESCRIPTION
### PR 类型

- [x] 新功能

### PR 是否包含破坏性更新？

- [x] 否

### PR 描述

在渠道的高级设置中添加“每分钟最大请求数”设置
感觉报 429 合适一些，但没找到哪里调，现在会报“分组xxx没有可以用xxx模型的渠道”

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-channel rate limiting: set a per-minute request cap in Channel settings (Advanced Settings).
  * Channel selection now skips channels that exceed their rate limit, improving reliability under load.
  * Rate limit is propagated in request context and included in relay metadata for downstream visibility.

* **Chores**
  * Introduced safe accessor for channel rate limit and supporting infrastructure for in-memory and Redis-backed enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->