### PR TITLE
fix(vertex): convert Claude format to Gemini when RequestMode is Gemini

### DIFF
--- a/relay/channel/vertex/adaptor.go
+++ b/relay/channel/vertex/adaptor.go
@@ -90,6 +90,13 @@ func removeFunctionResponseID(request *dto.GeminiChatRequest) {
 }
 
 func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.ClaudeRequest) (any, error) {
+	// If target model is Gemini, convert Claude format to Gemini format
+	if a.RequestMode == RequestModeGemini {
+		geminiAdaptor := gemini.Adaptor{}
+		return geminiAdaptor.ConvertClaudeRequest(c, info, request)
+	}
+
+	// Original logic: for Claude models on Vertex AI
 	if v, ok := claudeModelMap[info.UpstreamModelName]; ok {
 		c.Set("request_model", v)
 	} else {


### PR DESCRIPTION
## Problem

When using Vertex AI with model redirection from Claude model names to Gemini models, /v1/messages requests failed with 400 error because ConvertClaudeRequest always returned Claude format regardless of RequestMode.

## Solution

Added check for RequestModeGemini in ConvertClaudeRequest to delegate to Gemini adaptor's ConvertClaudeRequest method. This follows the same pattern already used in ConvertOpenAIRequest.

## Changes

- relay/channel/vertex/adaptor.go: +7 lines

## Testing

- go vet: Pass
- Local testing with Docker: Vertex AI + Claude format to Gemini redirection works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized request routing for improved handling between Claude and Gemini models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->