### PR TITLE
feat: support streaming for audio with raw audio chunk forwarding

### DIFF
--- a/docs/openapi/relay.json
+++ b/docs/openapi/relay.json
@@ -3733,6 +3733,11 @@
             "minimum": 0.25,
             "maximum": 4,
             "default": 1
+          },
+          "stream": {
+            "type": "boolean",
+            "default": false,
+            "description": "是否以流式方式返回音频（通过 HTTP 分块传输返回原始音频字节流，非 SSE）"
           }
         }
       },

--- a/dto/audio.go
+++ b/dto/audio.go
@@ -16,6 +16,7 @@ type AudioRequest struct {
 	Instructions   string          `json:"instructions,omitempty"`
 	ResponseFormat string          `json:"response_format,omitempty"`
 	Speed          float64         `json:"speed,omitempty"`
+	Stream         bool            `json:"stream,omitempty"`
 	StreamFormat   string          `json:"stream_format,omitempty"`
 	Metadata       json.RawMessage `json:"metadata,omitempty"`
 }
@@ -32,7 +33,7 @@ func (r *AudioRequest) GetTokenCountMeta() *types.TokenCountMeta {
 }
 
 func (r *AudioRequest) IsStream(c *gin.Context) bool {
-	return r.StreamFormat == "sse"
+	return r.Stream || r.StreamFormat == "sse"
 }
 
 func (r *AudioRequest) SetModelName(modelName string) {

--- a/relay/audio_handler.go
+++ b/relay/audio_handler.go
@@ -3,7 +3,11 @@ package relay
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
+	"unicode/utf8"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
@@ -50,15 +54,71 @@ func AudioHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 	}
 	statusCodeMappingStr := c.GetString("status_code_mapping")
 
-	var httpResp *http.Response
-	if resp != nil {
-		httpResp = resp.(*http.Response)
-		if httpResp.StatusCode != http.StatusOK {
-			newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
-			// reset status code 重置状态码
-			service.ResetStatusCode(newAPIError, statusCodeMappingStr)
-			return newAPIError
+	if resp == nil {
+		return types.NewError(errors.New("adaptor returned nil response"), types.ErrorCodeBadResponse, types.ErrOptionWithSkipRetry())
+	}
+	httpResp, ok := resp.(*http.Response)
+	if !ok {
+		return types.NewError(errors.New("invalid response type, expected *http.Response"), types.ErrorCodeBadResponse, types.ErrOptionWithSkipRetry())
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		newAPIError = service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+		service.ResetStatusCode(newAPIError, statusCodeMappingStr)
+		return newAPIError
+	}
+
+	contentType := httpResp.Header.Get("Content-Type")
+	if strings.HasPrefix(contentType, "audio/") && request.IsStream(c) {
+		defer func() {
+			if closeErr := httpResp.Body.Close(); closeErr != nil {
+				common.SysError(fmt.Sprintf("failed to close response body: %s", closeErr.Error()))
+			}
+		}()
+
+		for k, vv := range httpResp.Header {
+			if k == "Content-Length" || k == "Transfer-Encoding" || k == "Connection" {
+				continue
+			}
+			for _, v := range vv {
+				c.Writer.Header().Add(k, v)
+			}
 		}
+		c.Writer.WriteHeader(httpResp.StatusCode)
+
+		flusher, ok := c.Writer.(http.Flusher)
+		if !ok {
+			common.SysError("ResponseWriter does not support Flusher, streaming may be buffered")
+		} else {
+			flusher.Flush()
+		}
+
+		info.FirstResponseTime = time.Now()
+
+		_, err = io.Copy(c.Writer, httpResp.Body)
+		if err != nil {
+			common.SysError(fmt.Sprintf("audio streaming failed: %s | channel: %d | model: %s", err.Error(), info.ChannelId, request.Model))
+			return nil
+		}
+
+		if flusher != nil {
+			flusher.Flush()
+		}
+
+		promptTokens := utf8.RuneCountInString(request.Input)
+
+		usage := &dto.Usage{
+			PromptTokens: promptTokens,
+			TotalTokens:  promptTokens,
+			PromptTokensDetails: dto.InputTokenDetails{
+				TextTokens:  promptTokens,
+				AudioTokens: 0,
+			},
+		}
+
+		postConsumeQuota(c, info, usage)
+
+		return nil
 	}
 
 	usage, newAPIError := adaptor.DoResponse(c, httpResp, info)


### PR DESCRIPTION
### PR说明

目前 new-api 的 `/v1/audio/speech` 接口不支持流式返回。
而根据 OpenAI 官方接口语义，audio/speech 支持在生成过程中**以 HTTP 分块传输（chunked transfer）的方式持续返回音频字节流**，该行为并非 SSE（Server-Sent Events）。

本 PR 在不破坏现有行为的前提下，为 `/v1/audio/speech` 增加了**符合 OpenAI 语义的音频流式支持**。


### 变更内容

#### 1. 对齐 OpenAI 的 streaming 请求语义

在 `AudioRequest` 中新增字段：

```go
Stream bool `json:"stream,omitempty"`
```

并调整流式判断逻辑：

```go
func (r *AudioRequest) IsStream(c *gin.Context) bool {
	return r.Stream || r.StreamFormat == "sse"
}
```

说明：

* `stream: true`：用于对齐 OpenAI 官方 audio/speech 接口语义
* `stream_format == "sse"`：保留现有 new-api 的历史行为
* 两者并存，确保**向后兼容**


#### 2. Relay 层实现音频流直通转发

当满足以下两个条件时：

* 响应 `Content-Type` 以 `audio/` 开头
* 请求显式声明为流式（`stream=true` 或 `stream_format=sse`）

Relay 将：

* 跳过 `DoResponse` 解析逻辑
* 直接通过 `io.Copy` 将上游返回的音频字节流写入客户端响应
* 保持 HTTP chunked streaming 行为，不做任何封装或重编码

```go
if strings.HasPrefix(contentType, "audio/") && request.IsStream(c) {
	// raw audio streaming passthrough
}
```

该实现**严格遵循 audio/speech 的协议语义**，未引入 SSE。


#### 3. 完整、无损的响应 Header 转发

为避免多值 Header 丢失（如 `Set-Cookie` 等），响应头转发采用逐值 `Add` 的方式，并排除 hop-by-hop headers：

```go
for k, vv := range httpResp.Header {
	if k == "Content-Length" || k == "Transfer-Encoding" || k == "Connection" {
		continue
	}
	for _, v := range vv {
		c.Writer.Header().Add(k, v)
	}
}
```

保证 Header 语义完整性。


#### 4. 指标统计与配额处理

* 在首次 flush 时记录 `FirstResponseTime`，确保链路时延统计准确
* 由于 audio/speech 流式响应不返回 usage 信息：

  * 使用输入文本 rune 数作为保守的 token 估算
  * 通过现有 `postConsumeQuota` 路径记录消耗
* 不引入新的计费模型，避免行为不确定性


### 设计说明

* audio/speech 的“流式”本质是**原始音频字节的分块传输**
* 并非 `text/event-stream`，因此不应使用 SSE
* 本 PR 明确区分文本流与音频流，避免协议层混用


### 兼容性说明

* 非流式 `/v1/audio/speech` 行为完全不变
* 现有使用 `stream_format == "sse"` 的调用方不受影响
* 新增能力为可选增强，不引入破坏性变更



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for HTTP chunked transfer streaming for audio responses as an alternative to existing streaming methods.
  * Introduced new streaming configuration option for audio requests.

* **Documentation**
  * Updated API schema to reflect new streaming capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->