### PR TITLE
Fix size comparison in 32bit systems 修正无法编译为32位可执行文件的问题

### DIFF
--- a/relay/channel/volcengine/protocols.go
+++ b/relay/channel/volcengine/protocols.go
@@ -385,7 +385,7 @@ func (m *Message) writeSessionID(buf *bytes.Buffer) error {
 	}
 
 	size := len(m.SessionID)
-	if size > math.MaxUint32 {
+	if int64(size) > int64(math.MaxUint32) {
 		return fmt.Errorf("session ID size (%d) exceeds max(uint32)", size)
 	}
 
@@ -407,7 +407,7 @@ func (m *Message) writeErrorCode(buf *bytes.Buffer) error {
 
 func (m *Message) writePayload(buf *bytes.Buffer) error {
 	size := len(m.Payload)
-	if size > math.MaxUint32 {
+	if int64(size) > int64(math.MaxUint32) {
 		return fmt.Errorf("payload size (%d) exceeds max(uint32)", size)
 	}
 


### PR DESCRIPTION
in 32bit systems math.Maxunit32 will cause an error：math.MaxUint32 (untyped int constant 4294967295) overflows int
将new-api编译为32位可执行文件时，发现此处存在问题，会导致32位系统溢出。经检查，目前所有代码中仅此一处存在32位不支持问题，修改后便能正常编译为32位可执行文件并正常运行，因此建议修改以保持对armhf,x86等32位架构的支持。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved size validation handling to prevent potential overflow issues in edge cases, ensuring more robust data processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->