### PR TITLE
feat(gemini): map OpenAI stop to Gemini stopSequences

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -217,6 +217,13 @@ func CovertOpenAI2Gemini(c *gin.Context, textRequest dto.GeneralOpenAIRequest, i
 			"IMAGE",
 		}
 	}
+	if stopSequences := parseStopSequences(textRequest.Stop); len(stopSequences) > 0 {
+		// Gemini supports up to 5 stop sequences
+		if len(stopSequences) > 5 {
+			stopSequences = stopSequences[:5]
+		}
+		geminiRequest.GenerationConfig.StopSequences = stopSequences
+	}
 
 	adaptorWithExtraBody := false
 
@@ -629,6 +636,31 @@ func CovertOpenAI2Gemini(c *gin.Context, textRequest dto.GeneralOpenAIRequest, i
 	}
 
 	return &geminiRequest, nil
+}
+
+// parseStopSequences 解析停止序列，支持字符串或字符串数组
+func parseStopSequences(stop any) []string {
+	if stop == nil {
+		return nil
+	}
+
+	switch v := stop.(type) {
+	case string:
+		if v != "" {
+			return []string{v}
+		}
+	case []string:
+		return v
+	case []interface{}:
+		sequences := make([]string, 0, len(v))
+		for _, item := range v {
+			if str, ok := item.(string); ok && str != "" {
+				sequences = append(sequences, str)
+			}
+		}
+		return sequences
+	}
+	return nil
 }
 
 func hasFunctionCallContent(call *dto.FunctionCall) bool {


### PR DESCRIPTION
### PR 类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述
close https://github.com/QuantumNous/new-api/issues/2777
<img width="1237" height="1046" alt="image" src="https://github.com/user-attachments/assets/10157168-eb89-426e-b13d-441cf3b74dc9" />

将 OpenAI 的 stop 参数转换为 Gemini 的 stopSequences，确保停止序列在 Gemini 渠道生效。

实现细节：

- 在 OpenAI → Gemini 转换中解析 stop（支持 string/array）。
- 按 Gemini 规范最多保留 5 个 stopSequences。
- 新增通用解析函数以复用逻辑。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stop sequence support for Gemini API requests with flexible input handling
  * Stop sequences are automatically capped at 5 to comply with Gemini API specifications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->