### PR TITLE
feat: add kling video o1 support

### DIFF
--- a/relay/common/relay_utils.go
+++ b/relay/common/relay_utils.go
@@ -210,7 +210,9 @@ func ValidateBasicTaskRequest(c *gin.Context, info *RelayInfo, action string) *d
 		if err != nil {
 			return createTaskError(err, "invalid_multipart_form", http.StatusBadRequest, true)
 		}
-	} else if err := common.UnmarshalBodyReusable(c, &req); err != nil {
+	}
+	// 为了metadata字段的兼容性，统一UnmarshalBodyReusable
+	if err := common.UnmarshalBodyReusable(c, &req); err != nil {
 		return createTaskError(err, "invalid_request", http.StatusBadRequest, true)
 	}
 


### PR DESCRIPTION
新增可灵 kling-v2-6和kling-video-o1视频模型支持
请求示例:
```
curl http://localhost:30001/v1/videos \
  --request POST \
  --header 'Content-Type: multipart/form-data' \
  --form 'prompt=转个圈' \
  --form 'input_reference=@logo2.png' \
  --form 'model=kling-video-o1' \
  --form 'metadata={"image_list":[
  {
    "image_url":"https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimages_1.png",
    "type":"first_frame"
  },
  {
    "image_url":"https://ark-project.tos-cn-beijing.volces.com/doc_image/seedream4_imagesToimages_1.png",
    "type":"end_frame"
  }
]}' \
  --form 'image=https://h2.inkwai.com/bs2/upload-ylab-stunt/se/ai_portal_queue_mmu_image_upscale_aiweb/3214b798-e1b4-4b00-b7af-72b5b0417420_raw_image_0.jpg'
```
<img width="2536" height="1138" alt="image" src="https://github.com/user-attachments/assets/8ad99e16-47dc-4dac-8aba-79e6a6d25c02" />

<img width="2464" height="1212" alt="image" src="https://github.com/user-attachments/assets/e2f71a30-cdc3-4f6b-a622-f3c9b5357327" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Omni-Video model variant with enhanced capability to process image, element, and video lists in video generation requests.

* **Improvements**
  * Improved request body handling for video task processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->