### PR TITLE
fix: channel remark ignore issue

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -46,7 +46,7 @@ type Channel struct {
 	Setting           *string `json:"setting" gorm:"type:text"` // 渠道额外设置
 	ParamOverride     *string `json:"param_override" gorm:"type:text"`
 	HeaderOverride    *string `json:"header_override" gorm:"type:text"`
-	Remark            string  `json:"remark,omitempty" gorm:"type:varchar(255)" validate:"max=255"`
+	Remark            *string `json:"remark" gorm:"type:varchar(255)" validate:"max=255"`
 	// add after v0.8.5
 	ChannelInfo ChannelInfo `json:"channel_info" gorm:"type:json"`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel API now returns the remark field consistently in responses. The field is nullable, allowing clients to distinguish between no remark (null) and an empty remark ("").
  * Improves data clarity and consistency across integrations; clients should handle null values for remark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->