### PR TITLE
新增阿里千问余额查询功能

### DIFF
--- a/controller/channel-billing-ali.go
+++ b/controller/channel-billing-ali.go
@@ -1,0 +1,107 @@
+package controller
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/model"
+)
+
+type AliQueryAccountBalanceResponse struct {
+	RequestId string `json:"RequestId"`
+	Success   bool   `json:"Success"`
+	Code      string `json:"Code"`
+	Message   string `json:"Message"`
+	Data      struct {
+		AvailableAmount string `json:"AvailableAmount"`
+		Currency        string `json:"Currency"`
+	} `json:"Data"`
+}
+
+func buildAliQueryAccountBalanceURL(accessKeyId, accessKeySecret, regionId string) (string, error) {
+	params := url.Values{
+		"AccessKeyId":      []string{accessKeyId},
+		"Action":           []string{"QueryAccountBalance"},
+		"Format":           []string{"JSON"},
+		"SignatureMethod":  []string{"HMAC-SHA1"},
+		"SignatureVersion": []string{"1.0"},
+		"SignatureNonce":   []string{fmt.Sprintf("%d", time.Now().UnixNano())},
+		"Timestamp":        []string{time.Now().UTC().Format("2006-01-02T15:04:05Z")},
+		"Version":          []string{"2017-12-14"},
+	}
+	if regionId != "" {
+		params.Set("RegionId", regionId)
+	}
+
+	canonicalQuery := params.Encode()
+	stringToSign := "GET&" + url.QueryEscape("/") + "&" + url.QueryEscape(canonicalQuery)
+
+	mac := hmac.New(sha1.New, []byte(accessKeySecret+"&"))
+	_, err := mac.Write([]byte(stringToSign))
+	if err != nil {
+		return "", err
+	}
+	signature := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+
+	params.Set("Signature", signature)
+	finalQuery := params.Encode()
+
+	return "https://business.aliyuncs.com/?" + finalQuery, nil
+}
+
+func splitAliKey(key string) (apiKey, accessKeyId, accessKeySecret, region string, err error) {
+	parts := strings.Split(key, "|")
+	if len(parts) < 3 {
+		err = errors.New("阿里渠道密钥格式应为 apiKey|AccessKeyId|AccessKeySecret")
+		return
+	}
+	apiKey = strings.TrimSpace(parts[0])
+	accessKeyId = strings.TrimSpace(parts[1])
+	accessKeySecret = strings.TrimSpace(parts[2])
+	region = "cn-hangzhou"
+	return
+}
+
+func updateChannelAliBalance(channel *model.Channel) (float64, error) {
+	_, accessKeyId, accessKeySecret, region, err := splitAliKey(channel.Key)
+	if err != nil {
+		return 0, err
+	}
+
+	signedURL, err := buildAliQueryAccountBalanceURL(accessKeyId, accessKeySecret, region)
+	if err != nil {
+		return 0, err
+	}
+
+	body, err := GetResponseBody("GET", signedURL, channel, http.Header{})
+	if err != nil {
+		return 0, err
+	}
+
+	var resp AliQueryAccountBalanceResponse
+	if err = json.Unmarshal(body, &resp); err != nil {
+		return 0, err
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("ali balance query failed: %s %s", resp.Code, resp.Message)
+	}
+	if resp.Data.AvailableAmount == "" {
+		return 0, errors.New("ali balance empty response")
+	}
+
+	balance, err := strconv.ParseFloat(resp.Data.AvailableAmount, 64)
+	if err != nil {
+		return 0, err
+	}
+	channel.UpdateBalance(balance)
+	return balance, nil
+}

--- a/controller/channel-billing.go
+++ b/controller/channel-billing.go
@@ -378,6 +378,8 @@ func updateChannelBalance(channel *model.Channel) (float64, error) {
 		return updateChannelAPI2GPTBalance(channel)
 	case constant.ChannelTypeAIGC2D:
 		return updateChannelAIGC2DBalance(channel)
+	case constant.ChannelTypeAli:
+		return updateChannelAliBalance(channel)
 	case constant.ChannelTypeSiliconFlow:
 		return updateChannelSiliconFlowBalance(channel)
 	case constant.ChannelTypeDeepSeek:

--- a/controller/task_video.go
+++ b/controller/task_video.go
@@ -52,7 +52,7 @@ func updateVideoTaskAll(ctx context.Context, platform constant.TaskPlatform, cha
 	info.ChannelMeta = &relaycommon.ChannelMeta{
 		ChannelBaseUrl: cacheGetChannel.GetBaseURL(),
 	}
-	info.ApiKey = cacheGetChannel.Key
+	info.ApiKey = cacheGetChannel.GetKey()
 	adaptor.Init(info)
 	for _, taskId := range taskIds {
 		if err := updateVideoSingleTask(ctx, adaptor, cacheGetChannel, taskId, taskM); err != nil {
@@ -74,7 +74,7 @@ func updateVideoSingleTask(ctx context.Context, adaptor channel.TaskAdaptor, cha
 		logger.LogError(ctx, fmt.Sprintf("Task %s not found in taskM", taskId))
 		return fmt.Errorf("task %s not found", taskId)
 	}
-	key := channel.Key
+	key := channel.GetKey()
 
 	privateData := task.PrivateData
 	if privateData.Key != "" {

--- a/model/channel.go
+++ b/model/channel.go
@@ -102,10 +102,18 @@ func (channel *Channel) GetKeys() []string {
 	return keys
 }
 
+func (channel *Channel) GetKey() string {
+	if channel.Type == constant.ChannelTypeAli {
+		parts := strings.Split(channel.Key, "|")
+		return strings.TrimSpace(parts[0])
+	}
+	return channel.Key
+}
+
 func (channel *Channel) GetNextEnabledKey() (string, int, *types.NewAPIError) {
 	// If not in multi-key mode, return the original key string directly.
 	if !channel.ChannelInfo.IsMultiKey {
-		return channel.Key, 0, nil
+		return channel.GetKey(), 0, nil
 	}
 
 	// Obtain all keys (split by \n)


### PR DESCRIPTION
因为阿里的大模型apiKey并不具备余额查询权限
余额查询的查询在阿里更高一层的账号权限中, 需要将AccessKeyId和AccessKeySecret也填入渠道的key字段中
即格式为: `apiKey|AccessKeyId|AccessKeySecret`
警告: 请不要给AccessKey过高的权限, 阿里云的最佳实践是分配一个RAM用户, 使用RAM的子账号创建AccessKey, 并且AccessKey的权限只需要给余额的查询权限:`[AliyunBSSReadOnlyAccess](https://ram.console.aliyun.com/policies/detail?policyType=System&policyName=AliyunBSSReadOnlyAccess)`
见截图: <img width="1158" height="518" alt="image" src="https://github.com/user-attachments/assets/589b7d01-449b-4227-a34c-af98aa8e47d0" />

调用效果:
<img width="2286" height="738" alt="image" src="https://github.com/user-attachments/assets/037cab59-9f12-4617-9a43-9e03e9164873" />


