### PR TITLE
fix: stripe支付成功未正确跳转

### DIFF
--- a/controller/topup_stripe.go
+++ b/controller/topup_stripe.go
@@ -217,7 +217,7 @@ func genStripeLink(referenceId string, customerId string, email string, amount i
 
 	params := &stripe.CheckoutSessionParams{
 		ClientReferenceID: stripe.String(referenceId),
-		SuccessURL:        stripe.String(system_setting.ServerAddress + "/log"),
+		SuccessURL:        stripe.String(system_setting.ServerAddress + "/console/log"),
 		CancelURL:         stripe.String(system_setting.ServerAddress + "/topup"),
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
 			{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After completing a Stripe top-up, you are now redirected to the Console logs page instead of the generic log page.
  * Only the post-payment success redirect was updated; the payment flow, cancellations, and error handling remain unchanged.
  * No changes to public APIs or user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->