### PR TITLE
针对 chat 的 4 类接口和演练场接口回复的敏感词过滤

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -82,7 +82,12 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		defer ws.Close()
 	}
 
+	var writer *service.SensitiveWordFilterResponseWriter
 	defer func() {
+		if writer != nil && writer.GetNewAPIError() != nil {
+			writer.GetNewAPIError().SetMessage(common.MessageWithRequestId(writer.GetNewAPIError().Error(), requestId))
+		}
+
 		if newAPIError != nil {
 			newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
 			switch relayFormat {
@@ -122,6 +127,17 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 			newAPIError = types.NewError(err, types.ErrorCodeSensitiveWordsDetected)
 			return
 		}
+	}
+	//启用模型回复检查
+	if setting.ShouldCheckCompletionSensitive() && service.IsChatCompletionEndpoint(c) {
+		writer = &service.SensitiveWordFilterResponseWriter{
+			Url:            c.Request.URL.Path,
+			ResponseWriter: c.Writer,
+			Body:           &bytes.Buffer{},
+			Info:           relayInfo,
+			Context:        c,
+		}
+		c.Writer = writer
 	}
 
 	tokens, err := service.CountRequestToken(c, meta, relayInfo)
@@ -180,7 +196,11 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		}
 
 		if newAPIError == nil {
-			return
+			if writer != nil && writer.GetNewAPIError() != nil {
+				newAPIError = writer.GetNewAPIError()
+			} else {
+				return
+			}
 		}
 
 		processChannelError(c, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(c, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)

--- a/model/option.go
+++ b/model/option.go
@@ -135,6 +135,7 @@ func InitOptionMap() {
 	common.OptionMap["SelfUseModeEnabled"] = strconv.FormatBool(operation_setting.SelfUseModeEnabled)
 	common.OptionMap["ModelRequestRateLimitEnabled"] = strconv.FormatBool(setting.ModelRequestRateLimitEnabled)
 	common.OptionMap["CheckSensitiveOnPromptEnabled"] = strconv.FormatBool(setting.CheckSensitiveOnPromptEnabled)
+	common.OptionMap["CheckSensitiveOnCompletionEnabled"] = strconv.FormatBool(setting.CheckSensitiveOnCompletionEnabled)
 	common.OptionMap["StopOnSensitiveEnabled"] = strconv.FormatBool(setting.StopOnSensitiveEnabled)
 	common.OptionMap["SensitiveWords"] = setting.SensitiveWordsToString()
 	common.OptionMap["StreamCacheQueueLength"] = strconv.Itoa(setting.StreamCacheQueueLength)
@@ -278,6 +279,8 @@ func updateOptionMap(key string, value string) (err error) {
 			operation_setting.SelfUseModeEnabled = boolValue
 		case "CheckSensitiveOnPromptEnabled":
 			setting.CheckSensitiveOnPromptEnabled = boolValue
+		case "CheckSensitiveOnCompletionEnabled":
+			setting.CheckSensitiveOnCompletionEnabled = boolValue
 		case "ModelRequestRateLimitEnabled":
 			setting.ModelRequestRateLimitEnabled = boolValue
 		case "StopOnSensitiveEnabled":

--- a/service/sensitive.go
+++ b/service/sensitive.go
@@ -1,11 +1,19 @@
 package service
 
 import (
+	"bufio"
+	"bytes"
 	"errors"
-	"strings"
-
+	"fmt"
+	marshalCommon "github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/relay/common"
 	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"net/http"
+	"strings"
 )
 
 func CheckSensitiveMessages(messages []dto.Message) ([]string, error) {
@@ -74,4 +82,274 @@ func SensitiveWordReplace(text string, returnImmediately bool) (bool, []string, 
 		return true, words, builder.String()
 	}
 	return false, nil, text
+}
+
+// 大模型返回的内容敏感词过滤
+
+const SensitiveWordPlaceholders = "__--sensitive_words--__"
+const SensitiveErrorInfo = "\n\nuser sensitive words detected: "
+
+func IsChatCompletionEndpoint(c *gin.Context) bool {
+	return (c.Request.URL.Path == "/v1/chat/completions" && c.Request.Method == "POST") ||
+		(c.Request.URL.Path == "/v1/responses" && c.Request.Method == "POST") ||
+		(c.Request.URL.Path == "/v1/messages" && c.Request.Method == "POST") ||
+		(c.Request.URL.Path == "/pg/chat/completions" && c.Request.Method == "POST") ||
+		(strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") && c.Request.Method == "POST")
+}
+
+type SensitiveWordFilterResponseWriter struct {
+	gin.ResponseWriter
+	Url             string
+	Body            *bytes.Buffer
+	Info            *common.RelayInfo
+	Context         *gin.Context
+	newAPIError     *types.NewAPIError
+	responseWritten bool
+
+	// stream
+	streamContent              string
+	errorStreamMessageTemplate string
+}
+
+func (w *SensitiveWordFilterResponseWriter) appendStreamRespContent(content string) {
+	w.streamContent += content
+}
+
+func (w *SensitiveWordFilterResponseWriter) GetNewAPIError() *types.NewAPIError {
+	return w.newAPIError
+}
+
+// Write 实现 Write 方法
+func (w *SensitiveWordFilterResponseWriter) Write(b []byte) (int, error) {
+	if w.responseWritten {
+		return len(b), nil // 返回成功但不实际写入，或者返回错误
+	}
+
+	body := w.processBody(b)
+
+	if w.newAPIError != nil && !w.responseWritten {
+		w.responseWritten = true
+
+		// 根据格式生成错误响应
+		if w.Info.IsStream {
+			streamError := fmt.Sprintf("data: %s\n\ndata: [DONE]\n\n", w.errorStreamMessageTemplate)
+			w.ResponseWriter.Header().Set("Content-Type", "text/event-stream")
+			w.ResponseWriter.Header().Set("Cache-Control", "no-cache")
+			w.ResponseWriter.Header().Set("Connection", "keep-alive")
+			w.ResponseWriter.WriteHeader(w.newAPIError.StatusCode)
+			return w.ResponseWriter.Write([]byte(streamError))
+		} else {
+			var responseData []byte
+			switch w.Info.RelayFormat {
+			case types.RelayFormatClaude:
+				errorResponse := gin.H{
+					"type":  "error",
+					"error": w.newAPIError.ToClaudeError(),
+				}
+				responseData, _ = marshalCommon.Marshal(errorResponse)
+			default:
+				errorResponse := gin.H{
+					"error": w.newAPIError.ToOpenAIError(),
+				}
+				responseData, _ = marshalCommon.Marshal(errorResponse)
+			}
+			// 设置正确的头部
+			w.ResponseWriter.Header().Set("Content-Type", "application/json")
+			w.ResponseWriter.Header().Set("Content-Length", fmt.Sprintf("%d", len(responseData)))
+			w.ResponseWriter.WriteHeader(w.newAPIError.StatusCode)
+			// 写入错误响应并返回，不再处理原始数据
+			return w.ResponseWriter.Write(responseData)
+		}
+	}
+	return w.ResponseWriter.Write(body)
+}
+
+// processBody 处理响应体
+func (w *SensitiveWordFilterResponseWriter) processBody(data []byte) []byte {
+	if w.Info.IsStream {
+		// 流式响应处理
+		return w.processStreamResponse(data)
+	} else {
+		// 非流式响应处理
+		return w.processNonStreamResponse(data)
+	}
+}
+
+// processNonStreamResponse 处理非流式响应
+func (w *SensitiveWordFilterResponseWriter) processNonStreamResponse(bodyBytes []byte) []byte {
+	var contents string
+	if w.Info.RelayFormat == types.RelayFormatOpenAI {
+		var simpleResponse dto.OpenAITextResponse
+		if err := marshalCommon.Unmarshal(bodyBytes, &simpleResponse); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return bodyBytes
+		}
+		for _, choice := range simpleResponse.Choices {
+			value, isString := choice.Message.Content.(string)
+			if isString {
+				contents += value
+			}
+		}
+	} else if w.Info.RelayFormat == types.RelayFormatGemini {
+		var geminiResponse dto.GeminiChatResponse
+		if err := marshalCommon.Unmarshal(bodyBytes, &geminiResponse); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return bodyBytes
+		}
+		for _, candidate := range geminiResponse.Candidates {
+			for _, part := range candidate.Content.Parts {
+				contents += part.Text
+			}
+		}
+	} else if w.Info.RelayFormat == types.RelayFormatClaude {
+		var claudeResponse dto.ClaudeResponse
+		if err := marshalCommon.Unmarshal(bodyBytes, &claudeResponse); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return bodyBytes
+		}
+		for _, content := range claudeResponse.Content {
+			if content.Text != nil {
+				contents += *content.Text
+			}
+		}
+	} else if w.Info.RelayFormat == types.RelayFormatOpenAIResponses {
+		var responsesResponse dto.OpenAIResponsesResponse
+		if err := marshalCommon.Unmarshal(bodyBytes, &responsesResponse); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return bodyBytes
+		}
+		for _, output := range responsesResponse.Output {
+			for _, content := range output.Content {
+				contents += content.Text
+			}
+		}
+	}
+	if contents != "" {
+		contains, words := CheckSensitiveText(contents)
+		if contains {
+			logger.LogWarn(w.Context, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ", ")))
+			w.newAPIError = types.NewError(fmt.Errorf("user sensitive words detected: %s", strings.Join(words, ", ")), types.ErrorCodeSensitiveWordsDetected)
+			return bodyBytes
+		}
+	}
+	return bodyBytes
+}
+
+// processStreamResponse 处理流式响应
+func (w *SensitiveWordFilterResponseWriter) processStreamResponse(bodyBytes []byte) []byte {
+	scanner := bufio.NewScanner(bytes.NewReader(bodyBytes))
+	for scanner.Scan() {
+		data := scanner.Text()
+		if len(data) < 6 {
+			continue
+		}
+		if data[:5] != "data:" && data[:6] != "[DONE]" {
+			continue
+		}
+		data = data[5:]
+		data = strings.TrimLeft(data, " ")
+		data = strings.TrimSuffix(data, "\r")
+		if !strings.HasPrefix(data, "[DONE]") {
+			content, ok := w.parserLineChatInfo(data)
+			if !ok {
+				continue
+			}
+			w.appendStreamRespContent(content)
+		}
+	}
+	if w.streamContent != "" {
+		contains, words := CheckSensitiveText(w.streamContent)
+		if contains {
+			logger.LogWarn(w.Context, fmt.Sprintf("user sensitive words detected: %s", strings.Join(words, ", ")))
+			w.newAPIError = types.NewError(fmt.Errorf("user sensitive words detected: %s", strings.Join(words, ", ")), types.ErrorCodeSensitiveWordsDetected)
+			// 将最后一条
+			w.errorStreamMessageTemplate = strings.Replace(w.errorStreamMessageTemplate, SensitiveWordPlaceholders, strings.Join(words, ", "), 1)
+			return bodyBytes
+		}
+	}
+	return bodyBytes
+}
+
+func (w *SensitiveWordFilterResponseWriter) parserLineChatInfo(data string) (string, bool) {
+	var content string
+	if w.Info.RelayFormat == types.RelayFormatOpenAI {
+		var resp dto.ChatCompletionsStreamResponse
+		if err := marshalCommon.UnmarshalJsonStr(data, &resp); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return "", false
+		}
+		for index, choice := range resp.Choices {
+			if choice.Delta.Content != nil {
+				// 将流返回的字符串记录
+				content += *choice.Delta.Content
+
+				// 更改最后一个信息的内容，提供给后面如果检测到敏感词进行替换返回给前端
+				if index == len(resp.Choices)-1 {
+					resp.Choices[index].Delta.Content = &[]string{SensitiveErrorInfo + SensitiveWordPlaceholders}[0]
+				}
+			}
+		}
+
+		// 构建错误消息的模版
+		streamItemInfo, _ := marshalCommon.Marshal(resp)
+		w.errorStreamMessageTemplate = string(streamItemInfo)
+	} else if w.Info.RelayFormat == types.RelayFormatGemini {
+		var resp dto.GeminiChatResponse
+		if err := marshalCommon.UnmarshalJsonStr(data, &resp); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return "", false
+		}
+		for index, candidate := range resp.Candidates {
+			for partIndex, part := range candidate.Content.Parts {
+				// 将流返回的字符串记录
+				content += part.Text
+
+				// 更改最后一个信息的内容，提供给后面如果检测到敏感词进行替换返回给前端
+				if index == len(resp.Candidates)-1 && partIndex == len(candidate.Content.Parts)-1 {
+					resp.Candidates[index].Content.Parts[partIndex].Text = SensitiveErrorInfo + SensitiveWordPlaceholders
+				}
+			}
+		}
+
+		// 构建错误消息的模版
+		streamItemInfo, _ := marshalCommon.Marshal(resp)
+		w.errorStreamMessageTemplate = string(streamItemInfo)
+	} else if w.Info.RelayFormat == types.RelayFormatClaude {
+		var resp dto.ClaudeResponse
+		if err := marshalCommon.UnmarshalJsonStr(data, &resp); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return "", false
+		}
+
+		if resp.Type == "content_block_delta" {
+			if resp.Delta != nil {
+				// 将流返回的字符串记录
+				content += *resp.Delta.Text
+
+				// 更改最后一个信息的内容，提供给后面如果检测到敏感词进行替换返回给前端
+				resp.Delta.Text = &[]string{SensitiveErrorInfo + SensitiveWordPlaceholders}[0]
+			}
+		}
+
+		// 构建错误消息的模版
+		streamItemInfo, _ := marshalCommon.Marshal(resp)
+		w.errorStreamMessageTemplate = string(streamItemInfo)
+	} else if w.Info.RelayFormat == types.RelayFormatOpenAIResponses {
+		var resp dto.ResponsesStreamResponse
+		if err := marshalCommon.UnmarshalJsonStr(data, &resp); err != nil {
+			logger.LogError(w.Context, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError).Error())
+			return "", false
+		}
+		if resp.Type == "response.output_text.delta" {
+			// 将流返回的字符串记录
+			content = resp.Delta
+			// 更改最后一个信息的内容，提供给后面如果检测到敏感词进行替换返回给前端
+			resp.Delta = SensitiveErrorInfo + SensitiveWordPlaceholders
+		}
+
+		// 构建错误消息的模版
+		streamItemInfo, _ := marshalCommon.Marshal(resp)
+		w.errorStreamMessageTemplate = string(streamItemInfo)
+	}
+	return content, true
 }

