### PR TITLE
fix: video content api Priority use url field

### DIFF
--- a/controller/video_proxy.go
+++ b/controller/video_proxy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/service"
+	"github.com/samber/lo"
 
 	"github.com/gin-gonic/gin"
 )
@@ -134,8 +135,7 @@ func VideoProxy(c *gin.Context) {
 		videoURL = fmt.Sprintf("%s/v1/videos/%s/content", baseURL, task.TaskID)
 		req.Header.Set("Authorization", "Bearer "+channel.Key)
 	default:
-		// Video URL is directly in task.FailReason
-		videoURL = task.FailReason
+		videoURL = lo.Ternary(task.Url != "", task.Url, task.FailReason)
 	}
 
 	req.URL, err = url.Parse(videoURL)


### PR DESCRIPTION
openAI下载视频接口优先使用url字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video URL resolution in the proxy service to ensure proper video selection when URLs are explicitly provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->