### PR TITLE
fix: move oidc discovery url fetching to backend proxy

### DIFF
--- a/controller/oidc.go
+++ b/controller/oidc.go
@@ -249,14 +249,14 @@ func GetOIDCDiscovery(c *gin.Context) {
 	// SSRF防护 - 验证URL安全性
 	err := common.ValidateURLWithFetchSetting(
 		wellKnownURL,
-		true,
-		true,
-		false,
-		false,
+		fetchSetting.EnableSSRFProtection,
+		fetchSetting.AllowPrivateIp,
+		fetchSetting.DomainFilterMode,
+		fetchSetting.IpFilterMode,
 		fetchSetting.DomainList,
 		fetchSetting.IpList,
 		fetchSetting.AllowedPorts,
-		true,
+		fetchSetting.ApplyIPFilterForDomain,
 	)
 	if err != nil {
 		c.JSON(http.StatusForbidden, gin.H{


### PR DESCRIPTION
fix #994 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-protected, rate-limited backend OIDC discovery endpoint for fetching OpenID Connect metadata.
  * UI: New "Use backend proxy" checkbox in OIDC settings to choose backend- or frontend-based discovery (helps avoid CORS).
  * Settings now persist the proxy choice and automatically populate OIDC authorization, token, and user-info endpoints from discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->