### PR TITLE
修复claudeResponse流式请求空指针Panic

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -483,9 +483,11 @@ func StreamResponseClaude2OpenAI(reqMode int, claudeResponse *dto.ClaudeResponse
 				}
 			}
 		} else if claudeResponse.Type == "message_delta" {
-			finishReason := stopReasonClaude2OpenAI(*claudeResponse.Delta.StopReason)
-			if finishReason != "null" {
-				choice.FinishReason = &finishReason
+			if claudeResponse.Delta != nil && claudeResponse.Delta.StopReason != nil {
+				finishReason := stopReasonClaude2OpenAI(*claudeResponse.Delta.StopReason)
+				if finishReason != "null" {
+					choice.FinishReason = &finishReason
+				}
 			}
 			//claudeUsage = &claudeResponse.Usage
 		} else if claudeResponse.Type == "message_stop" {


### PR DESCRIPTION
claude在流式返回某些情况下StopReason为nil, 
该错误由于没有recover, 所以会导致panic后整个程序完全退出
如果使用docker守护则表现为docker重启, 
需要尽快修复!

**panic日志:**
new-api-1  | panic: runtime error: invalid memory address or nil pointer dereference
new-api-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x11411f0]
new-api-1  | 
new-api-1  | goroutine 1616088 [running]:
new-api-1  | github.com/QuantumNous/new-api/relay/channel/claude.StreamResponseClaude2OpenAI(0x2, 0xc0009020b0)
new-api-1  |      /build/relay/channel/claude/relay-claude.go:486 +0x750
new-api-1  | github.com/QuantumNous/new-api/relay/channel/claude.HandleStreamResponseData(0xc00029ab00, 0xc001fd6608, 0xc001d335c0, {0xc0002960d6, 0xc0}, 0x2)
new-api-1  |      /build/relay/channel/claude/relay-claude.go:659 +0x26e
new-api-1  | github.com/QuantumNous/new-api/relay/channel/claude.ClaudeStreamHandler.func1({0xc0002960d6?, 0xc001a14080?})
new-api-1  |      /build/relay/channel/claude/relay-claude.go:713 +0x3d
new-api-1  | github.com/QuantumNous/new-api/relay/helper.StreamScannerHandler.func4.2()
new-api-1  |      /build/relay/helper/stream_scanner.go:228 +0xaa
new-api-1  | created by github.com/QuantumNous/new-api/relay/helper.StreamScannerHandler.func4 in goroutine 1583058
new-api-1  |      /build/relay/helper/stream_scanner.go:225 +0x426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved system reliability by adding proper validation checks in response handling to prevent potential crashes when processing certain data edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->