### PR TITLE
feat: support openAI sdk retrieve videos

### DIFF
--- a/controller/task_video.go
+++ b/controller/task_video.go
@@ -97,6 +97,7 @@ func updateVideoSingleTask(ctx context.Context, adaptor channel.TaskAdaptor, cha
 		taskResult.Url = t.FailReason
 		taskResult.Progress = t.Progress
 		taskResult.Reason = t.FailReason
+		task.Data = t.Data
 	} else if taskResult, err = adaptor.ParseTaskResult(responseBody); err != nil {
 		return fmt.Errorf("parseTaskResult failed for task %s: %w", taskId, err)
 	} else {

--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -362,11 +362,20 @@ func videoFetchByIDRespBodyBuilder(c *gin.Context) (respBody []byte, taskResp *d
 		}
 	}()
 
-	if len(respBody) == 0 {
-		respBody, err = json.Marshal(dto.TaskResponse[any]{
-			Code: "success",
-			Data: TaskModel2Dto(originTask),
-		})
+	if len(respBody) != 0 {
+		return
+	}
+
+	if strings.HasPrefix(c.Request.RequestURI, "/v1/videos/") {
+		respBody = originTask.Data
+		return
+	}
+	respBody, err = json.Marshal(dto.TaskResponse[any]{
+		Code: "success",
+		Data: TaskModel2Dto(originTask),
+	})
+	if err != nil {
+		taskResp = service.TaskErrorWrapper(err, "marshal_response_failed", http.StatusInternalServerError)
 	}
 	return
 }


### PR DESCRIPTION
支持openai sdk获取Sora视频
参考: https://platform.openai.com/docs/api-reference/videos/retrieve
```
import OpenAI from 'openai';
const client = new OpenAI();
const video = await client.videos.retrieve('video_123');
console.log(video.id);
```
```
    const video = await client.videos.retrieve(config.get('taskId'));

    console.log('✅ 视频查询成功!');
    console.log('📋 视频任务详情:', video);
    console.log(`   ID: ${video.id}`);
    console.log(`   状态: ${video.status}`);
    console.log(`   创建时间: ${new Date(video.created_at * 1000).toLocaleString()}`);

    if (video.completed_at) {
      console.log(`   完成时间: ${new Date(video.completed_at * 1000).toLocaleString()}`);
    }
```
<img width="1110" height="728" alt="image" src="https://github.com/user-attachments/assets/3e536d0b-0f30-4e97-a744-46065889a770" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video task responses now include the task’s data payload, providing richer information for clients.
  * Video detail endpoints return the original task data directly, improving fidelity and alignment with upstream responses.
  * Response behavior remains consistent for status, progress, and reasons while delivering more complete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->