--- a/setting/sensitive.go
+++ b/setting/sensitive.go
@@ -5,7 +5,7 @@ import "strings"
 var CheckSensitiveEnabled = true
 var CheckSensitiveOnPromptEnabled = true
 
-//var CheckSensitiveOnCompletionEnabled = true
+var CheckSensitiveOnCompletionEnabled = false
 
 // StopOnSensitiveEnabled 如果检测到敏感词，是否立刻停止生成，否则替换敏感词
 var StopOnSensitiveEnabled = true
@@ -38,6 +38,6 @@ func ShouldCheckPromptSensitive() bool {
 	return CheckSensitiveEnabled && CheckSensitiveOnPromptEnabled
 }
 
-//func ShouldCheckCompletionSensitive() bool {
-//	return CheckSensitiveEnabled && CheckSensitiveOnCompletionEnabled
-//}
+func ShouldCheckCompletionSensitive() bool {
+	return CheckSensitiveEnabled && CheckSensitiveOnCompletionEnabled
+}

--- a/web/src/components/settings/OperationSetting.jsx
+++ b/web/src/components/settings/OperationSetting.jsx
@@ -58,6 +58,7 @@ const OperationSetting = () => {
     /* 敏感词设置 */
     CheckSensitiveEnabled: false,
     CheckSensitiveOnPromptEnabled: false,
+    CheckSensitiveOnCompletionEnabled: false,
     SensitiveWords: '',
 
     /* 日志设置 */

--- a/web/src/pages/Setting/Operation/SettingsSensitiveWords.jsx
+++ b/web/src/pages/Setting/Operation/SettingsSensitiveWords.jsx
@@ -34,6 +34,7 @@ export default function SettingsSensitiveWords(props) {
   const [inputs, setInputs] = useState({
     CheckSensitiveEnabled: false,
     CheckSensitiveOnPromptEnabled: false,
+    CheckSensitiveOnCompletionEnabled: false,
     SensitiveWords: '',
   });
   const refForm = useRef();
@@ -123,6 +124,21 @@ export default function SettingsSensitiveWords(props) {
                       CheckSensitiveOnPromptEnabled: value,
                     })
                   }
