### PR TITLE
fix: correct token usage conversion between Claude and OpenAI formats

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -597,7 +597,7 @@ func FormatClaudeResponseInfo(requestMode int, claudeResponse *dto.ClaudeRespons
 			claudeInfo.Model = claudeResponse.Message.Model
 
 			// message_start, 获取usage
-			claudeInfo.Usage.PromptTokens = claudeResponse.Message.Usage.InputTokens
+			claudeInfo.Usage.PromptTokens = claudeResponse.Message.Usage.InputTokens + claudeResponse.Message.Usage.CacheReadInputTokens
 			claudeInfo.Usage.PromptTokensDetails.CachedTokens = claudeResponse.Message.Usage.CacheReadInputTokens
 			claudeInfo.Usage.PromptTokensDetails.CachedCreationTokens = claudeResponse.Message.Usage.CacheCreationInputTokens
 			claudeInfo.Usage.ClaudeCacheCreation5mTokens = claudeResponse.Message.Usage.GetCacheCreation5mTokens()
@@ -612,9 +612,9 @@ func FormatClaudeResponseInfo(requestMode int, claudeResponse *dto.ClaudeRespons
 			}
 		} else if claudeResponse.Type == "message_delta" {
 			// 最终的usage获取
-			if claudeResponse.Usage.InputTokens > 0 {
+			if claudeResponse.Usage.InputTokens > 0 || claudeResponse.Usage.CacheReadInputTokens > 0 {
 				// 不叠加，只取最新的
-				claudeInfo.Usage.PromptTokens = claudeResponse.Usage.InputTokens
+				claudeInfo.Usage.PromptTokens = claudeResponse.Usage.InputTokens + claudeResponse.Usage.CacheReadInputTokens
 			}
 			claudeInfo.Usage.CompletionTokens = claudeResponse.Usage.OutputTokens
 			claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
@@ -738,9 +738,9 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 	if requestMode == RequestModeCompletion {
 		claudeInfo.Usage = service.ResponseText2Usage(c, claudeResponse.Completion, info.UpstreamModelName, info.GetEstimatePromptTokens())
 	} else {
-		claudeInfo.Usage.PromptTokens = claudeResponse.Usage.InputTokens
+		claudeInfo.Usage.PromptTokens = claudeResponse.Usage.InputTokens + claudeResponse.Usage.CacheReadInputTokens
 		claudeInfo.Usage.CompletionTokens = claudeResponse.Usage.OutputTokens
-		claudeInfo.Usage.TotalTokens = claudeResponse.Usage.InputTokens + claudeResponse.Usage.OutputTokens
+		claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
 		claudeInfo.Usage.PromptTokensDetails.CachedTokens = claudeResponse.Usage.CacheReadInputTokens
 		claudeInfo.Usage.PromptTokensDetails.CachedCreationTokens = claudeResponse.Usage.CacheCreationInputTokens
 		claudeInfo.Usage.ClaudeCacheCreation5mTokens = claudeResponse.Usage.GetCacheCreation5mTokens()

--- a/service/convert.go
+++ b/service/convert.go
@@ -319,7 +319,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type: "message_delta",
 					Usage: &dto.ClaudeUsage{
-						InputTokens:              oaiUsage.PromptTokens,
+						InputTokens:              oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedTokens,
 						OutputTokens:             oaiUsage.CompletionTokens,
 						CacheCreationInputTokens: oaiUsage.PromptTokensDetails.CachedCreationTokens,
 						CacheReadInputTokens:     oaiUsage.PromptTokensDetails.CachedTokens,
@@ -347,7 +347,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type: "message_delta",
 					Usage: &dto.ClaudeUsage{
-						InputTokens:              oaiUsage.PromptTokens,
+						InputTokens:              oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedTokens,
 						OutputTokens:             oaiUsage.CompletionTokens,
 						CacheCreationInputTokens: oaiUsage.PromptTokensDetails.CachedCreationTokens,
 						CacheReadInputTokens:     oaiUsage.PromptTokensDetails.CachedTokens,
@@ -476,7 +476,7 @@ func StreamResponseOpenAI2Claude(openAIResponse *dto.ChatCompletionsStreamRespon
 				claudeResponses = append(claudeResponses, &dto.ClaudeResponse{
 					Type: "message_delta",
 					Usage: &dto.ClaudeUsage{
-						InputTokens:              oaiUsage.PromptTokens,
+						InputTokens:              oaiUsage.PromptTokens - oaiUsage.PromptTokensDetails.CachedTokens,
 						OutputTokens:             oaiUsage.CompletionTokens,
 						CacheCreationInputTokens: oaiUsage.PromptTokensDetails.CachedCreationTokens,
 						CacheReadInputTokens:     oaiUsage.PromptTokensDetails.CachedTokens,
@@ -532,8 +532,9 @@ func ResponseOpenAI2Claude(openAIResponse *dto.OpenAITextResponse, info *relayco
 	claudeResponse.Content = contents
 	claudeResponse.StopReason = stopReason
 	claudeResponse.Usage = &dto.ClaudeUsage{
-		InputTokens:  openAIResponse.PromptTokens,
-		OutputTokens: openAIResponse.CompletionTokens,
+		InputTokens:          openAIResponse.PromptTokens - openAIResponse.PromptTokensDetails.CachedTokens,
+		OutputTokens:         openAIResponse.CompletionTokens,
+		CacheReadInputTokens: openAIResponse.PromptTokensDetails.CachedTokens,
 	}
 
 	return claudeResponse


### PR DESCRIPTION
## 问题描述
Claude API 的 `input_tokens` 不包含缓存命中的 tokens，而 OpenAI API 的 `prompt_tokens` 包含缓存 tokens。
当前代码直接将两者等同，导致格式转换时 usage 数据错误。

## 修复内容
1. **Claude→OpenAI**（[relay-claude.go](/relay/channel/claude/relay-claude.go)）：
   `PromptTokens = InputTokens + CacheReadInputTokens`
2. **OpenAI→Claude**（[convert.go](/service/convert.go)）：
   `InputTokens = PromptTokens - CachedTokens`

## 相关PR
https://github.com/QuantumNous/new-api/pull/2477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token usage accounting to accurately reflect cached input tokens in API response metrics and usage reports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->