### PR TITLE
support reasoning field for playground

### DIFF
--- a/web/src/hooks/playground/useApiRequest.jsx
+++ b/web/src/hooks/playground/useApiRequest.jsx
@@ -229,7 +229,7 @@ export const useApiRequest = (
         if (data.choices?.[0]) {
           const choice = data.choices[0];
           let content = choice.message?.content || '';
-          let reasoningContent = choice.message?.reasoning_content || '';
+          let reasoningContent = choice.message?.reasoning_content || choice.message?.reasoning || '';
 
           const processed = processThinkTags(content, reasoningContent);
 
@@ -332,6 +332,9 @@ export const useApiRequest = (
           if (delta) {
             if (delta.reasoning_content) {
               streamMessageUpdate(delta.reasoning_content, 'reasoning');
+            }
+            if (delta.reasoning) {
+              streamMessageUpdate(delta.reasoning, 'reasoning');
             }
             if (delta.content) {
               streamMessageUpdate(delta.content, 'content');


### PR DESCRIPTION
部分渠道（如 openrouter, ollama ）采用 reasoning 字段返回推理内容而非 reasoning_content，导致 playground 测试时看不到推理内容，将其增补到 playground 处理逻辑里

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of reasoning content from API responses with enhanced fallback mechanisms to handle additional response structures.

* **New Features**
  * Added real-time streaming support for reasoning data through event streaming to enable better response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->