### PR TITLE
fix request pass-through aws channels can't test

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -332,7 +332,7 @@ func testChannel(channel *model.Channel, testModel string, endpointType string) 
 	}
 
 	requestBody := bytes.NewBuffer(jsonData)
-	c.Request.Body = io.NopCloser(requestBody)
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(jsonData))
 	resp, err := adaptor.DoRequest(c, info, requestBody)
 	if err != nil {
 		return testResult{


### PR DESCRIPTION
common.GetRequestBody(c) read body is null

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved request body handling in test scenarios to better isolate test data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->