### PR TITLE
fix: improve OAuth user binding and registration logic

### DIFF
--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -31,7 +31,6 @@ type OidcResponse struct {
 type OidcUser struct {
 	OpenID            string `json:"sub"`
 	Email             string `json:"email"`
-	EmailVerified     bool   `json:"email_verified"`
 	Name              string `json:"name"`
 	PreferredUsername string `json:"preferred_username"`
 	Picture           string `json:"picture"`
@@ -99,10 +98,6 @@ func getOidcUserInfoByCode(code string) (*OidcUser, error) {
 	if oidcUser.OpenID == "" || oidcUser.Email == "" {
 		common.SysLog("OIDC 获取用户信息为空！请检查设置！")
 		return nil, errors.New("OIDC 获取用户信息为空！请检查设置！")
-	}
-	if !oidcUser.EmailVerified {
-		common.SysLog("OIDC 邮箱未验证！请检查设置！")
-		return nil, errors.New("OIDC 邮箱未验证！请先完成邮箱验证！")
 	}
 	return &oidcUser, nil
 }


### PR DESCRIPTION
Fix #1350 

Refactored GitHub and OIDC OAuth handlers to better handle existing users by email, prevent conflicting account bindings, and only allow new user registration if enabled. This improves account linking consistency and provides clearer error messages for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically link GitHub and OIDC sign-ins to existing accounts when verified email matches; update display name when appropriate.
  * Registration-disabled setting is enforced only when actually creating a new account for consistent behavior.

* **Bug Fixes**
  * Prevent linking when an email is already bound to a different OAuth identity; return a clear error.
  * Settings > Account Management: binding buttons (WeChat, GitHub, OIDC, LinuxDO) show correct status (未启用/已绑定/绑定) and are disabled when bound or not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->