### PR TITLE
fix: support Claude SSE format for ollama cloudflare xai cohere baidu tencent coze dify channels streaming responses

### DIFF
--- a/relay/channel/coze/relay-coze.go
+++ b/relay/channel/coze/relay-coze.go
@@ -172,6 +172,8 @@ func handleCozeEvent(c *gin.Context, info *relaycommon.RelayInfo, event string, 
 		if jsonData, err := common.Marshal(stopResponse); err == nil {
 			*lastStreamData = string(jsonData)
 			_ = openai.HandleStreamFormat(c, info, *lastStreamData, false, false)
+		} else {
+			common.SysLog("error marshalling coze stop response: " + err.Error())
 		}
 
 	case "conversation.message.delta":
@@ -208,6 +210,8 @@ func handleCozeEvent(c *gin.Context, info *relaycommon.RelayInfo, event string, 
 		if jsonData, err := common.Marshal(openaiResponse); err == nil {
 			*lastStreamData = string(jsonData)
 			_ = openai.HandleStreamFormat(c, info, *lastStreamData, false, false)
+		} else {
+			common.SysLog("error marshalling coze stream response: " + err.Error())
 		}
 
 	case "error":

--- a/relay/channel/dify/relay-dify.go
+++ b/relay/channel/dify/relay-dify.go
@@ -153,9 +153,11 @@ func requestOpenAI2Dify(c *gin.Context, info *relaycommon.RelayInfo, request dto
 					media := mediaContent.GetImageMedia()
 					var file *DifyFile
 					if media.IsRemoteImage() {
-						file.Type = media.MimeType
-						file.TransferMode = "remote_url"
-						file.URL = media.Url
+						file = &DifyFile{
+							Type:         media.MimeType,
+							TransferMode: "remote_url",
+							URL:          media.Url,
+						}
 					} else {
 						file = uploadDifyFile(c, info, difyReq.User, mediaContent)
 					}

--- a/relay/channel/tencent/relay-tencent.go
+++ b/relay/channel/tencent/relay-tencent.go
@@ -94,7 +94,7 @@ func streamResponseTencent2OpenAI(TencentResponse *TencentChatResponse) *dto.Cha
 func tencentStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	var responseText string
 	var lastStreamData string
-	var responseId string
+	responseId := helper.GetResponseID(c)
 	var created int64
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -117,11 +117,11 @@ func tencentStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *htt
 		}
 
 		response := streamResponseTencent2OpenAI(&tencentResponse)
+		response.Id = responseId
 		if len(response.Choices) != 0 {
 			responseText += response.Choices[0].Delta.GetContentString()
 		}
 
-		responseId = response.Id
 		created = response.Created
 
 		if jsonData, err := common.Marshal(response); err == nil {


### PR DESCRIPTION
## Summary
Fix multiple channels to properly output Claude SSE format when request uses Claude format (`/v1/messages`).

**Affected channels:**
- ollama
- cloudflare  
- xai
- cohere
- baidu
- tencent
- coze
- dify

Each channel now uses `openai.HandleStreamFormat()` and `openai.HandleFinalResponse()` which properly switch output format based on `info.RelayFormat`.

## Problem
When using channels with model alias and sending Claude format requests (`/v1/messages`), the streaming response was incorrectly using OpenAI SSE format:
```
data: {"id":"...","object":"chat.completion.chunk",...}
```

Instead of the expected Claude SSE format:
```
event: message_start
data: {"type":"message_start",...}

event: content_block_delta
data: {"type":"content_block_delta",...}
```

## Root Cause
The stream handlers in these channels were using `helper.ObjectData()` or `helper.StringData()` directly without checking `info.RelayFormat`, which always outputs OpenAI format.

## Solution
Use existing `openai.HandleStreamFormat()` and `openai.HandleFinalResponse()` functions which already implement proper format switching based on `info.RelayFormat` (supports OpenAI, Claude, and Gemini formats).

## Commits
Each channel has an independent commit for isolation:
1. `fix(ollama)`: support Claude SSE format for streaming responses
2. `fix(cloudflare)`: support Claude SSE format for streaming responses
3. `fix(xai)`: support Claude SSE format for streaming responses
4. `fix(cohere)`: support Claude SSE format for streaming responses
5. `fix(baidu)`: support Claude SSE format for streaming responses
6. `fix(tencent)`: support Claude SSE format for streaming responses
7. `fix(coze)`: support Claude SSE format for streaming responses
8. `fix(dify)`: support Claude SSE format for streaming responses

## Test plan
- [x] Test ollama channel with Claude format request (`/v1/messages`)
- [x] Test other channels with Claude format request
- [x] Verify response uses correct Claude SSE format with proper event types

#1439
#1618
#1854 
#2301 
#2378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streaming across multiple relay channels now funnels chunked data through a unified stream-format handler and central finalization path so streamed output is consistently serialized and emitted.

* **Bug Fixes**
  * Eliminated duplicate end/usage signals and consolidated final payload emission to ensure a single, correct final response is delivered for streamed conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->