### PR TITLE
// 如果 group2model2channels 和 channelsIDM 中记录的channel的 ChannelInfo 中的 …

### DIFF
--- a/model/channel_cache.go
+++ b/model/channel_cache.go
@@ -65,6 +65,14 @@ func InitChannelCache() {
 	}
 
 	channelSyncLock.Lock()
+	// 如果 group2model2channels 和 channelsIDM 中记录的channel的 ChannelInfo 中的 MultiKeyPollingIndex 需要继承
+	// 否则会导致轮询索引重置，影响多key轮询的正确性
+	for id, channel := range channelsIDM {
+		if newChannel, ok := newChannelId2channel[id]; ok {
+			newChannel.ChannelInfo.MultiKeyPollingIndex = channel.ChannelInfo.MultiKeyPollingIndex
+		}
+	}
+
 	group2model2channels = newGroup2model2channels
 	channelsIDM = newChannelId2channel
 	channelSyncLock.Unlock()


### PR DESCRIPTION
…MultiKeyPollingIndex 需要继承

	// 否则会导致轮询索引重置，影响多key轮询的正确性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Multi-key polling now retains its state across cache refreshes, preventing unintended resets.
  - Improves reliability and consistency of channel polling after configuration updates or reloads.
  - Reduces interruptions and avoids repeated or skipped polling due to state loss.

- Performance
  - Smoother, more stable polling behavior by preserving in-memory state during refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->