### PR TITLE
feat:  EditTokenModal 中针对用户创建的 token 默认无限额度

### DIFF
--- a/web/src/components/table/tokens/modals/EditTokenModal.jsx
+++ b/web/src/components/table/tokens/modals/EditTokenModal.jsx
@@ -66,9 +66,9 @@ const EditTokenModal = (props) => {
 
   const getInitValues = () => ({
     name: '',
-    remain_quota: 500000,
+    remain_quota: 0,
     expired_time: -1,
-    unlimited_quota: false,
+    unlimited_quota: true,
     model_limits_enabled: false,
     model_limits: [],
     allow_ips: '',


### PR DESCRIPTION
## 背景

在当前情况下，大多数用户创建 token 是默认 1$，大多数人在使用过程会很快遇到 token 使用完毕，我们大多数用户都应该会以自己额度为准，而且 key 大多数情况只有1个，因此改成默认创建无限额度 token 更合适。有需求的用户可以自行创建限额的 token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined token editor initial settings. The unlimited quota option is now enabled by default instead of using a preset limit, and the associated quota field resets appropriately. This provides a more flexible and intuitive starting configuration when editing or creating tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->