### PR TITLE
feat: 新增支持目前已发布的amazon nova model

### DIFF
--- a/relay/channel/aws/constants.go
+++ b/relay/channel/aws/constants.go
@@ -86,10 +86,27 @@ var awsModelCanCrossRegionMap = map[string]map[string]bool{
 		"apac": true,
 	},
 	"amazon.nova-premier-v1:0": {
+		"us": true,
+	},
+	"amazon.nova-canvas-v1:0": {
 		"us":   true,
 		"eu":   true,
 		"apac": true,
-	}}
+	},
+	"amazon.nova-reel-v1:0": {
+		"us":   true,
+		"eu":   true,
+		"apac": true,
+	},
+	"amazon.nova-reel-v1:1": {
+		"us": true,
+	},
+	"amazon.nova-sonic-v1:0": {
+		"us":   true,
+		"eu":   true,
+		"apac": true,
+	},
+}
 
 var awsRegionCrossModelPrefixMap = map[string]string{
 	"us": "us",


### PR DESCRIPTION
**例行检查**

[//]: # (方框内删除已有的空格，填 x 号)
- [x] 我已确认目前没有类似 issue
- [x] 我已确认我已升级到最新版本
- [x] 我已完整查看过项目 README，已确定现有版本无法满足需求
- [x] 我理解并愿意跟进此 issue，协助测试和提供反馈
- [x] 我理解并认可上述内容，并理解项目维护者精力有限，**不遵循规则的 issue 可能会被无视或直接关闭**

**功能描述**
支持的Model ID：https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
把当前Amazon已经发布支持的nova model都添加到代码中，方便直接能选择
<img width="594" height="917" alt="image" src="https://github.com/user-attachments/assets/68e6fac2-352e-4fa7-8afe-cd2d468769d1" />

**应用场景**
调用方式不变，之前已经支持



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Amazon Nova models: Canvas v1, Reel v1 (v0 & v1), and Sonic v1.
  * These models are now selectable in the AWS integration and enable expanded generation and media capabilities.
  * Several of the new models are available across regions (US, EU, APAC) to broaden deployment options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->