### PR TITLE
support param override model change log

### DIFF
--- a/relay/claude_handler.go
+++ b/relay/claude_handler.go
@@ -123,7 +123,7 @@ func ClaudeHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 		// apply param override
 		if len(info.ParamOverride) > 0 {
-			jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+			jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 			if err != nil {
 				return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 			}

--- a/relay/common/override.go
+++ b/relay/common/override.go
@@ -30,6 +30,25 @@ type ParamOperation struct {
 	Logic      string               `json:"logic,omitempty"`      // AND, OR (默认OR)
 }
 
+func ApplyParamOverrideWithInfo(jsonData []byte, info *RelayInfo) ([]byte, error) {
+	// 记录覆盖前的模型名
+	beforeModel := gjson.GetBytes(jsonData, "model").String()
+	// 复用原有参数覆盖逻辑
+	result, err := ApplyParamOverride(jsonData, info.paramOverride)
+	if err != nil {
+        return nil, err
+    }
+	if info != nil {
+        // 覆盖后的模型名
+        afterModel := gjson.GetBytes(result, "model").String()
+        if afterModel != "" && afterModel != beforeModel {
+            // 视作一次“模型映射”（来源于 override）
+            info.IsModelMapped = true
+            info.UpstreamModelName = afterModel
+        }
+    }
+	return result, nil
+}
 func ApplyParamOverride(jsonData []byte, paramOverride map[string]interface{}) ([]byte, error) {
 	if len(paramOverride) == 0 {
 		return jsonData, nil

--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -144,7 +144,7 @@ func TextHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types
 
 		// apply param override
 		if len(info.ParamOverride) > 0 {
-			jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+			jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 			if err != nil {
 				return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 			}

--- a/relay/gemini_handler.go
+++ b/relay/gemini_handler.go
@@ -156,7 +156,7 @@ func GeminiHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 		// apply param override
 		if len(info.ParamOverride) > 0 {
-			jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+			jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 			if err != nil {
 				return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 			}

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -69,7 +69,7 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 
 			// apply param override
 			if len(info.ParamOverride) > 0 {
-				jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+				jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 				if err != nil {
 					return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 				}

--- a/relay/rerank_handler.go
+++ b/relay/rerank_handler.go
@@ -60,7 +60,7 @@ func RerankHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *typ
 
 		// apply param override
 		if len(info.ParamOverride) > 0 {
-			jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+			jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 			if err != nil {
 				return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 			}

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -66,7 +66,7 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 
 		// apply param override
 		if len(info.ParamOverride) > 0 {
-			jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride)
+			jsonData, err = relaycommon.ApplyParamOverrideWithInfo(jsonData, info)
 			if err != nil {
 				return types.NewError(err, types.ErrorCodeChannelParamOverrideInvalid, types.ErrOptionWithSkipRetry())
 			}


### PR DESCRIPTION
参数覆盖可以用来修改模型名称，起到类似模型重命名/映射的作用，如果有模型名称修改行为，日志也应该进行相应的标记

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified parameter override handling across API handlers with enhanced model mapping detection and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->