### PR TITLE
feat: gemini thinking_level && snake params

### DIFF
--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -142,7 +142,38 @@ type GeminiThinkingConfig struct {
 	IncludeThoughts bool `json:"includeThoughts,omitempty"`
 	ThinkingBudget  *int `json:"thinkingBudget,omitempty"`
 	// TODO Conflict with thinkingbudget.
-	// ThinkingLevel   json.RawMessage `json:"thinkingLevel,omitempty"`
+	ThinkingLevel json.RawMessage `json:"thinkingLevel,omitempty"`
+}
+
+// UnmarshalJSON allows GeminiThinkingConfig to accept both snake_case and camelCase fields.
+func (c *GeminiThinkingConfig) UnmarshalJSON(data []byte) error {
+	type Alias GeminiThinkingConfig
+	var aux struct {
+		Alias
+		IncludeThoughtsSnake *bool           `json:"include_thoughts,omitempty"`
+		ThinkingBudgetSnake  *int            `json:"thinking_budget,omitempty"`
+		ThinkingLevelSnake   json.RawMessage `json:"thinking_level,omitempty"`
+	}
+
+	if err := common.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*c = GeminiThinkingConfig(aux.Alias)
+
+	if aux.IncludeThoughtsSnake != nil {
+		c.IncludeThoughts = *aux.IncludeThoughtsSnake
+	}
+
+	if aux.ThinkingBudgetSnake != nil {
+		c.ThinkingBudget = aux.ThinkingBudgetSnake
+	}
+
+	if len(aux.ThinkingLevelSnake) > 0 {
+		c.ThinkingLevel = aux.ThinkingLevelSnake
+	}
+
+	return nil
 }
 
 func (c *GeminiThinkingConfig) SetThinkingBudget(budget int) {


### PR DESCRIPTION
fix #2273 #2181 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini thinking configuration now accepts alternative field naming conventions (snake_case in addition to existing formats) for enhanced configuration flexibility.
  * Restored and exposed the thinking level field for Gemini thinking features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->