### PR TITLE
fix: 支持传入system_instruction和systemInstruction两种风格系统提示词参数名

### DIFF
--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -22,6 +22,27 @@ type GeminiChatRequest struct {
 	CachedContent      string                     `json:"cachedContent,omitempty"`
 }
 
+// UnmarshalJSON allows GeminiChatRequest to accept both snake_case and camelCase fields.
+func (r *GeminiChatRequest) UnmarshalJSON(data []byte) error {
+	type Alias GeminiChatRequest
+	var aux struct {
+		Alias
+		SystemInstructionSnake *GeminiChatContent `json:"system_instruction,omitempty"`
+	}
+
+	if err := common.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	*r = GeminiChatRequest(aux.Alias)
+
+	if aux.SystemInstructionSnake != nil {
+		r.SystemInstructions = aux.SystemInstructionSnake
+	}
+
+	return nil
+}
+
 type ToolConfig struct {
 	FunctionCallingConfig *FunctionCallingConfig `json:"functionCallingConfig,omitempty"`
 	RetrievalConfig       *RetrievalConfig       `json:"retrievalConfig,omitempty"`


### PR DESCRIPTION
fix #2448
https://github.com/googleapis/go-genai/blob/a7c0ed8b1fcade06ffcc62a91344e36e56d17f37/types.go#L2075
Golang SDK支持传入systemInstruction，Python SDK支持传入system_instruction，兼容两种方式，最终以systemInstruction作为参数发送

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API now accepts system configuration parameters in multiple naming formats for improved compatibility with diverse integration styles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->