### PR TITLE
fix: correct bool value for watermark

### DIFF
--- a/relay/helper/valid_request.go
+++ b/relay/helper/valid_request.go
@@ -160,8 +160,9 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 				imageRequest.N = 1
 			}
 
-			watermark := formData.Has("watermark")
-			if watermark {
+			hasWatermark := formData.Has("watermark")
+			if hasWatermark {
+				watermark := formData.Get("watermark") == "true"
 				imageRequest.Watermark = &watermark
 			}
 			break


### PR DESCRIPTION
修复豆包水印设置不生效的问题
https://www.volcengine.com/docs/82379/1541523
<img width="934" height="292" alt="image" src="https://github.com/user-attachments/assets/3bc98bc2-ee2b-4904-9fc5-827ac515029a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed watermark parameter handling in OpenAI image edit requests to respect the parameter's actual value rather than applying it whenever the field is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->