### PR TITLE
新增功能：渠道统计数据展示

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -1974,3 +1974,53 @@ func OllamaVersion(c *gin.Context) {
 		},
 	})
 }
+
+// GetChannelStatistics returns statistics for all channels
+func GetChannelStatistics(c *gin.Context) {
+	stats, err := model.GetAllChannelsStatistics()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    stats,
+	})
+}
+
+// GetSingleChannelStatistics returns daily statistics for a single channel
+func GetSingleChannelStatistics(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "Invalid channel ID",
+		})
+		return
+	}
+
+	// Get days parameter (default 7 days)
+	days := 7
+	if daysStr := c.Query("days"); daysStr != "" {
+		if d, err := strconv.Atoi(daysStr); err == nil && d > 0 {
+			days = d
+		}
+	}
+
+	stats, err := model.GetSingleChannelStatistics(id, days)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    stats,
+	})
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -164,6 +164,8 @@ func SetApiRouter(router *gin.Engine) {
 			channelRoute.GET("/tag/models", controller.GetTagModels)
 			channelRoute.POST("/copy/:id", controller.CopyChannel)
 			channelRoute.POST("/multi_key/manage", controller.ManageMultiKeys)
+			channelRoute.GET("/statistics", controller.GetChannelStatistics)
+			channelRoute.GET("/statistics/:id", controller.GetSingleChannelStatistics)
 		}
 		tokenRoute := apiRouter.Group("/token")
 		tokenRoute.Use(middleware.UserAuth())

