### PR TITLE
fix(aws): extract HTTP status code from AWS SDK errors

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -22,19 +22,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
 	bedrockruntimeTypes "github.com/aws/aws-sdk-go-v2/service/bedrockruntime/types"
-	"github.com/aws/smithy-go"
 	"github.com/aws/smithy-go/auth/bearer"
 )
 
 // getAwsErrorStatusCode extracts HTTP status code from AWS SDK error
 func getAwsErrorStatusCode(err error) int {
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		// Check for HTTP response error which contains status code
-		var httpErr interface{ HTTPStatusCode() int }
-		if errors.As(err, &httpErr) {
-			return httpErr.HTTPStatusCode()
-		}
+	// Check for HTTP response error which contains status code
+	var httpErr interface{ HTTPStatusCode() int }
+	if errors.As(err, &httpErr) {
+		return httpErr.HTTPStatusCode()
 	}
 	// Default to 500 if we can't determine the status code
 	return http.StatusInternalServerError


### PR DESCRIPTION
## PR 类型
- [x] Bug 修复  
- [ ] 新功能  
- [ ] 文档更新  
- [ ] 其他  

## PR 是否包含破坏性更新？
- [ ] 是  
- [x] 否  

## PR 描述

**问题：**  
AWS Bedrock 渠道在调用失败时，无论上游返回什么状态码（如 400 参数错误），都会被包装成 `500 Internal Server Error` 返回给客户端。

**修复：**  
- 新增 `getAwsErrorStatusCode` 函数，通过 smithy-go 的 `HTTPStatusCode()` 接口从 AWS SDK 错误中提取真实的 HTTP 状态码  
- 修改 `awsHandler`、`awsStreamHandler`、`handleNovaRequest` 三处错误处理逻辑，使用提取到的状态码替代硬编码的 500  

**影响范围：**  
仅影响 AWS Bedrock 渠道的错误响应状态码，不影响正常请求流程。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS error handling to derive and return more accurate HTTP status codes across model invocation, streaming responses, and proxied API requests. Replaces generic internal-server-error responses so clients receive more informative status codes for AWS-related failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->