### PR TITLE
feat: extend group ratio functionality to support user-specific overr…

### DIFF
--- a/controller/group.go
+++ b/controller/group.go
@@ -27,7 +27,7 @@ func GetUserGroups(c *gin.Context) {
 	userGroup := ""
 	userId := c.GetInt("id")
 	userGroup, _ = model.GetUserGroup(userId, false)
-	for groupName, ratio := range ratio_setting.GetGroupRatioCopy() {
+	for groupName, ratio := range ratio_setting.GetGroupRatioExtendCopy(userGroup) {
 		// UserUsableGroups contains the groups that the user can use
 		userUsableGroups := setting.GetUserUsableGroups(userGroup)
 		if desc, ok := userUsableGroups[groupName]; ok {


### PR DESCRIPTION
# feature

支持用户分组命中 【分组特殊倍率】的分组时候，允许用户可见特殊配置的分组

case:1
* user: default:
* 可见: 'default'

case:2
* user: vip
* 可见: vip_pro / vip_premium

<img width="338" height="260" alt="image" src="https://github.com/user-attachments/assets/44605989-7a35-47b6-bff9-b59fe7e34d94" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User groups can now extend default ratio settings with group-specific overrides so group-level customizations are applied.

* **Refactor**
  * Group ratio retrieval updated to merge defaults with any group-specific overrides when assembling effective ratios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->