### PR TITLE
🐛 fix(dashboard): include year in time bucket labels to fix cross-yea…

### DIFF
--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -219,7 +219,7 @@ export function timestamp2string(timestamp) {
 
 export function timestamp2string1(timestamp, dataExportDefaultTime = 'hour') {
   let date = new Date(timestamp * 1000);
-  // let year = date.getFullYear().toString();
+  let year = date.getFullYear().toString();
   let month = (date.getMonth() + 1).toString();
   let day = date.getDate().toString();
   let hour = date.getHours().toString();
@@ -235,11 +235,12 @@ export function timestamp2string1(timestamp, dataExportDefaultTime = 'hour') {
   if (hour.length === 1) {
     hour = '0' + hour;
   }
-  let str = month + '-' + day;
+  let str = year + '-' + month + '-' + day;
   if (dataExportDefaultTime === 'hour') {
     str += ' ' + hour + ':00';
   } else if (dataExportDefaultTime === 'week') {
     let nextWeek = new Date(timestamp * 1000 + 6 * 24 * 60 * 60 * 1000);
+    let nextYear = nextWeek.getFullYear().toString();
     let nextMonth = (nextWeek.getMonth() + 1).toString();
     let nextDay = nextWeek.getDate().toString();
     if (nextMonth.length === 1) {
@@ -248,7 +249,7 @@ export function timestamp2string1(timestamp, dataExportDefaultTime = 'hour') {
     if (nextDay.length === 1) {
       nextDay = '0' + nextDay;
     }
-    str += ' - ' + nextMonth + '-' + nextDay;
+    str += ' - ' + nextYear + '-' + nextMonth + '-' + nextDay;
   }
   return str;
 }


### PR DESCRIPTION
…r ordering

Ensure dashboard time buckets sort correctly across year boundaries by including the year in `timestamp2string1()` output. Previously, labels like `MM-DD` / `MM-DD HH:00` could be string-sorted into the wrong order (e.g. `01-01` before `12-31`), making it look like the new year’s data was missing or the timeline was “reversed”.

Changes:
- Update `timestamp2string1()` to emit sortable keys:
  - hour: `YYYY-MM-DD HH:00`
  - day: `YYYY-MM-DD`
  - week: `YYYY-MM-DD - YYYY-MM-DD` (both ends include year)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp formatting to consistently include the year in date displays.
  * Weekly date ranges now display the year for improved clarity and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->