### PR TITLE
fix: passkey 文案

### DIFF
--- a/setting/system_setting/passkey.go
+++ b/setting/system_setting/passkey.go
@@ -42,5 +42,8 @@ func GetPasskeySettings() *PasskeySettings {
 			defaultPasskeySettings.RPID = serverAddr
 		}
 	}
+	if defaultPasskeySettings.Origins == "" || defaultPasskeySettings.Origins == "[]" {
+		defaultPasskeySettings.Origins = ServerAddress
+	}
 	return &defaultPasskeySettings
 }

--- a/web/src/components/settings/SystemSetting.jsx
+++ b/web/src/components/settings/SystemSetting.jsx
@@ -1050,7 +1050,7 @@ const SystemSetting = () => {
                         field="['passkey.rp_id']"
                         label={t('网站域名标识')}
                         placeholder={t('例如：example.com')}
-                        extraText={t('留空自动使用当前域名')}
+                        extraText={t('留空则默认使用服务器地址，注意不能携带http://或者https://')}
                       />
                     </Col>
                   </Row>
@@ -1111,7 +1111,7 @@ const SystemSetting = () => {
                         field="['passkey.origins']"
                         label={t('允许的 Origins')}
                         placeholder={t('填写带https的域名，逗号分隔')}
-                        extraText={t('空的话则不限制 Origin，多个 Origin 用逗号分隔')}
+                        extraText={t('为空则默认使用服务器地址，多个 Origin 用逗号分隔，例如 https://newapi.pro,https://newapi.com ,注意不能携带[]，需使用https')}
                       />
                     </Col>
                   </Row>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Passkey settings now auto-fill Origins with the server address when left empty or set to "[]", ensuring a valid default for WebAuthn.
- Documentation
  - Updated help text for Passkey settings:
    - rp_id: clarified that leaving it empty uses the server address (without http:// or https://).
    - origins: clarified that leaving it empty defaults to the server address; multiple Origins should be comma-separated (e.g., https://newapi.pro,https://newapi.com), must use HTTPS, and should not include square brackets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->