### PR TITLE
Fix third-party binding cards showing incorrect status when disabled

### DIFF
--- a/web/src/components/settings/personal/cards/AccountManagement.jsx
+++ b/web/src/components/settings/personal/cards/AccountManagement.jsx
@@ -87,10 +87,13 @@ const AccountManagement = ({
   };
 
   const getBindingStatusText = (enabled, bound) => {
+    if (bound) {
+      return t('已绑定');
+    }
     if (!enabled) {
       return t('未启用');
     }
-    return bound ? t('已绑定') : t('未绑定');
+    return t('未绑定');
   };
 
   const getBindingButtonText = (enabled, bound) => {
@@ -101,9 +104,16 @@ const AccountManagement = ({
   };
 
   const renderProviderBinding = (enabled, accountId, label) => {
+    const hasAccountId = Boolean(accountId && accountId !== '');
+
+    if (hasAccountId) {
+      return renderAccountInfo(accountId, label);
+    }
+
     if (!enabled) {
       return <span className='text-gray-500'>{t('未启用')}</span>;
     }
+
     return renderAccountInfo(accountId, label);
   };
   return (


### PR DESCRIPTION
  ### PR 类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 文档更新
  - [ ] 其他

  ### PR 是否包含破坏性更新？

  - [ ] 是
  - [x] 否

  ### PR 描述
  - Ensure the WeChat binding card respects both the
  provider enable flag and the user’s binding state
  when rendering status and button text
  - Introduce shared helpers so all third-party
  providers show `未启用` when the administrator has
  disabled the integration instead of reporting `未绑
  定`
  - Align button disabling logic with the normalized
  enablement checks to avoid misleading actions

## 效果
**Before**
<img width="2093" height="749" alt="image" src="https://github.com/user-attachments/assets/8ce3705d-78c7-4b41-89ea-7836ca851498" />

**After**
<img width="2069" height="755" alt="image" src="https://github.com/user-attachments/assets/c239c5a4-58ec-438a-931c-539cc0542e79" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WeChat binding button now correctly reflects availability and is disabled when WeChat login is off.
  * Clearer binding status text for WeChat.

* **Refactor**
  * Unified rendering of account binding sections for WeChat, GitHub, OIDC, Telegram, and LinuxDO.
  * Consistent display of account IDs and statuses, showing “未启用” when a provider is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->