### PR TITLE
wan2.5自适应图文生视频功能

### DIFF
--- a/relay/channel/task/ali/adaptor.go
+++ b/relay/channel/task/ali/adaptor.go
@@ -122,7 +122,9 @@ func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
 }
 
 func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.TaskError) {
-	// 阿里通义万相支持 JSON 格式，不使用 multipart
+	if taskErr = relaycommon.ValidateMultipartDirect(c, info); taskErr != nil {
+		return
+	}
 	var taskReq relaycommon.TaskSubmitReq
 	if err := common.UnmarshalBodyReusable(c, &taskReq); err != nil {
 		return service.TaskErrorWrapper(err, "unmarshal_task_request_failed", http.StatusBadRequest)
@@ -140,7 +142,7 @@ func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycom
 	}
 	a.aliReq = aliReq
 	logger.LogJson(c, "ali video request body", aliReq)
-	return relaycommon.ValidateMultipartDirect(c, info)
+	return
 }
 
 func (a *TaskAdaptor) BuildRequestURL(info *relaycommon.RelayInfo) (string, error) {


### PR DESCRIPTION
1. wan2.5自适应图生视频和文生视频功能
```
wan2.5的图生视频模型为wan2.5-i2v-preview
文生视频模型为wan2.5-t2v-preview
正常用户需要为两种生成方式配置两种模型且不能混用
为调用方便增加自适配,可以只配wan2.5-i2v-preview, 
检测没有图片时, New会自动切为wan2.5-t2v-preview
```
2. 修复图生视频时,action显示为文生视频的问题 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation and error handling for video generation tasks.

* **Refactor**
  * Optimized internal request processing logic for enhanced efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->