### PR TITLE
🐛 fix: Gemini FunctionResponse parts inlineData parsing

### DIFF
--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -219,7 +219,7 @@ type GeminiFunctionResponse struct {
 	Response     map[string]interface{} `json:"response"`
 	WillContinue json.RawMessage        `json:"willContinue,omitempty"`
 	Scheduling   json.RawMessage        `json:"scheduling,omitempty"`
-	Parts        json.RawMessage        `json:"parts,omitempty"`
+	Parts        []GeminiPart           `json:"parts,omitempty"`
 	ID           json.RawMessage        `json:"id,omitempty"`
 }
 


### PR DESCRIPTION
Gemini native FunctionResponse may include media in functionResponse.parts. Previously, the Parts field was defined as json.RawMessage, preventing GeminiPart custom unmarshal logic from normalizing snake_case keys (inline_data/mime_type) to the camelCase format (inlineData/mimeType) required by Gemini REST.

This change updates GeminiFunctionResponse.Parts to []GeminiPart so nested media parts are correctly parsed and forwarded, enabling the model to read inline data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the structure of AI response handling to enable more robust validation and processing of incoming data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->