### PR TITLE
feat: add linux_do_id field to EditUserModal form

### DIFF
--- a/web/src/components/table/users/modals/EditUserModal.jsx
+++ b/web/src/components/table/users/modals/EditUserModal.jsx
@@ -338,6 +338,7 @@ const EditUserModal = (props) => {
                       'wechat_id',
                       'email',
                       'telegram_id',
+                      'linux_do_id',
                     ].map((field) => (
                       <Col span={24} key={field}>
                         <Form.Input


### PR DESCRIPTION
管理员面板>用户管理>编辑用户缺失了linux_do_id
加上能有效帮助管理员查看newapi用户绑定了哪个linux do账号

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only binding identifier field to the binding information section in the user editor, allowing users to view an additional binding detail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->