### PR TITLE
增加vidu图片生成模型支持

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -73,6 +73,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeMiniMax
 	case constant.ChannelTypeReplicate:
 		apiType = constant.APITypeReplicate
+	case constant.ChannelTypeVidu:
+		apiType = constant.APITypeVidu
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -35,5 +35,6 @@ const (
 	APITypeSubmodel
 	APITypeMiniMax
 	APITypeReplicate
+	APITypeVidu
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/relay/channel/vidu/adaptor.go
+++ b/relay/channel/vidu/adaptor.go
@@ -1,0 +1,80 @@
+package vidu
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+type Adaptor struct{}
+
+func (a *Adaptor) Init(info *relaycommon.RelayInfo) {}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	return fmt.Sprintf("%s/ent/v2/reference2image", info.ChannelBaseUrl), nil
+}
+
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	req.Set("Content-Type", "application/json")
+	req.Set("Authorization", "Token "+info.ApiKey)
+	return nil
+}
+
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	if info.RelayMode == relayconstant.RelayModeImagesEdits {
+		return imageEditFromOai(c, info, request)
+	}
+	return oaiImage2ViduImageRequest(info, request)
+}
+
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	return viduImageHandler(a, c, resp, info)
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return []string{"viduq2", "viduq1"}
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return "vidu"
+}
+
+func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}

--- a/relay/channel/vidu/dto.go
+++ b/relay/channel/vidu/dto.go
@@ -1,0 +1,41 @@
+package vidu
+
+type ImageRequest struct {
+	Model       string   `json:"model"`
+	Images      []string `json:"images,omitempty"`
+	Prompt      string   `json:"prompt"`
+	Seed        int      `json:"seed,omitempty"`
+	AspectRatio string   `json:"aspect_ratio,omitempty"`
+	Resolution  string   `json:"resolution,omitempty"`
+	Payload     string   `json:"payload,omitempty"`
+	CallbackUrl string   `json:"callback_url,omitempty"`
+}
+
+type ImageResponse struct {
+	TaskId      string   `json:"task_id"`
+	State       string   `json:"state"`
+	Model       string   `json:"model"`
+	Prompt      string   `json:"prompt"`
+	Images      []string `json:"images,omitempty"`
+	Seed        int      `json:"seed"`
+	AspectRatio string   `json:"aspect_ratio"`
+	Resolution  string   `json:"resolution"`
+	CallbackUrl string   `json:"callback_url,omitempty"`
+	Payload     string   `json:"payload,omitempty"`
+	Credits     int      `json:"credits"`
+	CreatedAt   string   `json:"created_at"`
+}
+
+type TaskResultResponse struct {
+	State     string        `json:"state"`
+	ErrCode   string        `json:"err_code,omitempty"`
+	Credits   int           `json:"credits"`
+	Payload   string        `json:"payload,omitempty"`
+	Creations []ImageResult `json:"creations"`
+}
+
+type ImageResult struct {
+	ID       string `json:"id"`
+	URL      string `json:"url"`
+	CoverURL string `json:"cover_url,omitempty"`
+}

