### PR TITLE
feat: add group option to search in console/token

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -31,7 +31,7 @@ func SearchTokens(c *gin.Context) {
 	userId := c.GetInt("id")
 	keyword := c.Query("keyword")
 	token := c.Query("token")
-	group := c.Query("group")
+	group := strings.TrimSpace(c.Query("group"))
 	tokens, err := model.SearchUserTokens(userId, keyword, token, group)
 	if err != nil {
 		common.ApiError(c, err)

--- a/model/token.go
+++ b/model/token.go
@@ -65,8 +65,9 @@ func GetAllUserTokens(userId int, startIdx int, num int) ([]*Token, error) {
 
 func SearchUserTokens(userId int, keyword string, token string, group string) (tokens []*Token, err error) {
 	if token != "" {
-		token = strings.Trim(token, "sk-")
+		token = strings.TrimPrefix(token, "sk-")
 	}
+	group = strings.TrimSpace(group)
 	query := DB.Where("user_id = ?", userId).Where("name LIKE ?", "%"+keyword+"%").Where(commonKeyCol+" LIKE ?", "%"+token+"%")
 	if group != "" && group != "null" {
 		query = query.Where(commonGroupCol+" = ?", group)

--- a/web/src/components/table/tokens/TokensFilters.jsx
+++ b/web/src/components/table/tokens/TokensFilters.jsx
@@ -84,7 +84,7 @@ const TokensFilters = ({
             field='searchGroup'
             placeholder={t('选择分组')}
             optionList={[
-              { label: t('选择分组'), value: null },
+              { label: t('选择分组'), value: '' },
               ...groupOptions,
             ]}
             showClear

--- a/web/src/hooks/tokens/useTokensData.jsx
+++ b/web/src/hooks/tokens/useTokensData.jsx
@@ -232,6 +232,8 @@ export const useTokensData = (openFluentNotification) => {
       } else {
         showError(message);
       }
+    } catch (error) {
+      showError(error.message || '搜索失败');
     } finally {
       setSearching(false);
     }


### PR DESCRIPTION
In Token Management, add Select group to filter token
<img width="1107" height="434" alt="image" src="https://github.com/user-attachments/assets/034c02ac-a69e-4e8f-bc0c-07740314839c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add group-based filtering to token search so users can narrow results by group.
  - Add a Group selector on the Tokens page with options loaded from available token groups.
  - Searches run immediately when the group selection changes; group is included with keyword and token filters.

- **Chores**
  - Updated search flow to support the new group filter while preserving existing error handling and responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->