### PR TITLE
fix: CrossGroupRetry default false

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -26,7 +26,7 @@ type Token struct {
 	AllowIps           *string        `json:"allow_ips" gorm:"default:''"`
 	UsedQuota          int            `json:"used_quota" gorm:"default:0"` // used quota
 	Group              string         `json:"group" gorm:"default:''"`
-	CrossGroupRetry    bool           `json:"cross_group_retry" gorm:"default:false"` // 跨分组重试，仅auto分组有效
+	CrossGroupRetry    bool           `json:"cross_group_retry"` // 跨分组重试，仅auto分组有效
 	DeletedAt          gorm.DeletedAt `gorm:"index"`
 }
 


### PR DESCRIPTION
移除gorm:"default:false"，避免每次 AutoMigrate时重复执行
`ALTER TABLE `tokens` MODIFY COLUMN `cross_group_retry` boolean DEFAULT false `
且bool默认false不影响原有功能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal database configuration for token handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->