### PR TITLE
fix: 支持aws 通过全局参数透传或者渠道参数透传来 调用

### DIFF
--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -157,15 +157,15 @@ func buildAwsRequestBody(c *gin.Context, info *relaycommon.RelayInfo, awsClaudeR
 	if model_setting.GetGlobalSettings().PassThroughRequestEnabled || info.ChannelSetting.PassThroughBodyEnabled {
 		body, err := common.GetRequestBody(c)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "get request body for pass-through fail")
 		}
 		var data map[string]interface{}
-		if err := json.Unmarshal(body, &data); err != nil {
-			return nil, err
+		if err := common.Unmarshal(body, &data); err != nil {
+			return nil, errors.Wrap(err, "pass-through unmarshal request body fail")
 		}
 		delete(data, "model")
 		delete(data, "stream")
-		return json.Marshal(data)
+		return common.Marshal(data)
 	}
 	return common.Marshal(awsClaudeReq)
 }


### PR DESCRIPTION
更新的原因：很多下游调用aws claude时候，会传递一些不在aws支持的参数，希望能够识别出错误信息，所以增加了该功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passthrough mode support for AWS relay requests when enabled globally or per channel, allowing original request fields to be forwarded.

* **Refactor**
  * Improved preparation of AWS request payloads for clearer logic and more reliable passthrough behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->