--- a/relay/channel/vidu/image.go
+++ b/relay/channel/vidu/image.go
@@ -1,0 +1,207 @@
+package vidu
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/logger"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+func oaiImage2ViduImageRequest(info *relaycommon.RelayInfo, request dto.ImageRequest) (*ImageRequest, error) {
+	req := &ImageRequest{
+		Model:  request.Model,
+		Prompt: request.Prompt,
+	}
+
+	if request.Extra != nil {
+		extraBytes, _ := json.Marshal(request.Extra)
+		err := json.Unmarshal(extraBytes, req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return req, nil
+}
+
+func imageEditFromOai(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (*ImageRequest, error) {
+	req := &ImageRequest{
+		Model:  request.Model,
+		Prompt: request.Prompt,
+	}
+
+	imageBase64Data, err := relaycommon.GetImageBase64sFromForm(c)
+	if err != nil {
+		return nil, fmt.Errorf("get image base64s from form failed: %w", err)
+	}
+
+	req.Images = make([]string, len(imageBase64Data))
+	for i, data := range imageBase64Data {
+		req.Images[i] = data.String()
+	}
+
+	var reqMap = make(map[string]string)
+	if err = common.UnmarshalBodyReusable(c, &reqMap); err != nil {
+		return nil, fmt.Errorf("unmarshal body reusable failed: %w", err)
+	}
+	for key, value := range reqMap {
+		switch key {
+		case "seed":
+			if req.Seed, err = strconv.Atoi(value); err != nil {
+				return nil, fmt.Errorf("invalid seed field: %w", err)
+			}
+		case "aspect_ratio":
+			req.AspectRatio = value
+		case "resolution":
+			req.Resolution = value
+		case "payload":
+			req.Payload = value
+		case "callback_url":
+			req.CallbackUrl = value
+		}
+	}
+
+	return req, nil
+}
+
+func asyncTaskWait(c *gin.Context, info *relaycommon.RelayInfo, taskID string) (*TaskResultResponse, []byte, error) {
+	time.Sleep(5 * time.Second)
+
+	for step := 0; step < 20; step++ {
+		logger.LogDebug(c, fmt.Sprintf("vidu image task wait step %d/20", step))
+		rsp, body, err := queryTask(info, taskID)
+		if err != nil {
+			logger.LogWarn(c, "vidu query task error: "+err.Error())
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		switch rsp.State {
+		case "success":
+			return rsp, body, nil
+		case "failed":
+			errMsg := "task failed"
+			if rsp.ErrCode != "" {
+				errMsg = rsp.ErrCode
+			}
+			return rsp, body, errors.New(errMsg)
+		case "created", "queueing", "processing":
+			time.Sleep(10 * time.Second)
+			continue
+		default:
+			return rsp, body, fmt.Errorf("unknown task state: %s", rsp.State)
+		}
+	}
+
+	return nil, nil, errors.New("task timeout")
+}
+
+func queryTask(info *relaycommon.RelayInfo, taskID string) (*TaskResultResponse, []byte, error) {
+	url := fmt.Sprintf("%s/ent/v2/tasks/%s/creations", info.ChannelBaseUrl, taskID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Authorization", "Token "+info.ApiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := service.GetHttpClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var res TaskResultResponse
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &res, body, nil
+}
+
+func response2OpenAIImage(c *gin.Context, response *TaskResultResponse, originBody []byte, info *relaycommon.RelayInfo) *dto.ImageResponse {
+	imageResponse := dto.ImageResponse{
+		Created:  info.StartTime.Unix(),
+		Metadata: originBody,
+	}
+
+	for _, creation := range response.Creations {
+		imageResponse.Data = append(imageResponse.Data, dto.ImageData{
+			Url: creation.URL,
+		})
+	}
+
+	return &imageResponse
+}
+
+func viduImageHandler(a *Adaptor, c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (*dto.Usage, *types.NewAPIError) {
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+	service.CloseResponseBodyGracefully(resp)
+
+	var viduTaskResp ImageResponse
+	err = json.Unmarshal(responseBody, &viduTaskResp)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	if viduTaskResp.State == "failed" {
+		return nil, types.NewError(errors.New("task failed"), types.ErrorCodeBadResponse)
+	}
+
+	viduResp, originBody, err := asyncTaskWait(c, info, viduTaskResp.TaskId)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponse)
+	}
+
+	if viduResp.State != "success" {
+		errMsg := "task failed"
+		if viduResp.ErrCode != "" {
+			errMsg = viduResp.ErrCode
+		}
+		return nil, types.WithOpenAIError(types.OpenAIError{
+			Message: errMsg,
+			Type:    "vidu_error",
+			Code:    viduResp.ErrCode,
+		}, resp.StatusCode)
+	}
+
+	logger.LogDebug(c, "vidu image result: "+string(originBody))
+
+	imageResponse := response2OpenAIImage(c, viduResp, originBody, info)
+
+	if len(imageResponse.Data) > 1 {
+		info.PriceData.AddOtherRatio("n", float64(len(imageResponse.Data)))
+	}
+
+	jsonResponse, err := json.Marshal(imageResponse)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeBadResponseBody)
+	}
+
+	service.IOCopyBytesGracefully(c, resp, jsonResponse)
+
+	return &dto.Usage{}, nil
+}

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -41,6 +41,7 @@ import (
 	taskVidu "github.com/QuantumNous/new-api/relay/channel/task/vidu"
 	"github.com/QuantumNous/new-api/relay/channel/tencent"
 	"github.com/QuantumNous/new-api/relay/channel/vertex"
+	"github.com/QuantumNous/new-api/relay/channel/vidu"
 	"github.com/QuantumNous/new-api/relay/channel/volcengine"
 	"github.com/QuantumNous/new-api/relay/channel/xai"
 	"github.com/QuantumNous/new-api/relay/channel/xunfei"
@@ -117,6 +118,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &minimax.Adaptor{}
 	case constant.APITypeReplicate:
 		return &replicate.Adaptor{}
+	case constant.APITypeVidu:
+		return &vidu.Adaptor{}
 	}
 	return nil
 }


### PR DESCRIPTION
官方文档: `https://platform.vidu.cn/docs/reference-to-image`
支持opeani格式的图片生成 和 图片编辑 接口
请求示例:  
```
curl http://localhost:30001/v1/images/generations \
  --request POST \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "viduq2",
  "prompt": "可爱的中国小女孩在花园里玩耍"
}'
```
<img width="2258" height="1034" alt="image" src="https://github.com/user-attachments/assets/79e73a66-93ee-4451-8af1-af6fa2466010" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vidu as a new image generation API provider
  * Integrated automatic background task monitoring for asynchronous image processing workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->