### PR TITLE
fix: handle JSON parsing for thinking content in ollama stream

### DIFF
--- a/relay/channel/ollama/stream.go
+++ b/relay/channel/ollama/stream.go
@@ -121,7 +121,14 @@ func ollamaStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http
 			if chunk.Message != nil && len(chunk.Message.Thinking) > 0 {
 				raw := strings.TrimSpace(string(chunk.Message.Thinking))
 				if raw != "" && raw != "null" {
-					delta.Choices[0].Delta.SetReasoningContent(raw)
+					// Unmarshal the JSON string to get the actual content without quotes
+					var thinkingContent string
+					if err := json.Unmarshal(chunk.Message.Thinking, &thinkingContent); err == nil {
+						delta.Choices[0].Delta.SetReasoningContent(thinkingContent)
+					} else {
+						// Fallback to raw string if it's not a JSON string
+						delta.Choices[0].Delta.SetReasoningContent(raw)
+					}
 				}
 			}
 			// tool calls
@@ -209,7 +216,14 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 		if ck.Message != nil && len(ck.Message.Thinking) > 0 {
 			raw := strings.TrimSpace(string(ck.Message.Thinking))
 			if raw != "" && raw != "null" {
-				reasoningBuilder.WriteString(raw)
+				// Unmarshal the JSON string to get the actual content without quotes
+				var thinkingContent string
+				if err := json.Unmarshal(ck.Message.Thinking, &thinkingContent); err == nil {
+					reasoningBuilder.WriteString(thinkingContent)
+				} else {
+					// Fallback to raw string if it's not a JSON string
+					reasoningBuilder.WriteString(raw)
+				}
 			}
 		}
 		if ck.Message != nil && ck.Message.Content != "" {
@@ -229,7 +243,14 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 			if len(single.Message.Thinking) > 0 {
 				raw := strings.TrimSpace(string(single.Message.Thinking))
 				if raw != "" && raw != "null" {
-					reasoningBuilder.WriteString(raw)
+					// Unmarshal the JSON string to get the actual content without quotes
+					var thinkingContent string
+					if err := json.Unmarshal(single.Message.Thinking, &thinkingContent); err == nil {
+						reasoningBuilder.WriteString(thinkingContent)
+					} else {
+						// Fallback to raw string if it's not a JSON string
+						reasoningBuilder.WriteString(raw)
+					}
 				}
 			}
 			aggContent.WriteString(single.Message.Content)


### PR DESCRIPTION
修复在Ollama渠道处理思考模型时，reasoning_content中出现了多余的双引号问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of reasoning content handling with improved parsing logic and automatic fallback support. This ensures content remains consistently available and properly formatted, maintaining stability regardless of content structure variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->