### PR TITLE
feat: topUp show correct symbol

### DIFF
--- a/web/src/components/topup/RechargeCard.jsx
+++ b/web/src/components/topup/RechargeCard.jsx
@@ -447,7 +447,7 @@ const RechargeCard = ({
                                 style={{ margin: '0 0 8px 0' }}
                               >
                                 <Coins size={18} />
-                                {formatLargeNumber(preset.value)} $
+                                {formatLargeNumber(displayValue)} {symbol}
                                 {hasDiscount && (
                                   <Tag style={{ marginLeft: 4 }} color='green'>
                                     {t('折').includes('off')


### PR DESCRIPTION
充值显示的货币符号根据配置显示正确的符号
<img width="1392" height="556" alt="image" src="https://github.com/user-attachments/assets/711bb9cd-52d1-47d7-817f-a9ab69a844f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the recharge card to display currency-specific monetary values with proper currency symbol placement, replacing the previously shown generic preset amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->