### PR TITLE
feat: support configuring the linuxdo endpoint via environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,9 @@
 # 设置 Dify 渠道是否输出工作流和节点信息到客户端
 # DIFY_DEBUG=true
 
+# LinuxDo相关配置
+LINUX_DO_TOKEN_ENDPOINT=https://connect.linux.do/oauth2/token
+LINUX_DO_USER_ENDPOINT=https://connect.linux.do/api/user
 
 # 节点类型
 # 如果是主节点则为master

--- a/controller/linuxdo.go
+++ b/controller/linuxdo.go
@@ -84,7 +84,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	}
 
 	// Get access token using Basic auth
-	tokenEndpoint := "https://connect.linux.do/oauth2/token"
+	tokenEndpoint := common.GetEnvOrDefaultString("LINUX_DO_TOKEN_ENDPOINT", "https://connect.linux.do/oauth2/token")
 	credentials := common.LinuxDOClientId + ":" + common.LinuxDOClientSecret
 	basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte(credentials))
 
@@ -129,7 +129,7 @@ func getLinuxdoUserInfoByCode(code string, c *gin.Context) (*LinuxdoUser, error)
 	}
 
 	// Get user info
-	userEndpoint := "https://connect.linux.do/api/user"
+	userEndpoint := common.GetEnvOrDefaultString("LINUX_DO_USER_ENDPOINT", "https://connect.linux.do/api/user")
 	req, err = http.NewRequest("GET", userEndpoint, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
#2197 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * LinuxDo OAuth endpoints are now configurable through environment variables, providing deployment flexibility while maintaining existing default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->