### PR TITLE
fix: passkey rpid detect

### DIFF
--- a/service/passkey/service.go
+++ b/service/passkey/service.go
@@ -80,9 +80,11 @@ func BuildWebAuthn(r *http.Request) (*webauthn.WebAuthn, error) {
 }
 
 func resolveOrigins(r *http.Request, settings *system_setting.PasskeySettings) ([]string, error) {
-	if len(settings.Origins) > 0 {
-		origins := make([]string, 0, len(settings.Origins))
-		for _, origin := range settings.Origins {
+	originsStr := strings.TrimSpace(settings.Origins)
+	if originsStr != "" {
+		originList := strings.Split(originsStr, ",")
+		origins := make([]string, 0, len(originList))
+		for _, origin := range originList {
 			trimmed := strings.TrimSpace(origin)
 			if trimmed == "" {
 				continue

--- a/setting/system_setting/passkey.go
+++ b/setting/system_setting/passkey.go
@@ -1,25 +1,27 @@
 package system_setting
 
 import (
+	"net/url"
 	"one-api/common"
 	"one-api/setting/config"
+	"strings"
 )
 
 type PasskeySettings struct {
-	Enabled              bool     `json:"enabled"`
-	RPDisplayName        string   `json:"rp_display_name"`
-	RPID                 string   `json:"rp_id"`
-	Origins              []string `json:"origins"`
-	AllowInsecureOrigin  bool     `json:"allow_insecure_origin"`
-	UserVerification     string   `json:"user_verification"`
-	AttachmentPreference string   `json:"attachment_preference"`
+	Enabled              bool   `json:"enabled"`
+	RPDisplayName        string `json:"rp_display_name"`
+	RPID                 string `json:"rp_id"`
+	Origins              string `json:"origins"`
+	AllowInsecureOrigin  bool   `json:"allow_insecure_origin"`
+	UserVerification     string `json:"user_verification"`
+	AttachmentPreference string `json:"attachment_preference"`
 }
 
 var defaultPasskeySettings = PasskeySettings{
 	Enabled:              false,
 	RPDisplayName:        common.SystemName,
 	RPID:                 "",
-	Origins:              []string{},
+	Origins:              "",
 	AllowInsecureOrigin:  false,
 	UserVerification:     "preferred",
 	AttachmentPreference: "",
@@ -30,5 +32,15 @@ func init() {
 }
 
 func GetPasskeySettings() *PasskeySettings {
+	if defaultPasskeySettings.RPID == "" && ServerAddress != "" {
+		// 从ServerAddress提取域名作为RPID
+		// ServerAddress可能是 "https://newapi.pro" 这种格式
+		serverAddr := strings.TrimSpace(ServerAddress)
+		if parsed, err := url.Parse(serverAddr); err == nil && parsed.Host != "" {
+			defaultPasskeySettings.RPID = parsed.Host
+		} else {
+			defaultPasskeySettings.RPID = serverAddr
+		}
+	}
 	return &defaultPasskeySettings
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Passkey origins now accepted as a single comma-separated string with whitespace tolerance and validation.
  - RP ID auto-derived from the server address when not set.
  - Default user verification set to “preferred” if unspecified.

- Refactor
  - Simplified Passkey settings form: origins moved from tag list to a single input field.
  - Unified submission flow to always include passkey settings from current form values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->