### PR TITLE
fix(i18n): disable namespace separator to fix URL display in translations

### DIFF
--- a/web/src/i18n/i18n.js
+++ b/web/src/i18n/i18n.js
@@ -42,6 +42,7 @@ i18n
       vi: viTranslation,
     },
     fallbackLng: 'zh',
+    nsSeparator: false,
     interpolation: {
       escapeValue: false,
     },


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

修复 i18n 翻译中包含 URL 的字符串显示不完整的问题。
<img width="1042" height="377" alt="image" src="https://github.com/user-attachments/assets/f095da57-46f0-4a9b-b585-0f3e6f658303" />
<img width="1156" height="420" alt="image" src="https://github.com/user-attachments/assets/de4d9354-467b-45c6-9375-6d4d3231d593" />

**问题现象：**
前端 placeholder 等文本中的 URL（如 `https://api.openai.com/v1/chat/completions`）只显示为 `//api.openai.com/v1/chat/completions`，丢失了 `https:` 部分。

**问题原因：**
i18next 默认使用 `:` 作为命名空间分隔符（nsSeparator）。当翻译字符串包含 `https:` 时，i18next 会将 `https` 解析为命名空间名称，将后面的部分作为翻译键，导致 `https:` 被截断。

**修复方案：**
在 i18n 配置中设置 `nsSeparator: false`，禁用命名空间分隔符功能。由于本项目只使用默认的 `translation` 命名空间，不使用多命名空间功能，此修改不会影响现有功能。

**影响范围：**
修复所有翻译文件中约 80 处包含 URL 的字符串显示问题。