### PR TITLE
fix: nano-banana not compatible imageSize

### DIFF
--- a/relay/channel/gemini/adaptor.go
+++ b/relay/channel/gemini/adaptor.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/QuantumNous/new-api/dto"
@@ -170,6 +171,12 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 		}
 
 		config := processSizeParameters(strings.TrimSpace(request.Size), request.Quality)
+
+		// 兼容 nano-banana 传quality[imageSize]会报错 An internal error has occurred. Please retry or report in https://developers.generativeai.google/guide/troubleshooting
+		if slices.Contains([]string{"nano-banana", "gemini-2.5-flash-image"}, info.UpstreamModelName) {
+			config.ImageSize = ""
+		}
+
 		googleGenerationConfig := map[string]interface{}{
 			"responseModalities": []string{"TEXT", "IMAGE"},
 			"imageConfig":        config,


### PR DESCRIPTION
nano-banana不支持gemini3新参数imageSize
请求会报错:`An internal error has occurred. Please retry or report in https://developers.generativeai.google/guide/troubleshooting`
但使用标准oai接口请求quality参数会转换为imageSize
需要删除该参数才请求正常
<img width="2792" height="882" alt="image" src="https://github.com/user-attachments/assets/1f18a1a8-55a5-4629-bde7-fb911e463841" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Enhanced image generation compatibility for specific Gemini models by optimizing request configuration handling to ensure proper processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->