### PR TITLE
feat: claude support parse file

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -356,9 +356,10 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 					claudeMediaMessage := dto.ClaudeMediaMessage{
 						Type: mediaMessage.Type,
 					}
-					if mediaMessage.Type == "text" {
+					switch mediaMessage.Type {
+					case dto.ContentTypeText:
 						claudeMediaMessage.Text = common.GetPointer[string](mediaMessage.Text)
-					} else {
+					case dto.ContentTypeImageURL:
 						imageUrl := mediaMessage.GetImageMedia()
 						claudeMediaMessage.Type = "image"
 						claudeMediaMessage.Source = &dto.ClaudeMessageSource{
@@ -381,8 +382,27 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 							claudeMediaMessage.Source.MediaType = "image/" + format
 							claudeMediaMessage.Source.Data = base64String
 						}
+						claudeMediaMessages = append(claudeMediaMessages, claudeMediaMessage)
+					case dto.ContentTypeFile:
+						file := mediaMessage.GetFile()
+						if file == nil {
+							return nil, fmt.Errorf("file content is missing data")
+						}
+						mimeType, base64String, err := service.DecodeBase64FileData(file.FileData)
+						if err != nil {
+							return nil, fmt.Errorf("decode file data failed: %w", err)
+						}
+						claudeMediaMessages = append(claudeMediaMessages, dto.ClaudeMediaMessage{
+							Type: "document",
+							Source: &dto.ClaudeMessageSource{
+								Type:      "base64",
+								MediaType: mimeType,
+								Data:      base64String,
+							},
+						})
+					default:
+						return nil, fmt.Errorf("unsupported content type '%s' for Claude", mediaMessage.Type)
 					}
-					claudeMediaMessages = append(claudeMediaMessages, claudeMediaMessage)
 				}
 				if message.ToolCalls != nil {
 					for _, toolCall := range message.ParseToolCalls() {


### PR DESCRIPTION
1. openai接口支持claude 理解 文件功能
2. 修复传文件时报空指针错误
请求: 
```
curl http://localhost:30001/v1/chat/completions \
  --request POST \
  --header 'Authorization: xxx' \
  --header 'Content-Type: application/json' \
  --data '{
  "model": "claude-sonnet-4-5-20250929",
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "type": "file",
          "file": {
            "filename": "clinx.pdf",
            "file_data": "data:application/pdf;base64,JVBERi0xLjMKJbrfrOAKMy..."
          }
        },
        {
          "type": "text",
          "text": "请总结这份文件的主要内容"
        }
      ]
    }
  ],
  "max_tokens": 400
}'
```
之前,会报错: 
```
[SYS] 2026/01/15 - 11:58:14 | panic detected: runtime error: invalid memory address or nil pointer dereference 
[SYS] 2026/01/15 - 11:58:14 | 202601151157038431820003enZMAC4 | [STAICK] 500
    relay/channel/claude/relay-claude.go:368 relay/channel/claude.RequestOpenAI2ClaudeMessage
```
修复后, 会正常理解文件
<img width="2770" height="1256" alt="image" src="https://github.com/user-attachments/assets/c13f2bb9-d51d-40ab-a3e7-35f1a516a13e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive file attachment and document upload support to Claude integration, enabling users to share and process files within conversations with automatic encoding.

* **Bug Fixes**
  * Improved error handling with explicit validation for supported content types and clearer error messages for unsupported formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->