### PR TITLE
fix: try fix retry /v1/audio/transcriptions

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -66,6 +66,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 	requestId := c.GetString(common.RequestIdKey)
 	group := common.GetContextKeyString(c, constant.ContextKeyUsingGroup)
 	originalModel := common.GetContextKeyString(c, constant.ContextKeyOriginalModel)
+	originalContentType := c.Request.Header.Get("Content-Type")
 
 	var (
 		newAPIError *types.NewAPIError
@@ -167,6 +168,9 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 		addUsedChannel(c, channel.Id)
 		requestBody, _ := common.GetRequestBody(c)
+		if relayFormat == types.RelayFormatOpenAIAudio && strings.Contains(originalContentType, "multipart/form-data") {
+			c.Request.Header.Set("Content-Type", originalContentType)
+		}
 		c.Request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 
 		switch relayFormat {


### PR DESCRIPTION
fix #2403 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed Content-Type header handling during audio request retries for OpenAI integrations. The system now correctly preserves multipart form-data formatting when rebuilding requests, ensuring audio content is properly processed during retry operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->