### PR TITLE
fix: root page does not have analytic code

### DIFF
--- a/common/embed-file-system.go
+++ b/common/embed-file-system.go
@@ -25,7 +25,7 @@ func (e *embedFileSystem) Exists(prefix string, path string) bool {
 
 func (e *embedFileSystem) Open(name string) (http.File, error) {
 	if name == "/" {
-		// This will make sure the index page gose to NoRouter handler,
+		// This will make sure the index page goes to NoRouter handler,
 		// which will use the replaced index bytes with analytic codes.
 		return nil, os.ErrNotExist
 	}


### PR DESCRIPTION
当前主页（index.html）是直接从 embed fs 内读取的，这导致 umami 和 GA 的替换逻辑未替换主页。
这个 PR 修改了主页的读取逻辑，强制使用替换逻辑替换后的主页，保证统计代码生效。

The root page https://xxx.xxx/ is served directly from the embed file system, which always delivers the original version of the index file — one that hasn’t been patched with the analytics code.

This PR prevents the static file system from serving the root page directly, ensuring that the version with the analytics code is always used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal file system handling architecture for better code maintainability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->