### PR TITLE
feat: implement admin global token search with scope control

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -11,6 +11,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const DefaultSearchLimit = 100
+
 func GetAllTokens(c *gin.Context) {
 	userId := c.GetInt("id")
 	pageInfo := common.GetPageQuery(c)
@@ -28,9 +30,23 @@ func GetAllTokens(c *gin.Context) {
 
 func SearchTokens(c *gin.Context) {
 	userId := c.GetInt("id")
+	role := c.GetInt("role")
+
 	keyword := c.Query("keyword")
 	token := c.Query("token")
-	tokens, err := model.SearchUserTokens(userId, keyword, token)
+	scope := c.Query("scope")
+
+	limit := DefaultSearchLimit
+
+	var tokens []*model.Token
+	var err error
+
+	if scope == "global" && role >= common.RoleAdminUser {
+		tokens, err = model.SearchAllTokens(keyword, token, limit)
+	} else {
+		tokens, err = model.SearchUserTokens(userId, keyword, token)
+	}
+
 	if err != nil {
 		common.ApiError(c, err)
 		return

--- a/model/token.go
+++ b/model/token.go
@@ -71,6 +71,25 @@ func SearchUserTokens(userId int, keyword string, token string) (tokens []*Token
 	return tokens, err
 }
 
+func SearchAllTokens(keyword string, token string, limit int) (tokens []*Token, err error) {
+	if token != "" {
+		token = strings.Trim(token, "sk-")
+	}
+
+	query := DB.Where("name LIKE ?", "%"+keyword+"%").Where(commonKeyCol+" LIKE ?", "%"+token+"%")
+
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+
+	err = query.Find(&tokens).Error
+
+	for _, t := range tokens {
+		t.Clean()
+	}
+
+	return tokens, err
+}
 func ValidateUserToken(key string) (token *Token, err error) {
 	if key == "" {
 		return nil, errors.New("未提供令牌")


### PR DESCRIPTION
### 📝 Description / 描述

**English:**

This PR introduces an optional `scope` parameter to the `GET /api/token/search` endpoint, allowing admins to search for tokens globally.

**Key Changes & Improvements:**

1. **Global Search Scope:** - `scope=global`: If provided **AND** the user is an admin, the search ignores the `user_id` filter.
* Default behavior remains unchanged (users can only search their own tokens).


2. **Security & Privacy (New):** - The returned token keys are now **masked** using the `Clean()` method. This prevents sensitive credentials from being exposed in the admin search results, while still providing necessary details (ID, user_id, status, quota).
3. **Performance Safety (New):**
* Implemented a hard limit (defined as `SearchMaxLimit = 100`) for search results to prevent OOM issues or database overload when matching a large number of tokens.


4. **Compatibility:**
* Used `commonKeyCol` instead of hardcoded strings to ensure database compatibility.



**中文:**

本 PR 为 `GET /api/token/search` 接口引入了 `scope` 参数，允许管理员进行全局令牌搜索。

**主要改动与改进：**

1. **全局搜索范围：**
* `scope=global`: 当提供此参数**且**用户为管理员时，查询将忽略 `user_id` 限制（全局搜索）。
* 默认行为保持不变（普通用户仅能搜索自己的令牌）。


2. **安全与隐私（新增）：**
* 返回的令牌 Key 现在会经过 `Clean()` 方法进行**脱敏处理**。这确保了在管理员查询时不会泄露完整的敏感凭据，同时保留必要的元数据（如 ID, 用户ID, 状态, 额度等）。


3. **性能保护（新增）：**
* 增加了最大结果数量限制（`SearchMaxLimit = 100`），防止因匹配过多数据导致内存溢出 (OOM) 或数据库过载。


4. **兼容性：**
* 使用 `commonKeyCol` 替代硬编码字符串，确保数据库兼容性。



### 🧪 How Has This Been Tested? / 测试方法

I have tested this locally using `curl`. / 我已在本地使用 `curl` 进行了测试。

1. **Default Behavior (默认行为)**:
`GET /api/token/search?token=sk-others`
✅ Result: Empty (Strictly filters by own ID). / 结果为空（严格过滤 ID）。
2. **Admin Global Search (管理员全局搜索)**:
`GET /api/token/search?token=sk-others&scope=global`
✅ Result: Successfully returns token details of another user. / 成功返回其他用户的令牌详情。
✅ **Security Check**: The `key` field in the response is masked. / **安全检查**：返回结果中的 `key` 字段已脱敏。
3. **Limit Check (限制检查)**:
✅ Result: Even with a broad search keyword, the result count is capped at 100 to ensure stability. / 即使搜索条件很宽泛，返回结果也限制在 100 条以内，确保稳定性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token search functionality enhanced with role-based scoping
  * Administrators can now perform global token searches across all users
  * Standard users can search their own tokens only
  * Search results limited to 100 tokens by default for improved performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->