### PR TITLE
feat: task pre consume modelPrice default use setting value

### DIFF
--- a/relay/relay_task.go
+++ b/relay/relay_task.go
@@ -144,7 +144,7 @@ func RelayTaskSubmit(c *gin.Context, info *relaycommon.RelayInfo) (taskErr *dto.
 	if !success {
 		defaultPrice, ok := ratio_setting.GetDefaultModelPriceMap()[modelName]
 		if !ok {
-			modelPrice = 0.1
+			modelPrice = float64(common.PreConsumedQuota) / common.QuotaPerUnit
 		} else {
 			modelPrice = defaultPrice
 		}


### PR DESCRIPTION
任务预扣费默认取后台设置的`请求预扣费额度`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined fallback pricing calculation for relay tasks to dynamically compute prices based on quota metrics instead of using fixed default values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->