### PR TITLE
fix: 修复 Anthropic 渠道缓存计费错误

### DIFF
--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -300,14 +300,20 @@ func postConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usage 
 	if !relayInfo.PriceData.UsePrice {
 		baseTokens := dPromptTokens
 		// 减去 cached tokens
+		// Anthropic API 的 input_tokens 已经不包含缓存 tokens，不需要减去
+		// OpenAI/OpenRouter 等 API 的 prompt_tokens 包含缓存 tokens，需要减去
 		var cachedTokensWithRatio decimal.Decimal
 		if !dCacheTokens.IsZero() {
-			baseTokens = baseTokens.Sub(dCacheTokens)
+			if relayInfo.ChannelType != constant.ChannelTypeAnthropic {
+				baseTokens = baseTokens.Sub(dCacheTokens)
+			}
 			cachedTokensWithRatio = dCacheTokens.Mul(dCacheRatio)
 		}
 		var dCachedCreationTokensWithRatio decimal.Decimal
 		if !dCachedCreationTokens.IsZero() {
-			baseTokens = baseTokens.Sub(dCachedCreationTokens)
+			if relayInfo.ChannelType != constant.ChannelTypeAnthropic {
+				baseTokens = baseTokens.Sub(dCachedCreationTokens)
+			}
 			dCachedCreationTokensWithRatio = dCachedCreationTokens.Mul(dCachedCreationRatio)
 		}
 


### PR DESCRIPTION
fix #2420 
## 问题描述

当使用 Anthropic 渠道通过 `/v1/chat/completions` 端点调用且启用缓存功能时， 计费逻辑错误地减去了缓存 tokens，导致严重的计费错误。
<img width="1167" height="267" alt="image" src="https://github.com/user-attachments/assets/176cec06-63c5-40a3-b174-0501cae20689" />


## 根本原因

不同 API 的 `prompt_tokens` 定义不同：

- **Anthropic API**: `input_tokens` 字段已经是纯输入 tokens（不包含缓存）
- **OpenAI API**: `prompt_tokens` 字段包含所有 tokens（包含缓存）
- **OpenRouter API**: `prompt_tokens` 字段包含所有 tokens（包含缓存）

当前 `postConsumeQuota` 函数对所有渠道都减去缓存 tokens，这对 Anthropic 渠道是错误的，因为其 `input_tokens` 已经不包含缓存。

## 修复方案

在 `relay/compatible_handler.go` 的 `postConsumeQuota` 函数中，添加渠道类型判断：

```go
if relayInfo.ChannelType != constant.ChannelTypeAnthropic {
    baseTokens = baseTokens.Sub(dCacheTokens)
}
```

只对非 Anthropic 渠道减去缓存 tokens。

## 影响分析

### ✅ 不受影响的场景

1. **无缓存调用**（所有渠道）
   - cache_tokens = 0
   - 减去 0 = 不减去
   - 结果：完全一致

2. **OpenAI/OpenRouter 渠道 + 缓存**
   - 继续减去缓存（因为 ChannelType != Anthropic）
   - 结果：完全一致

3. **Anthropic 渠道 + /v1/messages 端点**
   - 使用 PostClaudeConsumeQuota（不修改）
   - 结果：完全不受影响

### ✅ 修复的场景

4. **Anthropic 渠道 + /v1/chat/completions + 缓存**
   - 修复前：错误地减去缓存，导致出现负数
   - 修复后：不减去缓存，计费正确



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache token deduction handling for Anthropic-channel requests when pricing calculations are disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->