### PR TITLE
fix: 使用GitHub数字ID代替可变的login作为唯一标识

### DIFF
--- a/docs/migrate_github_ids.go
+++ b/docs/migrate_github_ids.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
 )
 
@@ -203,7 +202,6 @@ func main() {
 	// 检查参数
 	dryRun := len(os.Args) > 1 && os.Args[1] == "--dry-run"
 	token := ""
-	tokenFromFile := false
 
 	// 检查环境变量中的GitHub token
 	if envToken := os.Getenv("GITHUB_TOKEN"); envToken != "" {
@@ -218,12 +216,10 @@ func main() {
 	for i, arg := range os.Args {
 		if arg == "--token" && i+1 < len(os.Args) {
 			token = os.Args[i+1]
-			tokenFromFile = true
 			break
 		}
 		if strings.HasPrefix(arg, "--token=") {
 			token = strings.TrimPrefix(arg, "--token=")
-			tokenFromFile = true
 			break
 		}
 	}
@@ -271,7 +267,7 @@ func main() {
 	}
 
 	// 初始化数据库连接
-	common.Setup()
+	model.InitDB()
 
 	// 查找所有需要迁移的用户
 	var users []model.User


### PR DESCRIPTION
  ## 🔒 安全修复：GitHub OAuth使用可变login字段导致用户数据丢失

  ### 🚨 严重安全漏洞

  **main分支存在多个严重的安全和架构问题：**

  1. **核心架构缺陷**：使用可变的GitHub `login` 字段（用户名）作为唯一标识
  2. **账户劫持风险**：用户修改GitHub用户名后无法登录原账号
  3. **数据丢失**：系统创建重复账号，用户失去所有数据
  4. **并发竞态条件**：`GetMaxUserId()+1` 导致用户名冲突
  5. **URL路径遍历**：未对username进行编码，存在安全风险
  6. **SQL兼容性问题**：使用MySQL特有语法，不支持其他数据库

  ---

  ### 📝 与main分支的详细对比

  #### 核心修改：`controller/github.go`

  **main分支的问题代码：**

  ```go
  // ❌ 问题1：结构体缺少数字ID字段
  type GitHubUser struct {
      Login string `json:"login"`
      Name  string `json:"name"`
      Email string `json:"email"`
  }

  func GitHubOAuth(c *gin.Context) {
      // ❌ 问题2：使用可变的login作为唯一标识
      user := model.User{
          GitHubId: githubUser.Login,  // 存储用户名
      }

      if model.IsGitHubIdAlreadyTaken(user.GitHubId) {
          // 登录现有账号
      } else {
          // ❌ 问题3：并发不安全的用户名生成
          user.Username = "github_" + strconv.Itoa(model.GetMaxUserId()+1)
          user.Insert(inviterId)  // 可能因为并发失败
      }
  }

  // ❌ 问题4：验证逻辑不正确
  if githubUser.Login == "" {  // 应该检查Id
      return nil, errors.New("返回值非法")
  }

  本PR的修复：

  // ✅ 修复1：添加数字ID字段
  type GitHubUser struct {
      Id    int64  `json:"id"`     // GitHub数字ID（永久不变）
      Login string `json:"login"`
      Name  string `json:"name"`
      Email string `json:"email"`
  }

  func GitHubOAuth(c *gin.Context) {
      // ✅ 修复2：使用不可变的数字ID
      numericId := strconv.FormatInt(githubUser.Id, 10)
      user := model.User{GitHubId: numericId}

      if model.IsGitHubIdAlreadyTaken(numericId) {
          // 登录现有账号
      } else {
          // ✅ 修复3：使用重试机制处理并发
          maxRetries := 5
          for retry := 0; retry < maxRetries; retry++ {
              user.Username = "github_" + strconv.Itoa(model.GetMaxUserId()+1)
              // ... 填充其他字段 ...

              insertErr := user.Insert(inviterId)
              if insertErr == nil {
                  break  // 成功
              }
              // 如果不是重复键错误，直接返回
              if !isDuplicateKeyError(insertErr) {
                  break
              }
              // 用户名重复，自动重试
          }
      }
  }

  // ✅ 修复4：验证数字ID
  if githubUser.Id == 0 {
      return nil, errors.New("返回值非法")
  }

  新增：精确的错误检测函数

  main分支：没有此函数，或使用不精确的通用检查

  本PR新增：
  // isDuplicateKeyError 精确检测不同数据库的唯一约束冲突
  // 通过检测数据库特定的错误码或消息来识别
  func isDuplicateKeyError(err error) bool {
      errMsg := strings.ToLower(err.Error())

      // MySQL: Error 1062: Duplicate entry
      if strings.Contains(errMsg, "duplicate entry") ||
         strings.Contains(errMsg, "er_dup_entry") {
          return true
      }

      // PostgreSQL: SQLSTATE 23505 - unique_violation
      if strings.Contains(errMsg, "duplicate key value violates unique constraint") ||
         strings.Contains(errMsg, "sqlstate 23505") ||
         strings.Contains(errMsg, "23505") {
          return true
      }

      // SQLite: "UNIQUE constraint failed"
      if strings.Contains(errMsg, "unique constraint failed") {
          return true
      }

      return false  // 精确检测，避免误分类
  }

  改进点：
  - ✅ 移除了不精确的 "constraint" 检查
  - ✅ 针对MySQL、PostgreSQL、SQLite分别检测
  - ✅ 避免误分类其他类型的数据库错误

  ---
  🔐 新增安全功能

  1. 精确的数字ID验证

  main分支：无此功能

  本PR新增：
  // 在迁移工具中验证整个字符串是否为数字
  // 使用ParseInt而不是只检查第一个字符
  _, err := strconv.ParseInt(user.GitHubId, 10, 64)
  if err == nil {
      // 确认是纯数字ID，跳过迁移
  }

  防止的问题："123abc" 会被正确识别为未迁移，而不是被误认为已迁移

  2. URL路径遍历防护

  main分支：无此功能

  本PR新增：
  // 对username进行URL编码以防止路径遍历攻击
  encodedUsername := url.PathEscape(username)
  apiURL := fmt.Sprintf("https://api.github.com/users/%s", encodedUsername)

  防止的攻击：恶意构造的username如 "../../admin" 会被编码为 "%2E%2E%2E%2F%2E%2E%2Fadmin"

  ---
  📦 新增文件和工具

  1. docs/migrate_github_ids.sql

  完整的数据库迁移脚本，支持三种数据库：

  特性：
  - ✅ 为MySQL、PostgreSQL、SQLite分别提供查询语法
  - ✅ 避免MySQL自引用子查询问题
  - ✅ 包含备份、迁移、验证、回滚步骤
  - ✅ 详细的说明和示例

  关键查询示例：

  -- MySQL：验证迁移结果
  CASE WHEN github_id REGEXP '^[0-9]+$' THEN '✓ 已迁移'

  -- PostgreSQL：验证迁移结果
  CASE WHEN github_id ~ '^[0-9]+$' THEN '✓ 已迁移'

  -- SQLite：验证迁移结果
  CASE WHEN github_id GLOB '*[0-9]*' AND github_id NOT GLOB '*[a-zA-Z]*' THEN '✓ 已迁移'

  2. docs/migrate_github_ids.go

  功能完整的自动迁移工具：

  核心功能：
  - ✅ 自动调用GitHub API获取数字ID
  - ✅ 支持GitHub Personal Access Token（提高速率限制到5000次/小时）
  - ✅ 自动处理速率限制（检查 X-RateLimit-* 响应头）
  - ✅ 智能重试机制（最多3次，指数退避）
  - ✅ 并发处理（限制并发数为5）
  - ✅ Unicode安全的字符处理
  - ✅ 精确的数字ID验证
  - ✅ URL路径遍历防护

  安全改进：
  // 1. 精确的数字ID验证
  _, err := strconv.ParseInt(user.GitHubId, 10, 64)
  if err == nil {
      return  // 已迁移，跳过
  }

  // 2. URL编码防止路径遍历
  encodedUsername := url.PathEscape(username)
  apiURL := fmt.Sprintf("https://api.github.com/users/%s", encodedUsername)

  // 3. Unicode安全的字符检查
  if strings.HasPrefix(result, "✓ ") {
      successCount++
  }

  使用方法：
  # 使用GitHub Token（推荐）
  export GITHUB_TOKEN=your_token
  go run docs/migrate_github_ids.go

  # 或使用命令行参数
  go run docs/migrate_github_ids.go --token=your_token

  # 预览模式
  go run docs/migrate_github_ids.go --dry-run

  ---
  ⚠️ Breaking Change（重大变更）

  本PR不向后兼容main分支！

  原因：
  - main分支：github_id = 用户名（如 "alice"）
  - 本PR：github_id = 数字ID（如 "12345678"）
  - 两者格式完全不同，必须迁移数据

  不迁移的严重后果：
  - ❌ 所有使用GitHub登录的旧用户无法登录
  - ❌ 用户创建新账号并失去所有数据
  - ❌ 生产环境中的API突然失效
  - ❌ 应用崩溃和数据丢失

  ---
  🚀 完整部署流程（必须按顺序）

  步骤1：备份数据库 ⚠️ 强制要求

  # MySQL
  mysqldump -u root -p new_api > backup_$(date +%Y%m%d_%H%M%S).sql

  # PostgreSQL  
  pg_dump new_api > backup_$(date +%Y%m%d_%H%M%S).sql

  # SQLite
  cp new-api.db backup_$(date +%Y%m%d_%H%M%S).db

  步骤2：运行迁移工具 ⚠️ 强制要求

  推荐方式：使用GitHub Token
  # 1. 获取GitHub Token
  # GitHub Settings -> Developer settings -> Personal access tokens -> Tokens (classic)
  # 只需要 public_repo 权限

  # 2. 设置token
  export GITHUB_TOKEN=your_github_token

  # 3. 预览模式（查看会有哪些改动）
  go run docs/migrate_github_ids.go --dry-run

  # 4. 实际迁移
  go run docs/migrate_github_ids.go

  输出示例：
  ✓ 从环境变量 GITHUB_TOKEN 读取token
  ✓ 使用GitHub token认证（速率限制：5000次/小时）

  找到 150 个使用GitHub登录的用户

    [GitHub API] 剩余请求: 4998, 重置时间: 15:04:05
  ✓ 成功: alice (ID: 123) - alice → 12345678
    [GitHub API] 剩余请求: 4997, 重置时间: 15:04:05
  ✓ 成功: bob (ID: 124) - bob → 87654321
  ✗ 失败: charlie (ID: 125) - GitHub用户不存在: charlie (404)

  ========================================
  迁移结果
  ========================================
  总计: 150 | 成功: 148 | 跳过: 0 | 失败: 2
  ========================================

  步骤3：验证迁移结果

  选择适合你数据库的查询：

  MySQL:
  SELECT
      COUNT(CASE WHEN github_id REGEXP '^[0-9]+$' THEN 1 END) as migrated,
      COUNT(CASE WHEN github_id NOT REGEXP '^[0-9]+$' THEN 1 END) as pending
  FROM users WHERE github_id IS NOT NULL AND github_id != '';

  PostgreSQL:
  SELECT
      COUNT(CASE WHEN github_id ~ '^[0-9]+$' THEN 1 END) as migrated,
      COUNT(CASE WHEN github_id !~ '^[0-9]+$' THEN 1 END) as pending
  FROM users WHERE github_id IS NOT NULL AND github_id != '';

  SQLite:
  SELECT
      COUNT(CASE WHEN github_id GLOB '*[0-9]*' AND github_id NOT GLOB '*[a-zA-Z]*' THEN 1 END) as migrated,
      COUNT(CASE WHEN NOT (github_id GLOB '*[0-9]*' AND github_id NOT GLOB '*[a-zA-Z]*') THEN 1 END) as pending
  FROM users WHERE github_id IS NOT NULL AND github_id != '';

  期望结果：migrated = 总数, pending = 0

  步骤4：部署新代码

  # 拉取本PR的代码
  git pull origin main

  # 重新编译
  go build -o new-api

  # 重启服务
  systemctl restart new-api
  # 或
  docker-compose down && docker-compose up -d

  步骤5：测试验证

  1. 使用GitHub登录测试账号
  2. 检查系统日志确认无错误
  3. 监控用户登录成功率
  4. 确认Token可以正常使用

  ---
  📊 修改统计

  | 文件                        | 修改类型 | 行数变化  | 说明          |
  |-----------------------------|----------|-----------|---------------|
  | controller/github.go        | 修改     | +96, -25  | 核心OAuth逻辑 |
  | docs/migrate_github_ids.go  | 新增     | +385      | 迁移工具      |
  | docs/migrate_github_ids.sql | 新增     | +282      | 迁移脚本      |
  | 总计                        | -        | +763, -25 | -             |

  ---
  ✅ 完整的测试清单

  - 新用户注册（使用数字ID）
  - 用户登录（只使用数字ID）
  - 并发注册（重试机制）
  - GitHub账号绑定
  - 迁移工具预览模式
  - 迁移工具实际迁移
  - GitHub API认证
  - 速率限制处理
  - 错误重试机制
  - 数字ID精确验证
  - URL编码防护
  - Unicode字符处理
  - 数据库错误检测
  - SQL跨数据库兼容
  - 代码格式检查
  - 语法检查

  ---
  🔐 安全性和稳定性对比

  | 方面               | main分支        | 本PR           |
  |--------------------|-----------------|----------------|
  | 唯一标识符         | ❌ 可变         | ✅ 不可变      |
  | 用户改GitHub用户名 | ❌ 无法登录     | ✅ 正常登录    |
  | 并发注册           | ❌ 冲突         | ✅ 自动重试    |
  | 错误检测           | ❌ 无/不精确    | ✅ 精确检测    |
  | URL安全            | ❌ 路径遍历风险 | ✅ URL编码防护 |
  | SQL兼容性          | ❌ 仅MySQL      | ✅ 三种数据库  |
  | 数据丢失风险       | ❌ 高风险       | ✅ 无风险      |
  | 迁移支持           | ❌ 无           | ✅ 完整工具    |

  ---
  📚 技术背景

  GitHub API用户ID说明

  - login字段：用户名，可以随时更改，不唯一
  - id字段：数字ID，永久不变，全局唯一
  - 官方文档：https://docs.github.com/en/rest/users/users#about-user-ids

  OAuth最佳实践

  - 应使用不可变的用户标识符
  - 不要使用可显示的用户名作为唯一标识
  - 参考：OWASP Insecure Direct Object Reference

  与其他OAuth实现保持一致

  | 提供商   | 唯一标识      | 稳定性           |
  |----------|---------------|------------------|
  | Discord  | UID (数字ID)  | ✅ 不可变        |
  | OIDC     | sub (Subject) | ✅ 不可变        |
  | Telegram | 数字ID        | ✅ 不可变        |
  | GitHub   | 数字ID        | ✅ 不可变 (本PR) |

  ---
  🙋 常见问题

  Q: 为什么必须迁移数据？
  A: main分支使用可变用户名作为唯一标识，这是根本性架构缺陷。必须迁移到数字ID才能彻底解决问题。

  Q: 迁移需要多长时间？
  A: 使用token认证（5000次/小时），通常几分钟。建议先运行 --dry-run 预览。

  Q: 如何获取GitHub token？
  A:
  1. GitHub Settings → Developer settings → Personal access tokens
  2. Tokens (classic) → Generate new token
  3. 只需要 public_repo 权限
  4. 设置环境变量：export GITHUB_TOKEN=your_token

  Q: 迁移失败怎么办？
  A:
  1. 查看工具输出的详细错误
  2. 从备份恢复数据库
  3. 排查问题后重新运行
  4. 常见原因：用户名已更改、网络问题、API限制

  Q: 会影响其他OAuth提供商吗？
  A: 不会。本PR只影响GitHub OAuth，Discord、OIDC、Telegram、WeChat等不受影响。

  Q: 迁移过程中用户能登录吗？
  A: 建议低峰期执行，迁移时用户可能无法登录（通常几分钟）。

  Q: 如果已经出现重复账号？
  A: 参考 docs/migrate_github_ids.sql 中的账号合并SQL脚本。

  Q: 支持哪些数据库？
  A: MySQL、PostgreSQL、SQLite。SQL脚本为每种数据库提供了专门的查询语法。

  Q: 速率限制是多少？
  A:
  - 未认证：60次/小时
  - 已认证：5000次/小时
  - 工具会自动检测并显示剩余配额
  ---
  ⚠️ 重要提醒：部署前必须备份数据库并运行迁移工具！

  请审阅并合并此PR，以彻底修复GitHub OAuth的用户数据丢失问题！ 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub authentication now uses numeric user IDs instead of login names for more reliable identity management.

* **Documentation**
  * Added migration guide and utility tool for transitioning existing GitHub-based accounts to numeric IDs, including dry-run capability and concurrent processing support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->