### PR TITLE
feat: task log show username

### DIFF
--- a/model/task.go
+++ b/model/task.go
@@ -57,6 +57,7 @@ type Task struct {
 	FinishTime int64                 `json:"finish_time" gorm:"index"`
 	Progress   string                `json:"progress" gorm:"type:varchar(20);index"`
 	Properties Properties            `json:"properties" gorm:"type:json"`
+	Username   string                `json:"username,omitempty" gorm:"-"`
 	// 禁止返回给用户，内部可能包含key等隐私信息
 	PrivateData TaskPrivateData `json:"-" gorm:"column:private_data;type:json"`
 	Data        json.RawMessage `json:"data" gorm:"type:json"`
@@ -231,6 +232,12 @@ func TaskGetAllTasks(startIdx int, num int, queryParams SyncTaskQueryParams) []*
 	err = query.Order("id desc").Limit(num).Offset(startIdx).Find(&tasks).Error
 	if err != nil {
 		return nil
+	}
+
+	for _, task := range tasks {
+		if cache, err := GetUserCache(task.UserId); err == nil {
+			task.Username = cache.Username
+		}
 	}
 
 	return tasks

--- a/web/src/components/table/task-logs/TaskLogsColumnDefs.jsx
+++ b/web/src/components/table/task-logs/TaskLogsColumnDefs.jsx
@@ -42,6 +42,8 @@ import {
   TASK_ACTION_REMIX_GENERATE,
 } from '../../../constants/common.constant';
 import { CHANNEL_OPTIONS } from '../../../constants/channel.constants';
+import { stringToColor } from '../../../helpers/render';
+import { Avatar, Space } from '@douyinfe/semi-ui';
 
 const colors = [
   'amber',
@@ -285,6 +287,39 @@ export const getTaskLogsColumns = ({
           </div>
         ) : (
           <></>
+        );
+      },
+    },
+    {
+      key: COLUMN_KEYS.USERNAME,
+      title: t('用户'),
+      dataIndex: 'username',
+      render: (text, record, index) => {
+        if (!isAdminUser) {
+          return <></>;
+        }
+        const displayName = record.display_name;
+        const label = displayName || text || t('未知');
+        const avatarText =
+          typeof displayName === 'string' && displayName.length > 0
+            ? displayName[0]
+            : typeof text === 'string' && text.length > 0
+              ? text[0]
+              : '?';
+
+        return (
+          <Space>
+            <Avatar
+              size='extra-small'
+              color={stringToColor(label)}
+              style={{ cursor: 'default' }}
+            >
+              {avatarText}
+            </Avatar>
+            <Typography.Text ellipsis={{ showTooltip: true }}>
+              {label}
+            </Typography.Text>
+          </Space>
         );
       },
     },

--- a/web/src/hooks/task-logs/useTaskLogsData.js
+++ b/web/src/hooks/task-logs/useTaskLogsData.js
@@ -40,6 +40,7 @@ export const useTaskLogsData = () => {
     FINISH_TIME: 'finish_time',
     DURATION: 'duration',
     CHANNEL: 'channel',
+    USERNAME: 'username',
     PLATFORM: 'platform',
     TYPE: 'type',
     TASK_ID: 'task_id',
@@ -104,6 +105,7 @@ export const useTaskLogsData = () => {
         // For non-admin users, force-hide admin-only columns (does not touch admin settings)
         if (!isAdminUser) {
           merged[COLUMN_KEYS.CHANNEL] = false;
+          merged[COLUMN_KEYS.USERNAME] = false;
         }
         setVisibleColumns(merged);
       } catch (e) {
@@ -122,6 +124,7 @@ export const useTaskLogsData = () => {
       [COLUMN_KEYS.FINISH_TIME]: true,
       [COLUMN_KEYS.DURATION]: true,
       [COLUMN_KEYS.CHANNEL]: isAdminUser,
+      [COLUMN_KEYS.USERNAME]: isAdminUser,
       [COLUMN_KEYS.PLATFORM]: true,
       [COLUMN_KEYS.TYPE]: true,
       [COLUMN_KEYS.TASK_ID]: true,
@@ -151,7 +154,10 @@ export const useTaskLogsData = () => {
     const updatedColumns = {};
 
     allKeys.forEach((key) => {
-      if (key === COLUMN_KEYS.CHANNEL && !isAdminUser) {
+      if (
+        (key === COLUMN_KEYS.CHANNEL || key === COLUMN_KEYS.USERNAME) &&
+        !isAdminUser
+      ) {
         updatedColumns[key] = false;
       } else {
         updatedColumns[key] = checked;


### PR DESCRIPTION
任务日志显示用户名称
<img width="2916" height="732" alt="image" src="https://github.com/user-attachments/assets/f6b1157a-fdac-455a-8088-360bc6890d37" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin users can now see a username column in the task logs table. The column displays user avatars with initials and shows either the display name or username, providing quick identification of users associated with each task.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->