### PR TITLE
feat: 即梦视频支持按秒计费

### DIFF
--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -158,6 +158,12 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.
 		}
 	}
 
+	// build body
+	requestBody, err := adaptor.BuildRequestBody(c, info)
+	if err != nil {
+		taskErr = service.TaskErrorWrapper(err, "build_request_failed", http.StatusInternalServerError)
+		return
+	}
 	// 预扣
 	groupRatio := ratio_setting.GetGroupRatio(info.UsingGroup)
 	var ratio float64
@@ -189,12 +195,6 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.
 		return
 	}
 
-	// build body
-	requestBody, err := adaptor.BuildRequestBody(c, info)
-	if err != nil {
-		taskErr = service.TaskErrorWrapper(err, "build_request_failed", http.StatusInternalServerError)
-		return
-	}
 	// do request
 	resp, err := adaptor.DoRequest(c, info, requestBody)
 	if err != nil {


### PR DESCRIPTION
1.  支持按即梦视频参数frames或openai标准seconds按秒计费
2.  将计费逻辑移到构造请求体之后, 以支持时长放在厂商透传的参数内的情况
注意:  更新后需要把即梦模型的单次计费改为每秒的价格
官方文档: https://www.volcengine.com/docs/85621/1792702?lang=zh
<img width="1640" height="228" alt="image" src="https://github.com/user-attachments/assets/92b7c7db-fd43-450b-a84f-91413a3e72c1" />

计费文档: 
<img width="1452" height="652" alt="image" src="https://github.com/user-attachments/assets/14a5078f-6670-49e7-b26c-214bcfc6c1ca" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced billing validation for frame-based and seconds-based inputs to ensure accurate pricing calculations and prevent invalid configurations.

* **Refactor**
  * Optimized request processing order for improved billing accuracy and consistency in pricing data handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->