### PR TITLE
fix: kling correct fail reason

### DIFF
--- a/relay/channel/task/kling/adaptor.go
+++ b/relay/channel/task/kling/adaptor.go
@@ -346,7 +346,7 @@ func (a *TaskAdaptor) ParseTaskResult(respBody []byte) (*relaycommon.TaskInfo, e
 	}
 	taskInfo.Code = resPayload.Code
 	taskInfo.TaskID = resPayload.Data.TaskId
-	taskInfo.Reason = resPayload.Message
+	taskInfo.Reason = resPayload.Data.TaskStatusMsg
 	//任务状态，枚举值：submitted（已提交）、processing（处理中）、succeed（成功）、failed（失败）
 	status := resPayload.Data.TaskStatus
 	switch status {


### PR DESCRIPTION
可灵的错误返回, message永远是`SUCCESS`
TaskStatusMsg才是正确的错误信息
`{"code": 0, "data": {"task_id": "833446756*******", "task_info": {}, "created_at": 1766737710125, "updated_at": 1766737711775, "task_result": {}, "task_status": "failed", "task_status_msg": "Image pixel is invalid"}, "message": "SUCCEED", "request_id": "ace7625a-3e18-49aa-abc4-*******"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task status message extraction to correctly source information from the appropriate nested data payload, ensuring more accurate status details are displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->