--- a/web/src/components/table/channels/ChannelsActions.jsx
+++ b/web/src/components/table/channels/ChannelsActions.jsx
@@ -52,6 +52,7 @@ const ChannelsActions = ({
   activePage,
   pageSize,
   setActivePage,
+  setShowChannelStatistics,
   t,
 }) => {
   return (
@@ -91,6 +92,16 @@ const ChannelsActions = ({
             trigger='click'
             render={
               <Dropdown.Menu>
+                <Dropdown.Item>
+                  <Button
+                    size='small'
+                    type='primary'
+                    className='w-full'
+                    onClick={() => setShowChannelStatistics(true)}
+                  >
+                    {t('渠道统计')}
+                  </Button>
+                </Dropdown.Item>
                 <Dropdown.Item>
                   <Button
                     size='small'

--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -289,6 +289,8 @@ export const getChannelsColumns = ({
   checkOllamaVersion,
   setShowMultiKeyManageModal,
   setCurrentMultiKeyChannel,
+  setShowSingleChannelStatistics,
+  setCurrentStatisticsChannel,
 }) => {
   return [
     {
@@ -715,6 +717,17 @@ export const getChannelsColumns = ({
                   {t('编辑')}
                 </Button>
               )}
+
+              <Button
+                type='tertiary'
+                size='small'
+                onClick={() => {
+                  setCurrentStatisticsChannel(record);
+                  setShowSingleChannelStatistics(true);
+                }}
+              >
+                {t('统计')}
+              </Button>
 
               <Dropdown
                 trigger='click'

--- a/web/src/components/table/channels/ChannelsTable.jsx
+++ b/web/src/components/table/channels/ChannelsTable.jsx
@@ -61,6 +61,9 @@ const ChannelsTable = (channelsData) => {
     // Multi-key management
     setShowMultiKeyManageModal,
     setCurrentMultiKeyChannel,
+    // Single channel statistics
+    setShowSingleChannelStatistics,
+    setCurrentStatisticsChannel,
   } = channelsData;
 
   // Get all columns
@@ -86,6 +89,8 @@ const ChannelsTable = (channelsData) => {
       checkOllamaVersion,
       setShowMultiKeyManageModal,
       setCurrentMultiKeyChannel,
+      setShowSingleChannelStatistics,
+      setCurrentStatisticsChannel,
     });
   }, [
     t,
@@ -108,6 +113,8 @@ const ChannelsTable = (channelsData) => {
     checkOllamaVersion,
     setShowMultiKeyManageModal,
     setCurrentMultiKeyChannel,
+    setShowSingleChannelStatistics,
+    setCurrentStatisticsChannel,
   ]);
 
   // Filter columns based on visibility settings

--- a/web/src/components/table/channels/index.jsx
+++ b/web/src/components/table/channels/index.jsx
@@ -33,6 +33,8 @@ import ColumnSelectorModal from './modals/ColumnSelectorModal';
 import EditChannelModal from './modals/EditChannelModal';
 import EditTagModal from './modals/EditTagModal';
 import MultiKeyManageModal from './modals/MultiKeyManageModal';
+import SingleChannelStatisticsModal from './modals/SingleChannelStatisticsModal';
+import ChannelStatisticsModal from './modals/ChannelStatisticsModal';
 import { createCardProPagination } from '../../../helpers/utils';
 
 const ChannelsPage = () => {
@@ -62,6 +64,17 @@ const ChannelsPage = () => {
         onCancel={() => channelsData.setShowMultiKeyManageModal(false)}
         channel={channelsData.currentMultiKeyChannel}
         onRefresh={channelsData.refresh}
+      />
+      <SingleChannelStatisticsModal
+        visible={channelsData.showSingleChannelStatistics}
+        onCancel={() => channelsData.setShowSingleChannelStatistics(false)}
+        channelId={channelsData.currentStatisticsChannel?.id}
+        channelName={channelsData.currentStatisticsChannel?.name}
+      />
+      <ChannelStatisticsModal
+        visible={channelsData.showChannelStatistics}
+        onCancel={() => channelsData.setShowChannelStatistics(false)}
+        t={channelsData.t}
       />
 
       {/* Main Content */}

--- a/web/src/components/table/channels/modals/ChannelStatisticsModal.jsx
+++ b/web/src/components/table/channels/modals/ChannelStatisticsModal.jsx
@@ -1,0 +1,133 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+import React, { useState, useEffect } from 'react';
+import { Modal, Table, Spin } from '@douyinfe/semi-ui';
+import { API } from '../../../../helpers';
+
+const ChannelStatisticsModal = ({ visible, onCancel, t }) => {
+  const [loading, setLoading] = useState(false);
+  const [statistics, setStatistics] = useState([]);
+
+  useEffect(() => {
+    if (visible) {
+      loadStatistics();
+    }
+  }, [visible]);
+
+  const loadStatistics = async () => {
+    setLoading(true);
+    try {
+      const res = await API.get('/api/channel/statistics');
+      const { success, data } = res.data;
+      if (success) {
+        setStatistics(data || []);
+      }
+    } catch (error) {
+      console.error('Failed to load statistics:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const columns = [
+    {
+      title: t('渠道ID'),
+      dataIndex: 'channel_id',
+      key: 'channel_id',
+      width: 100,
+      sorter: (a, b) => a.channel_id - b.channel_id,
+    },
+    {
+      title: t('渠道名称'),
+      dataIndex: 'channel_name',
+      key: 'channel_name',
+      sorter: (a, b) => a.channel_name.localeCompare(b.channel_name),
+    },
+    {
+      title: t('总请求数'),
+      dataIndex: 'total_requests',
+      key: 'total_requests',
+      width: 120,
+      sorter: (a, b) => a.total_requests - b.total_requests,
+      render: (text) => text.toLocaleString(),
+    },
+    {
+      title: t('成功请求'),
+      dataIndex: 'success_count',
+      key: 'success_count',
+      width: 120,
+      sorter: (a, b) => a.success_count - b.success_count,
+      render: (text) => (
+        <span style={{ color: '#52c41a' }}>{text.toLocaleString()}</span>
+      ),
+    },
+    {
+      title: t('失败请求'),
+      dataIndex: 'error_count',
+      key: 'error_count',
+      width: 120,
+      sorter: (a, b) => a.error_count - b.error_count,
+      render: (text) => (
+        <span style={{ color: text > 0 ? '#ff4d4f' : undefined }}>
+          {text.toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      title: t('成功率'),
+      dataIndex: 'success_rate',
+      key: 'success_rate',
+      width: 120,
+      sorter: (a, b) => a.success_rate - b.success_rate,
+      render: (rate) => {
+        const color =
+          rate >= 95 ? '#52c41a' : rate >= 80 ? '#faad14' : '#ff4d4f';
+        return <span style={{ color }}>{rate.toFixed(2)}%</span>;
+      },
+    },
+  ];
+
+  return (
+    <Modal
+      title={t('渠道统计')}
+      visible={visible}
+      onCancel={onCancel}
+      footer={null}
+      width={900}
+      centered
+    >
+      <Spin spinning={loading}>
+        <Table
+          columns={columns}
+          dataSource={statistics}
+          pagination={{
+            pageSize: 10,
+            showSizeChanger: true,
+            showTotal: (total) => t('共 {total} 个渠道', { total }),
+          }}
+          rowKey='channel_id'
+          size='small'
+        />
+      </Spin>
+    </Modal>
+  );
+};
+
+export default ChannelStatisticsModal;

--- a/web/src/components/table/channels/modals/SingleChannelStatisticsModal.jsx
+++ b/web/src/components/table/channels/modals/SingleChannelStatisticsModal.jsx
@@ -1,0 +1,201 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+import React, { useState, useEffect } from 'react';
+import { Modal, Spin, Radio, RadioGroup, Typography } from '@douyinfe/semi-ui';
+import { VChart } from '@visactor/react-vchart';
+import { API } from '../../../../helpers';
+
+const { Text } = Typography;
+
+const SingleChannelStatisticsModal = ({ visible, onCancel, channelId, channelName }) => {
+  const [loading, setLoading] = useState(false);
+  const [statistics, setStatistics] = useState([]);
+  const [days, setDays] = useState(7);
+  const [chartSpec, setChartSpec] = useState(null);
+
+  useEffect(() => {
+    if (visible && channelId) {
+      loadStatistics();
+    }
+  }, [visible, channelId, days]);
+
+  const loadStatistics = async () => {
+    setLoading(true);
+    try {
+      const res = await API.get(`/api/channel/statistics/${channelId}?days=${days}`);
+      const { success, data } = res.data;
+      if (success && data) {
+        setStatistics(data);
+        generateChartSpec(data);
+      }
+    } catch (error) {
+      console.error('Failed to load statistics:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const generateChartSpec = (data) => {
+    if (!data || data.length === 0) {
+      setChartSpec(null);
+      return;
+    }
+
+    // Transform data for VChart
+    const chartData = [];
+    data.forEach((item) => {
+      chartData.push({
+        date: item.date,
+        type: '成功',
+        count: item.success_count,
+      });
+      chartData.push({
+        date: item.date,
+        type: '失败',
+        count: item.error_count,
+      });
+    });
+
+    // Calculate total stats
+    const totalRequests = data.reduce((sum, item) => sum + item.total_count, 0);
+    const totalSuccess = data.reduce((sum, item) => sum + item.success_count, 0);
+    const totalErrors = data.reduce((sum, item) => sum + item.error_count, 0);
+    const avgSuccessRate = totalRequests > 0 ? ((totalSuccess / totalRequests) * 100).toFixed(2) : 0;
+
+    const spec = {
+      type: 'bar',
+      data: [
+        {
+          id: 'barData',
+          values: chartData,
+        },
+      ],
+      xField: 'date',
+      yField: 'count',
+      seriesField: 'type',
+      stack: true,
+      legends: {
+        visible: true,
+        orient: 'bottom',
+      },
+      title: {
+        visible: true,
+        text: `${channelName || '渠道'} - 最近${days}天统计`,
+        subtext: `总请求: ${totalRequests} | 成功: ${totalSuccess} | 失败: ${totalErrors} | 成功率: ${avgSuccessRate}%`,
+      },
+      bar: {
+        style: {
+          cornerRadius: 4,
+        },
+        state: {
+          hover: {
+            stroke: '#000',
+            lineWidth: 1,
+          },
+        },
+      },
+      tooltip: {
+        mark: {
+          content: [
+            {
+              key: (datum) => datum['type'],
+              value: (datum) => datum['count'],
+            },
+          ],
+        },
+      },
+      color: {
+        type: 'ordinal',
+        range: ['#52c41a', '#ff4d4f'],
+      },
+      axes: [
+        {
+          orient: 'left',
+          title: {
+            visible: true,
+            text: '请求数',
+          },
+        },
+        {
+          orient: 'bottom',
+          title: {
+            visible: true,
+            text: '日期',
+          },
+          label: {
+            autoRotate: true,
+            autoRotateAngle: [0, 45],
+          },
+        },
+      ],
+    };
+
+    setChartSpec(spec);
+  };
+
+  const CHART_CONFIG = {
+    autoFit: true,
+  };
+
+  return (
+    <Modal
+      title={`${channelName || '渠道'} 统计`}
+      visible={visible}
+      onCancel={onCancel}
+      footer={null}
+      width={900}
+      centered
+    >
+      <div className='mb-4'>
+        <Text strong>时间范围：</Text>
+        <RadioGroup
+          type='button'
+          value={days}
+          onChange={(e) => setDays(e.target.value)}
+          style={{ marginLeft: 8 }}
+        >
+          <Radio value={7}>最近7天</Radio>
+          <Radio value={14}>最近14天</Radio>
+          <Radio value={30}>最近30天</Radio>
+        </RadioGroup>
+      </div>
+
+      <Spin spinning={loading}>
+        <div style={{ height: '500px' }}>
+          {chartSpec ? (
+            <VChart spec={chartSpec} option={CHART_CONFIG} />
+          ) : (
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              height: '100%',
+              color: '#999'
+            }}>
+              暂无数据
+            </div>
+          )}
+        </div>
+      </Spin>
+    </Modal>
+  );
+};
+
+export default SingleChannelStatisticsModal;

--- a/web/src/hooks/channels/useChannelsData.jsx
+++ b/web/src/hooks/channels/useChannelsData.jsx
@@ -114,6 +114,13 @@ export const useChannelsData = () => {
   const [showMultiKeyManageModal, setShowMultiKeyManageModal] = useState(false);
   const [currentMultiKeyChannel, setCurrentMultiKeyChannel] = useState(null);
 
+  // Single channel statistics states
+  const [showSingleChannelStatistics, setShowSingleChannelStatistics] = useState(false);
+  const [currentStatisticsChannel, setCurrentStatisticsChannel] = useState(null);
+
+  // All channels statistics states
+  const [showChannelStatistics, setShowChannelStatistics] = useState(false);
+
   // Refs
   const requestCounter = useRef(0);
   const allSelectingRef = useRef(false);
@@ -1163,6 +1170,16 @@ export const useChannelsData = () => {
     setShowMultiKeyManageModal,
     currentMultiKeyChannel,
     setCurrentMultiKeyChannel,
+
+    // Single channel statistics states
+    showSingleChannelStatistics,
+    setShowSingleChannelStatistics,
+    currentStatisticsChannel,
+    setCurrentStatisticsChannel,
+
+    // All channels statistics states
+    showChannelStatistics,
+    setShowChannelStatistics,
 
     // Form
     formApi,


### PR DESCRIPTION
实现了两种渠道统计查看方式：

1. 单个渠道统计
   - 在渠道列表每行的操作按钮中添加"统计"按钮
   - 点击后弹窗显示该渠道最近7天/14天/30天的请求统计
   - 使用柱状图展示每日的成功请求和失败请求数量
   - 显示总请求数、成功数、失败数和平均成功率

2. 全部渠道统计
   - 在页面顶部"批量操作"菜单中添加"渠道统计"选项
   - 显示所有渠道的统计数据表格
   - 支持按渠道ID、名称、请求数、成功率等排序
   - 成功率根据数值显示不同颜色（绿色>=95%，黄色>=80%，红色<80%）

技术实现：
- 后端：新增 GetSingleChannelStatistics API，使用SQL按日期分组统计
- 前端：使用 VChart 展示柱状图，Semi UI Table 组件展示表格
- 路由：GET /api/channel/statistics/:id

修改的文件：
- model/channel.go - 添加统计数据模型和查询函数
- controller/channel.go - 添加统计API控制器
- router/api-router.go - 添加统计路由
- web/src/components/table/channels/ - 添加统计弹窗组件和按钮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel statistics feature enabling users to view aggregate metrics for all channels, including total requests, success/error counts, and success rates.
  * Added individual channel statistics modal with selectable time ranges (7, 14, or 30 days) displaying daily performance data and visual charts.
  * Integrated statistics quick-access buttons into the channels table for convenient viewing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->