### PR TITLE
fix: test channel frequency

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -625,7 +625,7 @@ func AutomaticallyTestChannels() {
 			}
 			for {
 				frequency := operation_setting.GetMonitorSetting().AutoTestChannelMinutes
-				time.Sleep(time.Duration(frequency) * time.Minute)
+				time.Sleep(time.Duration(int(math.Round(frequency))) * time.Minute)
 				common.SysLog(fmt.Sprintf("automatically test channels with interval %d minutes", frequency))
 				common.SysLog("automatically testing all channels")
 				_ = testAllChannels(false)

--- a/setting/operation_setting/monitor_setting.go
+++ b/setting/operation_setting/monitor_setting.go
@@ -8,8 +8,8 @@ import (
 )
 
 type MonitorSetting struct {
-	AutoTestChannelEnabled bool `json:"auto_test_channel_enabled"`
-	AutoTestChannelMinutes int  `json:"auto_test_channel_minutes"`
+	AutoTestChannelEnabled bool    `json:"auto_test_channel_enabled"`
+	AutoTestChannelMinutes float64 `json:"auto_test_channel_minutes"`
 }
 
 // 默认配置
@@ -28,7 +28,7 @@ func GetMonitorSetting() *MonitorSetting {
 		frequency, err := strconv.Atoi(os.Getenv("CHANNEL_TEST_FREQUENCY"))
 		if err == nil && frequency > 0 {
 			monitorSetting.AutoTestChannelEnabled = true
-			monitorSetting.AutoTestChannelMinutes = frequency
+			monitorSetting.AutoTestChannelMinutes = float64(frequency)
 		}
 	}
 	return &monitorSetting


### PR DESCRIPTION
fix #2115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel test intervals are now rounded to whole minute values for consistent timing behavior in monitoring operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->