### PR TITLE
fix(model): increase TaskID varchar length to 250 for Vertex AI Veo 3.1

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -43,7 +43,7 @@ type Task struct {
 	ID         int64                 `json:"id" gorm:"primary_key;AUTO_INCREMENT"`
 	CreatedAt  int64                 `json:"created_at" gorm:"index"`
 	UpdatedAt  int64                 `json:"updated_at"`
-	TaskID     string                `json:"task_id" gorm:"type:varchar(191);index"` // 第三方id，不一定有/ song id\ Task id
+	TaskID     string                `json:"task_id" gorm:"type:varchar(250);index"` // 第三方id，不一定有/ song id\ Task id
 	Platform   constant.TaskPlatform `json:"platform" gorm:"type:varchar(30);index"` // 平台
 	UserId     int                   `json:"user_id" gorm:"index"`
 	Group      string                `json:"group" gorm:"type:varchar(50)"` // 修正计费用


### PR DESCRIPTION
Vertex AI Veo 3.1 returns task_id values that can exceed 191 characters. Increase the column length to 250 to accommodate these longer IDs.

Fixes #2417 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database infrastructure to support larger task identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->