### PR TITLE
feat: support custom model prefix for AWS

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -20,6 +20,7 @@ type AwsKeyType string
 
 const (
 	AwsKeyTypeAKSK   AwsKeyType = "ak_sk" // 默认
+	AwsKeyTypeAKSKRegionPrefix AwsKeyType = "ak_sk_region_prefix"
 	AwsKeyTypeApiKey AwsKeyType = "api_key"
 )
 

--- a/relay/channel/aws/adaptor.go
+++ b/relay/channel/aws/adaptor.go
@@ -31,6 +31,7 @@ type Adaptor struct {
 	AwsModelId string
 	AwsReq     any
 	IsNova     bool
+	ModelPrefix string // 可配置的模型前缀，如 "global", "us", "eu", "apac", "jp" 等
 }
 
 func (a *Adaptor) ConvertGeminiRequest(*gin.Context, *relaycommon.RelayInfo, *dto.GeminiChatRequest) (any, error) {

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -1491,8 +1491,12 @@ const EditChannelModal = (props) => {
                           placeholder={t('请选择密钥格式')}
                           optionList={[
                             {
-                              label: 'AccessKey / SecretAccessKey',
+                              label: 'AccessKey / SecretAccessKey / Region',
                               value: 'ak_sk',
+                            },
+                            {
+                              label: 'AccessKey / SecretAccessKey / Region / Prefix',
+                              value: 'ak_sk_region_prefix',
                             },
                             { label: 'API Key', value: 'api_key' },
                           ]}
@@ -1580,7 +1584,10 @@ const EditChannelModal = (props) => {
                             inputs.type === 33
                               ? inputs.aws_key_type === 'api_key'
                                 ? t('请输入 API Key，一行一个，格式：APIKey|Region')
-                                : t(
+                                : inputs.aws_key_type === 'ak_sk_region_prefix'
+                                  ? t('请输入密钥，一行一个，格式：AccessKey|SecretAccessKey|Region|Prefix')
+                                  :
+                                  t(
                                     '请输入密钥，一行一个，格式：AccessKey|SecretAccessKey|Region',
                                   )
                               : t('请输入密钥，一行一个')
@@ -1782,7 +1789,9 @@ const EditChannelModal = (props) => {
                               inputs.type === 33
                                 ? inputs.aws_key_type === 'api_key'
                                   ? t('请输入 API Key，格式：APIKey|Region')
-                                  : t('按照如下格式输入：AccessKey|SecretAccessKey|Region')
+                                  : inputs.aws_key_type === 'ak_sk_region_prefix'
+                                    ? t('请输入密钥，一行一个，格式：AccessKey|SecretAccessKey|Region|Prefix')
+                                    : t('按照如下格式输入：AccessKey|SecretAccessKey|Region')
                                 : t(type2secretPrompt(inputs.type))
                             }
                             rules={


### PR DESCRIPTION
close #1928 ，支持用户自定义

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AWS authentication with regional model prefix configuration. Users can now specify AccessKey, SecretAccessKey, Region, and Model Prefix when configuring AWS channels, enabling region-specific model routing and customizable model prefix settings for enhanced AWS integration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->