### PR TITLE
增加wan2.5-i2i-preview图生图支持

### DIFF
--- a/relay/channel/ali/dto.go
+++ b/relay/channel/ali/dto.go
@@ -112,6 +112,19 @@ type AliImageInput struct {
 	Messages       []AliMessage `json:"messages,omitempty"`
 }
 
+type WanImageInput struct {
+	Prompt         string   `json:"prompt"`                    // 必需：文本提示词，描述生成图像中期望包含的元素和视觉特点
+	Images         []string `json:"images"`                    // 必需：图像URL数组，长度不超过2，支持HTTP/HTTPS URL或Base64编码
+	NegativePrompt string   `json:"negative_prompt,omitempty"` // 可选：反向提示词，描述不希望在画面中看到的内容
+}
+
+type WanImageParameters struct {
+	N         int     `json:"n,omitempty"`         // 生成图片数量，取值范围1-4，默认4
+	Watermark *bool   `json:"watermark,omitempty"` // 是否添加水印标识，默认false
+	Seed      int     `json:"seed,omitempty"`      // 随机数种子，取值范围[0, 2147483647]
+	Strength  float64 `json:"strength,omitempty"`  // 修改幅度 0.0-1.0，默认0.5（部分模型支持）
+}
+
 type AliRerankParameters struct {
 	TopN            *int  `json:"top_n,omitempty"`
 	ReturnDocuments *bool `json:"return_documents,omitempty"`

--- a/relay/channel/ali/image.go
+++ b/relay/channel/ali/image.go
@@ -58,11 +58,7 @@ func oaiImage2Ali(request dto.ImageRequest) (*AliImageRequest, error) {
 	return &imageRequest, nil
 }
 
-func oaiFormEdit2AliImageEdit(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (*AliImageRequest, error) {
-	var imageRequest AliImageRequest
-	imageRequest.Model = request.Model
-	imageRequest.ResponseFormat = request.ResponseFormat
-
+func getImageBase64sFromForm(c *gin.Context, fieldName string) ([]string, error) {
 	mf := c.Request.MultipartForm
 	if mf == nil {
 		if _, err := c.MultipartForm(); err != nil {
@@ -127,7 +123,18 @@ func oaiFormEdit2AliImageEdit(c *gin.Context, info *relaycommon.RelayInfo, reque
 		imageBase64s = append(imageBase64s, dataURL)
 		image.Close()
 	}
+	return imageBase64s, nil
+}
 
+func oaiFormEdit2AliImageEdit(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (*AliImageRequest, error) {
+	var imageRequest AliImageRequest
+	imageRequest.Model = request.Model
+	imageRequest.ResponseFormat = request.ResponseFormat
+
+	imageBase64s, err := getImageBase64sFromForm(c, "image")
+	if err != nil {
+		return nil, fmt.Errorf("get image base64s from form failed: %w", err)
+	}
 	//dto.MediaContent{}
 	mediaContents := make([]AliMediaContent, len(imageBase64s))
 	for i, b64 := range imageBase64s {

--- a/relay/channel/ali/image_wan.go
+++ b/relay/channel/ali/image_wan.go
@@ -1,0 +1,39 @@
+package ali
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+)
+
+func oaiFormEdit2WanxImageEdit(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (*AliImageRequest, error) {
+	var err error
+	var imageRequest AliImageRequest
+	imageRequest.Model = request.Model
+	imageRequest.ResponseFormat = request.ResponseFormat
+	wanInput := WanImageInput{
+		Prompt: request.Prompt,
+	}
+
+	if err := common.UnmarshalBodyReusable(c, &wanInput); err != nil {
+		return nil, err
+	}
+	if wanInput.Images, err = getImageBase64sFromForm(c, "image"); err != nil {
+		return nil, fmt.Errorf("get image base64s from form failed: %w", err)
+	}
+	wanParams := WanImageParameters{
+		N: int(request.N),
+	}
+	imageRequest.Input = wanInput
+	imageRequest.Parameters = wanParams
+	return &imageRequest, nil
+}
+
+func isWanModel(modelName string) bool {
+	return strings.Contains(modelName, "wan")
+}


### PR DESCRIPTION
官方文档:`https://help.aliyun.com/zh/model-studio/wan2-5-image-edit-api-reference?spm=a2c4g.11186623.help-menu-2400256.d_2_2_5.334275acmnKHP4&scm=20140722.H_2982258._.OR_help-T_cn~zh-V_1#4c9724d501qsq`
支持模型:`wan2.5-i2i-preview`
请求示例:
```
curl http://localhost:3000/v1/images/edits \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'image=@avatar.png' \
  --form 'prompt=转个圈' \
  --form 'model=wan2.5-i2i-preview'
```
<img width="2806" height="1292" alt="image" src="https://github.com/user-attachments/assets/f75579b4-211d-44da-be12-9d9677f978cf" />
<img width="2394" height="1046" alt="image" src="https://github.com/user-attachments/assets/e94fff0e-1ecc-4d9a-9833-1e5ccdefc97c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for WAN-based image editing models. Enhanced request handling now intelligently routes WAN model requests through specialized endpoints with async processing. New capabilities include configurable image synthesis parameters (watermark control, seed values, strength settings), negative prompt support, and optimized response handling tailored to WAN model workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->