+                />
+              </Col>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Switch
+                    field={'CheckSensitiveOnCompletionEnabled'}
+                    label={t('启用模型回复检查')}
+                    size='default'
+                    checkedText='｜'
+                    uncheckedText='〇'
+                    onChange={(value) =>
+                        setInputs({
+                          ...inputs,
+                          CheckSensitiveOnCompletionEnabled: value,
+                        })
+                    }
                 />
               </Col>
             </Row>


### PR DESCRIPTION
1. 针对以下接口对其 ResponseWriter 的 write 方法进行拦截从而获取大模型的响应进行敏感词过滤
```golang
func IsChatCompletionEndpoint(c *gin.Context) bool {
	return (c.Request.URL.Path == "/v1/chat/completions" && c.Request.Method == "POST") ||
		(c.Request.URL.Path == "/v1/responses" && c.Request.Method == "POST") ||
		(c.Request.URL.Path == "/v1/messages" && c.Request.Method == "POST") ||
		(c.Request.URL.Path == "/pg/chat/completions" && c.Request.Method == "POST") ||
		(strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") && c.Request.Method == "POST")
}
```
2. 增加了响应值敏感词过滤的前端开关，默认为 false 从而对于没有开启的用户没有影响, 开关的 config 名称使用之前 commit 中注释的  [feat: 敏感词过滤](https://github.com/QuantumNous/new-api/pull/131/files#diff-695e2ea0345b4003d32ed4cc7d6d8a1bebcff70f6bff10db0d9c2499b7a6f34d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sensitive word filtering for AI-generated chat responses. When enabled, the system detects and blocks responses containing sensitive content before delivery to the user.

* **Configuration**
  * New setting toggle added to enable or disable sensitive word checking for chat completion responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->