### PR TITLE
feat(openai): strip account-bound reasoning from Responses input

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -135,6 +135,8 @@ func initConstantEnv() {
 	constant.ErrorLogEnabled = GetEnvOrDefaultBool("ERROR_LOG_ENABLED", false)
 	// 任务轮询时查询的最大数量
 	constant.TaskQueryLimit = GetEnvOrDefault("TASK_QUERY_LIMIT", 1000)
+	// 是否移除 Responses API 输入中的 reasoning 相关项（用于多账户轮询场景）
+	constant.RemoveResponsesReasoningInput = GetEnvOrDefaultBool("REMOVE_RESPONSES_REASONING_INPUT", false)
 
 	soraPatchStr := GetEnvOrDefaultString("TASK_PRICE_PATCH", "")
 	if soraPatchStr != "" {

--- a/constant/env.go
+++ b/constant/env.go
@@ -17,6 +17,7 @@ var NotificationLimitDurationMinute int
 var GenerateDefaultToken bool
 var ErrorLogEnabled bool
 var TaskQueryLimit int
+var RemoveResponsesReasoningInput bool
 
 // temporary variable for sora patch, will be removed in future
 var TaskPricePatches []string

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -570,6 +570,12 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 		}
 		request.Model = originModel
 	}
+
+	// 移除 input 中的 reasoning 相关项（用于多账户轮询场景）
+	if constant.RemoveResponsesReasoningInput {
+		request.RemoveReasoningFromInput()
+	}
+
 	return request, nil
 }
 


### PR DESCRIPTION
### PR 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

本 PR 旨在移除 Responses API 请求 `input` 中与账号/会话绑定的 `reasoning*` 项，避免在多账户轮询（如 Azure 多账号）时因切
换账号导致请求失败或异常。

> 常见报错：status_code=400, Item with id 'rs_xxxxxxx' not found.

实现要点：
- 新增环境变量 `REMOVE_RESPONSES_REASONING_INPUT`（默认 `false`）。
- 开关开启时，在转发 OpenAI Responses 请求前过滤 `input` 数组里 `type` 以 `reasoning` 开头的条目。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added environment configuration option to remove reasoning-related input from OpenAI responses (disabled by default)
* Reasoning filtering now applies automatically during request processing when the option is enabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->