### PR TITLE
feat: Fill thoughtSignature only for Gemini/Vertex channels using OpenAI format

### DIFF
--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -177,7 +177,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		return nil, errors.New("request is nil")
 	}
 
-	geminiRequest, err := CovertGemini2OpenAI(c, *request, info)
+	geminiRequest, err := CovertOpenAI2Gemini(c, *request, info)
 	if err != nil {
 		return nil, err
 	}

--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -296,7 +296,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 		info.UpstreamModelName = claudeReq.Model
 		return vertexClaudeReq, nil
 	} else if a.RequestMode == RequestModeGemini {
-		geminiRequest, err := gemini.CovertGemini2OpenAI(c, *request, info)
+		geminiRequest, err := gemini.CovertOpenAI2Gemini(c, *request, info)
 		if err != nil {
 			return nil, err
 		}

--- a/setting/model_setting/gemini.go
+++ b/setting/model_setting/gemini.go
@@ -11,6 +11,7 @@ type GeminiSettings struct {
 	SupportedImagineModels                []string          `json:"supported_imagine_models"`
 	ThinkingAdapterEnabled                bool              `json:"thinking_adapter_enabled"`
 	ThinkingAdapterBudgetTokensPercentage float64           `json:"thinking_adapter_budget_tokens_percentage"`
+	FunctionCallThoughtSignatureEnabled   bool              `json:"function_call_thought_signature_enabled"`
 }
 
 // 默认配置
@@ -29,6 +30,7 @@ var defaultGeminiSettings = GeminiSettings{
 	},
 	ThinkingAdapterEnabled:                false,
 	ThinkingAdapterBudgetTokensPercentage: 0.6,
+	FunctionCallThoughtSignatureEnabled:   true,
 }
 
 // 全局实例

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "react-template",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -69,6 +69,8 @@
     "Gemini思考适配设置": "Gemini thinking adaptation settings",
     "Gemini版本设置": "Gemini version settings",
     "Gemini设置": "Gemini settings",
+    "启用FunctionCall思维签名填充": "Enable FunctionCall thoughtSignature fill",
+    "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature": "Fill thoughtSignature only for Gemini/Vertex channels using the OpenAI format",
     "GitHub": "GitHub",
     "GitHub Client ID": "GitHub Client ID",
     "GitHub Client Secret": "GitHub Client Secret",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -71,6 +71,8 @@
     "Gemini思考适配设置": "Paramètres d'adaptation de la pensée Gemini",
     "Gemini版本设置": "Paramètres de version Gemini",
     "Gemini设置": "Paramètres Gemini",
+    "启用FunctionCall思维签名填充": "Activer le remplissage de thoughtSignature pour FunctionCall",
+    "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature": "Remplit thoughtSignature uniquement pour les canaux Gemini/Vertex utilisant le format OpenAI",
     "GitHub": "GitHub",
     "GitHub Client ID": "ID client GitHub",
     "GitHub Client Secret": "Secret client GitHub",

--- a/web/src/i18n/locales/ja.json
+++ b/web/src/i18n/locales/ja.json
@@ -69,6 +69,8 @@
     "Gemini思考适配设置": "Gemini思考モード設定",
     "Gemini版本设置": "Geminiバージョン設定",
     "Gemini设置": "Gemini設定",
+    "启用FunctionCall思维签名填充": "FunctionCall用のthoughtSignature自動付与を有効化",
+    "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature": "OpenAI形式を利用するGemini/VertexチャネルにのみthoughtSignatureを付与します",
     "GitHub": "GitHub",
     "GitHub Client ID": "GitHub Client ID",
     "GitHub Client Secret": "GitHub Client Secret",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -73,6 +73,8 @@
     "Gemini思考适配设置": "Настройки адаптации мышления Gemini",
     "Gemini版本设置": "Настройки версии Gemini",
     "Gemini设置": "Настройки Gemini",
