### PR TITLE
fix: root page does not have analytic code

### DIFF
--- a/common/embed-file-system.go
+++ b/common/embed-file-system.go
@@ -25,7 +25,7 @@ func (e *embedFileSystem) Exists(prefix string, path string) bool {
 
 func (e *embedFileSystem) Open(name string) (http.File, error) {
 	if name == "/" {
-		// This will make sure the index page gose to NoRouter handler,
+		// This will make sure the index page goes to NoRouter handler,
 		// which will use the replaced index bytes with analytic codes.
 		return nil, os.ErrNotExist
 	}


### PR DESCRIPTION
The root page `https://xxx.xxx/` is served directly from the embed file system, which always delivers the original version of the index file — one that hasn’t been patched with the analytics code.

This PR prevents the static file system from serving the root page directly, ensuring that the version with the analytics code is always used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved embedded file system implementation for better maintainability and flexibility.
* **Bug Fixes**
  * Fixed handling of the root path when serving embedded files so requests to "/" behave correctly and return appropriate errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->