### PR TITLE
修复钱包页面刷新时显示错误余额数据的问题

### DIFF
--- a/web/src/components/topup/index.jsx
+++ b/web/src/components/topup/index.jsx
@@ -465,9 +465,8 @@ const TopUp = () => {
   };
 
   useEffect(() => {
-    if (!userState?.user?.id) {
-      getUserQuota().then();
-    }
+    // 始终获取最新用户数据，确保余额等统计信息准确
+    getUserQuota().then();
     setTransferAmount(getQuotaPerUnit());
   }, []);
 


### PR DESCRIPTION
问题现象
在钱包管理页面刷新时，账户的统计数据（当前余额、历史消耗、请求次数）会短暂显示错误的数值或 NaN，随后才恢复正常。

原因分析 
TopUp 组件的 useEffect 逻辑中存在优化判断：当检测到 userState?.user?.id 存在时会跳过 getUserQuota() 的 API 调用。 然而，页面刷新时 PageLayout 会优先从 localStorage 加载缓存的用户信息，这份缓存数据往往是过期的或缺少 quota 等动态字段，导致页面渲染了错误的数据。

解决方案
移除了 useEffect 中的条件判断，强制组件在挂载时始终调用 getUserQuota()，确保无论本地缓存状态如何，都能获取并显示最新的用户配额信息。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the top-up feature to reliably refresh user quota and balance information on component load, ensuring users always see current and accurate account details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->