### PR TITLE
ignore ghcr

### DIFF
--- a/.github/workflows/docker-image-arm64.yml
+++ b/.github/workflows/docker-image-arm64.yml
@@ -38,8 +38,8 @@ jobs:
           echo "Building tag: $TAG for ${{ matrix.arch }}"
 
 
-      - name: Normalize GHCR repository
-        run: echo "GHCR_REPOSITORY=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+#      - name: Normalize GHCR repository
+#        run: echo "GHCR_REPOSITORY=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -50,12 +50,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Log in to GHCR
+#        uses: docker/login-action@v3
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (labels)
         id: meta
@@ -63,7 +63,7 @@ jobs:
         with:
           images: |
             calciumion/new-api
-            ghcr.io/${{ env.GHCR_REPOSITORY }}
+#            ghcr.io/${{ env.GHCR_REPOSITORY }}
 
       - name: Build & push single-arch (to both registries)
         uses: docker/build-push-action@v6
@@ -74,8 +74,8 @@ jobs:
           tags: |
             calciumion/new-api:${{ env.TAG }}-${{ matrix.arch }}
             calciumion/new-api:latest-${{ matrix.arch }}
-            ghcr.io/${{ env.GHCR_REPOSITORY }}:${{ env.TAG }}-${{ matrix.arch }}
-            ghcr.io/${{ env.GHCR_REPOSITORY }}:latest-${{ matrix.arch }}
+#            ghcr.io/${{ env.GHCR_REPOSITORY }}:${{ env.TAG }}-${{ matrix.arch }}
+#            ghcr.io/${{ env.GHCR_REPOSITORY }}:latest-${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -83,16 +83,16 @@ jobs:
           sbom: false
 
   create_manifests:
-    name: Create multi-arch manifests (Docker Hub + GHCR)
+    name: Create multi-arch manifests (Docker Hub)
     needs: [build_single_arch]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Extract tag
         run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Normalize GHCR repository
-        run: echo "GHCR_REPOSITORY=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+#
+#      - name: Normalize GHCR repository
+#        run: echo "GHCR_REPOSITORY=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -115,23 +115,23 @@ jobs:
             calciumion/new-api:latest-arm64
 
       # ---- GHCR ----
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Log in to GHCR
+#        uses: docker/login-action@v3
+#        with:
+#          registry: ghcr.io
+#          username: ${{ github.actor }}
+#          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create & push manifest (GHCR - version)
-        run: |
-          docker buildx imagetools create \
-            -t ghcr.io/${GHCR_REPOSITORY}:${TAG} \
-            ghcr.io/${GHCR_REPOSITORY}:${TAG}-amd64 \
-            ghcr.io/${GHCR_REPOSITORY}:${TAG}-arm64
-
-      - name: Create & push manifest (GHCR - latest)
-        run: |
-          docker buildx imagetools create \
-            -t ghcr.io/${GHCR_REPOSITORY}:latest \
-            ghcr.io/${GHCR_REPOSITORY}:latest-amd64 \
-            ghcr.io/${GHCR_REPOSITORY}:latest-arm64
+#      - name: Create & push manifest (GHCR - version)
+#        run: |
+#          docker buildx imagetools create \
+#            -t ghcr.io/${GHCR_REPOSITORY}:${TAG} \
+#            ghcr.io/${GHCR_REPOSITORY}:${TAG}-amd64 \
+#            ghcr.io/${GHCR_REPOSITORY}:${TAG}-arm64
+#
+#      - name: Create & push manifest (GHCR - latest)
+#        run: |
+#          docker buildx imagetools create \
+#            -t ghcr.io/${GHCR_REPOSITORY}:latest \
+#            ghcr.io/${GHCR_REPOSITORY}:latest-amd64 \
+#            ghcr.io/${GHCR_REPOSITORY}:latest-arm64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI workflow to publish ARM64 Docker images to Docker Hub only.
  - Disabled and commented out GHCR logins, tags, and publish steps.
  - Removed GHCR references from image tags and metadata.
  - Adjusted multi-arch manifest creation to target only Docker Hub.
  - Renamed manifest job display name to reflect Docker Hub-only publishing.
  - Added placeholder comments indicating deactivated GHCR steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->