### PR TITLE
任务轮询最大时长支持配置,默认24h

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -146,6 +146,13 @@ func initConstantEnv() {
 	constant.ErrorLogEnabled = GetEnvOrDefaultBool("ERROR_LOG_ENABLED", false)
 	// 任务轮询时查询的最大数量
 	constant.TaskQueryLimit = GetEnvOrDefault("TASK_QUERY_LIMIT", 1000)
+	// 任务轮询查询最大时长
+	maxQueryDuration := GetEnvOrDefaultString("TASK_MAX_QUERY_DURATION", "24h")
+	if duration, err := time.ParseDuration(maxQueryDuration); err == nil {
+		constant.TaskMaxQueryDuration = duration
+	} else {
+		constant.TaskMaxQueryDuration = 24 * time.Hour
+	}
 
 	soraPatchStr := GetEnvOrDefaultString("TASK_PRICE_PATCH", "")
 	if soraPatchStr != "" {

--- a/constant/env.go
+++ b/constant/env.go
@@ -1,5 +1,7 @@
 package constant
 
+import "time"
+
 var StreamingTimeout int
 var DifyDebug bool
 var MaxFileDownloadMB int
@@ -17,6 +19,7 @@ var NotificationLimitDurationMinute int
 var GenerateDefaultToken bool
 var ErrorLogEnabled bool
 var TaskQueryLimit int
+var TaskMaxQueryDuration time.Duration
 
 // temporary variable for sora patch, will be removed in future
 var TaskPricePatches []string


### PR DESCRIPTION
增加TASK_MAX_QUERY_DURATION参数限制任务轮询最大长度,默认24h
可通过设置环境变量 TASK_MAX_QUERY_DURATION=24h 修改最大时长

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for configurable maximum query duration for unfinished sync tasks with a default 24-hour limit. Can be customized via environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->