### PR TITLE
fix: adjust column spans in JSONEditor for better layout  #1719

### DIFF
--- a/controller/model.go
+++ b/controller/model.go
@@ -207,7 +207,7 @@ func ListModels(c *gin.Context, modelType int) {
 		c.JSON(200, gin.H{
 			"success": true,
 			"data":    userOpenAiModels,
-      "object":  "list",
+			"object":  "list",
 		})
 	}
 }

--- a/web/src/components/common/ui/JSONEditor.jsx
+++ b/web/src/components/common/ui/JSONEditor.jsx
@@ -443,7 +443,7 @@ const JSONEditor = ({
 
           return (
             <Row key={pair.id} gutter={8} align='middle'>
-              <Col span={6}>
+              <Col span={10}>
                 <div className='relative'>
                   <Input
                     placeholder={t('键名')}
@@ -470,7 +470,7 @@ const JSONEditor = ({
                   )}
                 </div>
               </Col>
-              <Col span={16}>{renderValueInput(pair.id, pair.value)}</Col>
+              <Col span={12}>{renderValueInput(pair.id, pair.value)}</Col>
               <Col span={2}>
                 <Button
                   icon={<IconDelete />}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated JSON Editor layout: widened the key field and slightly reduced the value field for clearer readability and easier editing of long keys. No behavior changes.
* **Chores**
  * Minor formatting adjustments to JSON response indentation for consistency. No functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->