### PR TITLE
feat: jimeng_v30_pro only support one image

### DIFF
--- a/relay/channel/task/jimeng/adaptor.go
+++ b/relay/channel/task/jimeng/adaptor.go
@@ -421,6 +421,10 @@ func (a *TaskAdaptor) convertToRequestPayload(req *relaycommon.TaskSubmitReq) (*
 		}
 	}
 
+	// 图片文件URL，仅支持输入1张图片 参考: https://www.volcengine.com/docs/85621/1777001
+	if r.ReqKey == "jimeng_ti2v_v30_pro" && len(req.Images) > 1 {
+		return nil, fmt.Errorf("jimeng_v30_pro 不支持多图输入")
+	}
 	return &r, nil
 }
 


### PR DESCRIPTION
即梦3.0pro模型图片文件URL，仅支持输入1张图片 
否则报错:
` {"code": 50501, "message": "Internal RPC Error: :  <- [返回]算法返回码=10001,消息=RPC Internal Error 算法服务返回了内部异常: <- [返回]算法返回码=100402,消息=RPC Internal Error 算法服务返回了内部异常:target=sd://ic.cv.seed_t2v?cluster=com_seedance_caption&idc= retry final failed"}`
参考: https://www.volcengine.com/docs/85621/1777001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to prevent multiple images from being processed in specific scenarios, with improved error handling to provide appropriate feedback when invalid input is detected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->