### PR TITLE
feat: 为 Vertex 渠道添加 Claude 请求转换开关

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -25,7 +25,8 @@ const (
 
 type ChannelOtherSettings struct {
 	AzureResponsesVersion string        `json:"azure_responses_version,omitempty"`
-	VertexKeyType         VertexKeyType `json:"vertex_key_type,omitempty"` // "json" or "api_key"
+	VertexKeyType         VertexKeyType `json:"vertex_key_type,omitempty"`         // "json" or "api_key"
+	VertexClaudeToGemini  bool          `json:"vertex_claude_to_gemini,omitempty"` // Claude 请求转换为 Gemini 格式
 	OpenRouterEnterprise  *bool         `json:"openrouter_enterprise,omitempty"`
 	AllowServiceTier      bool          `json:"allow_service_tier,omitempty"`      // 是否允许 service_tier 透传（默认过滤以避免额外计费）
 	DisableStore          bool          `json:"disable_store,omitempty"`           // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）


### PR DESCRIPTION
添加可配置开关以控制 Vertex 渠道中 Claude 模型请求的处理方式：
- 开关关闭（默认）：使用原生 Anthropic 端点和格式
- 开关开启：将 Claude 请求转换为 Gemini 格式并发送到 Google 端点

后端修改：
- dto/channel_settings.go: 添加 VertexClaudeToGemini 字段
- relay/channel/vertex/adaptor.go:
  - Init 方法根据开关设置 RequestMode
  - ConvertClaudeRequest 方法在开关开启时调用 Gemini 转换

前端修改：
- EditChannelModal.jsx: 添加开关 UI 控件和相关数据处理逻辑

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration toggle for Vertex channels to enable Claude-to-Gemini conversion, providing users with control over Claude request processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->