### PR TITLE
feat: add UseBetaQuery setting for Claude channels

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -7,6 +7,7 @@ type ChannelSettings struct {
 	PassThroughBodyEnabled bool   `json:"pass_through_body_enabled,omitempty"`
 	SystemPrompt           string `json:"system_prompt,omitempty"`
 	SystemPromptOverride   bool   `json:"system_prompt_override,omitempty"`
+	UseBetaQuery           bool   `json:"use_beta_query,omitempty"` // 为Claude渠道请求添加?beta=true参数
 }
 
 type VertexKeyType string

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -280,7 +280,12 @@ func GenRelayInfoClaude(c *gin.Context, request dto.Request) *RelayInfo {
 	info.ClaudeConvertInfo = &ClaudeConvertInfo{
 		LastMessagesType: LastMessageTypeNone,
 	}
+	// 检查URL query参数中的beta=true
 	if c.Query("beta") == "true" {
+		info.IsClaudeBetaQuery = true
+	}
+	// 检查渠道设置中的UseBetaQuery
+	if info.ChannelMeta.ChannelSetting.UseBetaQuery {
 		info.IsClaudeBetaQuery = true
 	}
 	return info

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -162,6 +162,7 @@ const EditChannelModal = (props) => {
     pass_through_body_enabled: false,
     system_prompt: '',
     system_prompt_override: false,
+    use_beta_query: false,
     settings: '',
     // 仅 Vertex: 密钥格式（存入 settings.vertex_key_type）
     vertex_key_type: 'json',
@@ -238,6 +239,7 @@ const EditChannelModal = (props) => {
     proxy: '',
     pass_through_body_enabled: false,
     system_prompt: '',
+    use_beta_query: false,
   });
   const showApiConfigCard = true; // 控制是否显示 API 配置卡片
   const getInitValues = () => ({ ...originInputs });
@@ -416,6 +418,7 @@ const EditChannelModal = (props) => {
           data.system_prompt = parsedSettings.system_prompt || '';
           data.system_prompt_override =
             parsedSettings.system_prompt_override || false;
+          data.use_beta_query = parsedSettings.use_beta_query || false;
         } catch (error) {
           console.error('解析渠道设置失败:', error);
           data.force_format = false;
@@ -424,6 +427,7 @@ const EditChannelModal = (props) => {
           data.pass_through_body_enabled = false;
           data.system_prompt = '';
           data.system_prompt_override = false;
+          data.use_beta_query = false;
         }
       } else {
         data.force_format = false;
@@ -432,6 +436,7 @@ const EditChannelModal = (props) => {
         data.pass_through_body_enabled = false;
         data.system_prompt = '';
         data.system_prompt_override = false;
+        data.use_beta_query = false;
       }
 
       if (data.settings) {
@@ -484,6 +489,7 @@ const EditChannelModal = (props) => {
         pass_through_body_enabled: data.pass_through_body_enabled,
         system_prompt: data.system_prompt,
         system_prompt_override: data.system_prompt_override || false,
+        use_beta_query: data.use_beta_query || false,
       });
       // console.log(data);
     } else {
@@ -731,6 +737,7 @@ const EditChannelModal = (props) => {
       pass_through_body_enabled: false,
       system_prompt: '',
       system_prompt_override: false,
+      use_beta_query: false,
     });
     // 重置密钥模式状态
     setKeyMode('append');
@@ -898,6 +905,7 @@ const EditChannelModal = (props) => {
       pass_through_body_enabled: localInputs.pass_through_body_enabled || false,
       system_prompt: localInputs.system_prompt || '',
       system_prompt_override: localInputs.system_prompt_override || false,
+      use_beta_query: localInputs.use_beta_query || false,
     };
     localInputs.setting = JSON.stringify(channelExtraSettings);
 
@@ -923,6 +931,7 @@ const EditChannelModal = (props) => {
     delete localInputs.pass_through_body_enabled;
     delete localInputs.system_prompt;
     delete localInputs.system_prompt_override;
+    delete localInputs.use_beta_query;
     delete localInputs.is_enterprise_account;
     // 顶层的 vertex_key_type 不应发送给后端
     delete localInputs.vertex_key_type;
@@ -2488,6 +2497,21 @@ const EditChannelModal = (props) => {
                       '如果用户请求中包含系统提示词，则使用此设置拼接到用户的系统提示词前面',
                     )}
                   />
+
+                  {(inputs.type === 14 || inputs.type === 33) && (
+                    <Form.Switch
+                      field='use_beta_query'
+                      label={t('启用 Beta API')}
+                      checkedText={t('开')}
+                      uncheckedText={t('关')}
+                      onChange={(value) =>
+                        handleChannelSettingsChange('use_beta_query', value)
+                      }
+                      extraText={t(
+                        '为 Claude 渠道的 /v1/messages 请求添加 ?beta=true 参数，用于访问 Claude 的 Beta 功能',
+                      )}
+                    />
+                  )}
                 </Card>
               </div>
             </Spin>


### PR DESCRIPTION
Add a new channel setting `use_beta_query` that allows administrators to configure Claude channels (types 14 and 33) to automatically append `?beta=true` query parameter to all /v1/messages requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Beta API” toggle in channel settings for supported Claude channels, allowing requests to use beta mode.
  - Beta mode can also be enabled per-request via the beta=true query parameter.
  - The new setting is available in the Edit Channel dialog and persists with channel configuration.
  - Default is off; toggle affects only applicable channel types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->