+    "启用FunctionCall思维签名填充": "Включить автозаполнение thoughtSignature для FunctionCall",
+    "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature": "Заполнять thoughtSignature только для каналов Gemini/Vertex, использующих формат OpenAI",
     "GitHub": "GitHub",
     "GitHub Client ID": "ID клиента GitHub",
     "GitHub Client Secret": "Секрет клиента GitHub",

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -67,6 +67,8 @@
     "Gemini思考适配设置": "Gemini思考适配设置",
     "Gemini版本设置": "Gemini版本设置",
     "Gemini设置": "Gemini设置",
+    "启用FunctionCall思维签名填充": "启用FunctionCall思维签名填充",
+    "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature": "仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature",
     "GitHub": "GitHub",
     "GitHub Client ID": "GitHub Client ID",
     "GitHub Client Secret": "GitHub Client Secret",

--- a/web/src/pages/Setting/Model/SettingGeminiModel.jsx
+++ b/web/src/pages/Setting/Model/SettingGeminiModel.jsx
@@ -39,19 +39,22 @@ const GEMINI_VERSION_EXAMPLE = {
   default: 'v1beta',
 };
 
+const DEFAULT_GEMINI_INPUTS = {
+  'gemini.safety_settings': '',
+  'gemini.version_settings': '',
+  'gemini.supported_imagine_models': '',
+  'gemini.thinking_adapter_enabled': false,
+  'gemini.thinking_adapter_budget_tokens_percentage': 0.6,
+  'gemini.function_call_thought_signature_enabled': true,
+};
+
 export default function SettingGeminiModel(props) {
   const { t } = useTranslation();
 
   const [loading, setLoading] = useState(false);
-  const [inputs, setInputs] = useState({
-    'gemini.safety_settings': '',
-    'gemini.version_settings': '',
-    'gemini.supported_imagine_models': '',
-    'gemini.thinking_adapter_enabled': false,
-    'gemini.thinking_adapter_budget_tokens_percentage': 0.6,
-  });
+  const [inputs, setInputs] = useState(DEFAULT_GEMINI_INPUTS);
   const refForm = useRef();
-  const [inputsRow, setInputsRow] = useState(inputs);
+  const [inputsRow, setInputsRow] = useState(DEFAULT_GEMINI_INPUTS);
 
   async function onSubmit() {
     await refForm.current
@@ -92,9 +95,9 @@ export default function SettingGeminiModel(props) {
   }
 
   useEffect(() => {
-    const currentInputs = {};
+    const currentInputs = { ...DEFAULT_GEMINI_INPUTS };
     for (let key in props.options) {
-      if (Object.keys(inputs).includes(key)) {
+      if (Object.prototype.hasOwnProperty.call(DEFAULT_GEMINI_INPUTS, key)) {
         currentInputs[key] = props.options[key];
       }
     }
@@ -162,6 +165,23 @@ export default function SettingGeminiModel(props) {
                   ]}
                   onChange={(value) =>
                     setInputs({ ...inputs, 'gemini.version_settings': value })
+                  }
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col span={16}>
+                <Form.Switch
+                  label={t('启用FunctionCall思维签名填充')}
+                  field={'gemini.function_call_thought_signature_enabled'}
+                  extraText={t(
+                    '仅为使用OpenAI格式的Gemini/Vertex渠道填充thoughtSignature',
+                  )}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      'gemini.function_call_thought_signature_enabled': value,
+                    })
                   }
                 />
               </Col>


### PR DESCRIPTION
fix #2255 
在Gemini设置中添加开关，默认开启，填充虚拟字段
<img width="1146" height="328" alt="image" src="https://github.com/user-attachments/assets/340fc04f-41e1-4be1-80b0-4bc065011114" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FunctionCall thoughtSignature auto-fill feature for Gemini and Vertex AI channels using OpenAI format
  * New toggle in Gemini settings to enable/disable this feature (enabled by default)

* **Documentation**
  * Added multilingual UI support for the new setting across English, French, Japanese, Russian, and Chinese interfaces

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->