### PR TITLE
fix: 未设置价格模型不会被拉取，除非设置自用模式

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -823,3 +823,16 @@ func FormatMatchingModelName(name string) string {
 	}
 	return name
 }
+
+// result: 倍率or价格， usePrice， exist
+func GetModelRatioOrPrice(model string) (float64, bool, bool) { // price or ratio
+	price, usePrice := GetModelPrice(model, false)
+	if usePrice {
+		return price, true, true
+	}
+	modelRatio, success, _ := GetModelRatio(model)
+	if success {
+		return modelRatio, false, true
+	}
+	return 37.5, false, false
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model filtering based on pricing and ratio configuration settings. Only models with properly configured pricing information are now available when this setting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->