### PR TITLE
feat: support HTTP_PROXY environment variable for default HTTP client

### DIFF
--- a/service/http_client.go
+++ b/service/http_client.go
@@ -38,6 +38,7 @@ func InitHttpClient() {
 		MaxIdleConns:        common.RelayMaxIdleConns,
 		MaxIdleConnsPerHost: common.RelayMaxIdleConnsPerHost,
 		ForceAttemptHTTP2:   true,
+		Proxy:               http.ProxyFromEnvironment, // Support HTTP_PROXY, HTTPS_PROXY, NO_PROXY env vars
 	}
 
 	if common.RelayTimeout == 0 {


### PR DESCRIPTION
## Description
 
Enable the default HTTP client to respect `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables by adding `Proxy: http.ProxyFromEnvironment` to the transport configuration.
 
## Motivation
 
Currently, setting proxy environment variables in Docker Compose has no effect on API requests because the custom `http.Transport` in `InitHttpClient()` doesn't configure proxy support. Users have to manually set proxy URLs for each channel, which is tedious when managing hundreds of channels.
 
## Changes
 
- Modified `service/http_client.go`: Added `Proxy: http.ProxyFromEnvironment` to the default transport
- This allows users to set global proxy via Docker environment variables:
  ```yaml
  environment:
    - HTTP_PROXY=http://192.168.1.1:7890
    - HTTPS_PROXY=http://192.168.1.1:7890
    - NO_PROXY=localhost,127.0.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proxy support to HTTP client configuration. The application now respects standard proxy environment variables for network requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->