### PR TITLE
feat: add reasoning effort suffix support in model pricing

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -834,6 +834,15 @@ func FormatMatchingModelName(name string) string {
 	if strings.HasPrefix(name, "gpt-4o-gizmo") {
 		name = "gpt-4o-gizmo-*"
 	}
+
+	// Strip reasoning effort suffixes for pricing
+	reasoningSuffixes := []string{"-high", "-minimal", "-low", "-medium", "-none", "-xhigh"}
+	for _, suffix := range reasoningSuffixes {
+		if strings.HasSuffix(name, suffix) {
+			name = strings.TrimSuffix(name, suffix)
+			break
+		}
+	}
 	return name
 }
 


### PR DESCRIPTION
### PR 描述

#### 背景
当前模型定价系统无法自动处理带有推理力度后缀（reasoning effort suffixes）的模型名称，导致这些模型无法使用基础模型的定价配置。

#### 实现内容
在 `FormatMatchingModelName` 函数中增加对以下六种推理力度后缀的支持：
- `-high` - 高推理力度
- `-minimal` - 最小推理力度
- `-low` - 低推理力度
- `-medium` - 中等推理力度
- `-none` - 无推理力度
- `-xhigh` - 超高推理力度

#### 工作原理
当模型名称包含上述后缀时，系统会自动移除后缀，使用基础模型名称进行价格和倍率查询。例如：
- `gemini-3-flash-preview-minimal` → 查询 `gemini-3-flash-preview` 的定价

#### 优势
1. **灵活性提升**：无需为每个推理力度后缀变体单独配置价格
2. **统一管理**：所有模型的不同推理力度变体共享基础模型的定价配置
3. **易于扩展**：未来新增的模型自动支持这些推理力度后缀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model pricing lookup to correctly handle model name variations by normalizing pricing-related suffixes, ensuring consistent price and ratio resolution across different model name formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->