### PR TITLE
feat: update price display use current currency symbol

### DIFF
--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -1086,9 +1086,12 @@ function renderPriceSimpleCore({
   );
   const finalGroupRatio = effectiveGroupRatio;
 
+  const { symbol, rate } = getCurrencyConfig();
   if (modelPrice !== -1) {
-    return i18next.t('价格：${{price}} * {{ratioType}}：{{ratio}}', {
-      price: modelPrice,
+    const displayPrice = (modelPrice * rate).toFixed(6);
+    return i18next.t('价格：{{symbol}}{{price}} * {{ratioType}}：{{ratio}}', {
+      symbol: symbol,
+      price: displayPrice,
       ratioType: ratioLabel,
       ratio: finalGroupRatio,
     });


### PR DESCRIPTION
使用日志详情的货币单位使用设置的单位
比如当前设置为人民币
之前:
<img width="1234" height="418" alt="image" src="https://github.com/user-attachments/assets/920a88b1-13fa-4eb0-91e9-ebdd9ff4c96b" />

修复后:
<img width="1080" height="282" alt="image" src="https://github.com/user-attachments/assets/dae07e5d-843f-4ad5-ab02-56627633c561" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Price displays now correctly apply current exchange rates and show appropriate currency symbols based on your configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->