### PR TITLE
Feature: Support global token search for admins via scope parameter

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -28,9 +28,21 @@ func GetAllTokens(c *gin.Context) {
 
 func SearchTokens(c *gin.Context) {
 	userId := c.GetInt("id")
+	role := c.GetInt("role")
+
 	keyword := c.Query("keyword")
 	token := c.Query("token")
-	tokens, err := model.SearchUserTokens(userId, keyword, token)
+	scope := c.Query("scope")
+
+	var tokens []*model.Token
+	var err error
+
+	if scope == "global" && role >= common.RoleAdminUser {
+		tokens, err = model.SearchAllTokens(keyword, token)
+	} else {
+		tokens, err = model.SearchUserTokens(userId, keyword, token)
+	}
+
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/model/token.go
+++ b/model/token.go
@@ -71,6 +71,14 @@ func SearchUserTokens(userId int, keyword string, token string) (tokens []*Token
 	return tokens, err
 }
 
+func SearchAllTokens(keyword string, token string) (tokens []*Token, err error) {
+	if token != "" {
+		token = strings.Trim(token, "sk-")
+	}
+	err = DB.Where("name LIKE ?", "%"+keyword+"%").Where("`key` LIKE ?", "%"+token+"%").Find(&tokens).Error
+	return tokens, err
+}
+
 func ValidateUserToken(key string) (token *Token, err error) {
 	if key == "" {
 		return nil, errors.New("未提供令牌")


### PR DESCRIPTION
### 📝 Description / 描述

**English:**
Currently, the `GET /api/token/search` endpoint strictly filters results by the current user's ID. This prevents admins from searching for tokens belonging to other users.
This PR introduces an optional `scope` parameter:
- `scope=global`: If provided **AND** the user is an admin, the search ignores the `user_id` filter (global search).
- Default: If omitted or the user is not an admin, it falls back to the original behavior (search own tokens only).

**中文:**
目前 `GET /api/token/search` 接口强制过滤当前用户 ID，导致管理员无法查询其他用户的令牌。
本 PR 引入了一个可选的 `scope` 参数：
- `scope=global`: 当提供此参数**且**用户为管理员时，查询将忽略 `user_id` 限制（全局搜索）。
- 默认行为: 如果不传此参数或用户非管理员，则保持原有行为（仅搜索自己的令牌）。

### 🧪 How Has This Been Tested? / 测试方法

I have tested this locally using `curl`. / 我已在本地使用 `curl` 进行了测试。

1.  **Default Behavior (默认行为)**:
    `GET /api/token/search?token=sk-others`
    ✅ Result: Empty (Strictly filters by own ID). / 结果为空（严格过滤 ID）。

2.  **Admin Global Search (管理员全局搜索)**:
    `GET /api/token/search?token=sk-others&scope=global`
    ✅ Result: Successfully returns token details of another user. / 成功返回其他用户的令牌详情。

3.  **Permission Check (权限检查)**:
    Tested with a normal user account using `scope=global`.
    ✅ Result: Empty (Fallback to own tokens), security ensured. / 结果为空（回退到仅查自己），确保安全。

### ☑️ Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Token search now includes role-based access control; administrators can search all tokens globally via a scope parameter, while standard users search only personal tokens
  * Enhanced token filtering capabilities by keyword and key

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->