### PR TITLE
新增Suno官方Api支持

### DIFF
--- a/controller/task.go
+++ b/controller/task.go
@@ -164,9 +164,9 @@ func updateSunoTaskAll(ctx context.Context, channelId int, taskIds []string, tas
 
 		task.Status = lo.If(model.TaskStatus(responseItem.Status) != "", model.TaskStatus(responseItem.Status)).Else(task.Status)
 		task.FailReason = lo.If(responseItem.FailReason != "", responseItem.FailReason).Else(task.FailReason)
-		task.SubmitTime = lo.If(responseItem.SubmitTime != 0, responseItem.SubmitTime/1000).Else(task.SubmitTime)
-		task.StartTime = lo.If(responseItem.StartTime != 0, responseItem.StartTime/1000).Else(task.StartTime)
-		task.FinishTime = lo.If(responseItem.FinishTime != 0, responseItem.FinishTime/1000).Else(task.FinishTime)
+		task.SubmitTime = lo.If(responseItem.SubmitTime != 0, responseItem.SubmitTime).Else(task.SubmitTime)
+		task.StartTime = lo.If(responseItem.StartTime != 0, responseItem.StartTime).Else(task.StartTime)
+		task.FinishTime = lo.If(responseItem.FinishTime != 0, responseItem.FinishTime).Else(task.FinishTime)
 		if responseItem.FailReason != "" || task.Status == model.TaskStatusFailure {
 			logger.LogInfo(ctx, task.TaskID+" 构建失败，"+task.FailReason)
 			task.Progress = "100%"

--- a/relay/channel/task/suno/suno_official.go
+++ b/relay/channel/task/suno/suno_official.go
@@ -67,7 +67,7 @@ func (r *OfficialSunoResponse) ToStandardResponse() dto.TaskResponse[[]dto.SunoD
 	var finishTime int64
 	var url string
 	if r.Data.Status == "SUCCESS" {
-		finishTime = time.Now().UnixMilli()
+		finishTime = time.Now().Unix()
 		if sunoData := r.Data.Response.SunoData; len(sunoData) > 0 {
 			url = sunoData[0].AudioURL
 		}
@@ -84,8 +84,8 @@ func (r *OfficialSunoResponse) ToStandardResponse() dto.TaskResponse[[]dto.SunoD
 		Status:     r.Data.Status,
 		FailReason: failReason,
 		Url:        url,
-		SubmitTime: r.Data.CreateTime,
-		StartTime:  r.Data.CreateTime,
+		SubmitTime: r.Data.CreateTime / 1000, // to seconds
+		StartTime:  r.Data.CreateTime / 1000,
 		FinishTime: finishTime,
 		Data:       dataBytes,
 	}


### PR DESCRIPTION
官方文档: https://docs.sunoapi.org/cn/suno-api/generate-music
支持歌曲生成, 任务查询
一. 歌曲生成
请求示例:
```
curl http://localhost:3000/suno/api/v1/generate \
  --request POST \
  --header 'Authorization: sk-i1jMTvWrTOvDeqNB***i' \
  --header 'Content-Type: application/json' \
  --data '{
  "audioWeight": 0.65,
  "customMode": true,
  "model": "V4_5ALL",
  "prompt": "儿童上学歌曲",
  "style": "Classical",
  "styleWeight": 0.65,
  "title": "hi",
  "vocalGender": "m",
  "weirdnessConstraint": 0.65
}'
```
返回示例:
```
{
  "code": 200,
  "msg": "success",
  "data": {
    "taskId": "74b53309b750d7774742621ec96b4437"
  }
}
```
<img width="2604" height="1054" alt="image" src="https://github.com/user-attachments/assets/f18ac750-7bb1-4b3a-a942-1676ca40548a" />
<img width="2460" height="1184" alt="image" src="https://github.com/user-attachments/assets/fbb1a2c8-4421-4a40-9e0a-54b4652cec59" />

查询示例: 和原来一致
<img width="2814" height="1278" alt="image" src="https://github.com/user-attachments/assets/d55e21ff-b877-45d3-916c-6818f31ad50e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Official Suno API support with a new /api/v1/generate music-generation endpoint
  * Music preview in task logs — click to preview generated music

* **Enhancements**
  * Tasks now include a URL for direct content access
  * Extended Suno request options: instrumental, model, callback URL, and custom mode
  * Improved parsing and error handling for official/non-official Suno responses
  * Better detection and routing for music actions and model resolution

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->