### PR TITLE
feat: doubao add first and last image to video

### DIFF
--- a/relay/channel/task/doubao/adaptor.go
+++ b/relay/channel/task/doubao/adaptor.go
@@ -30,6 +30,7 @@ type ContentItem struct {
 	Text     string          `json:"text,omitempty"`      // for text type
 	ImageURL *ImageURL       `json:"image_url,omitempty"` // for image_url type
 	Video    *VideoReference `json:"video,omitempty"`     // for video (sample) type
+	Role     string          `json:"role,omitempty"`      // reference_image / first_frame / last_frame
 }
 
 type ImageURL struct {


### PR DESCRIPTION
豆包视频支持首尾帧生视频, 增加role字段
文档: https://www.volcengine.com/docs/82379/1520757
<img width="1314" height="996" alt="image" src="https://github.com/user-attachments/assets/dacd64e1-1223-4bda-b458-08433f1518c3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced content items with role identification to better handle different media types (e.g., reference images, first frame, last frame).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->