### PR TITLE
fix: Set default to unsupported value for gpt-5 model series requests

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -306,10 +306,11 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 			request.Temperature = nil
 		}
 
+		// gpt-5系列模型适配 归零不再支持的参数
 		if strings.HasPrefix(info.UpstreamModelName, "gpt-5") {
-			if info.UpstreamModelName != "gpt-5-chat-latest" {
-				request.Temperature = nil
-			}
+			request.Temperature = nil
+			request.TopP = 0 // oai 的 top_p 默认值是 1.0，但是为了 omitempty 属性直接不传，这里显式设置为 0
+			request.LogProbs = false
 		}
 
 		// 转换模型推理力度后缀


### PR DESCRIPTION
GPT5、5.1 系列不再支持以下参数，因此直接强制重写到默认值或者零值不传
https://platform.openai.com/docs/guides/latest-model
<img width="709" height="411" alt="image" src="https://github.com/user-attachments/assets/d71f6711-8d08-4f59-a8ef-040b19a02c90" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced parameter compatibility for GPT-5 models to ensure reliable request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->