### PR TITLE
fix: make channel Host override take effect

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -98,6 +98,19 @@ func processHeaderOverride(info *common.RelayInfo, c *gin.Context) (map[string]s
 	return headerOverride, nil
 }
 
+func applyHeaderOverrideToRequest(req *http.Request, headerOverride map[string]string) {
+	if req == nil {
+		return
+	}
+	for key, value := range headerOverride {
+		req.Header.Set(key, value)
+		// set Host in req
+		if strings.EqualFold(key, "Host") {
+			req.Host = value
+		}
+	}
+}
+
 func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody io.Reader) (*http.Response, error) {
 	fullRequestURL, err := a.GetRequestURL(info)
 	if err != nil {
@@ -121,9 +134,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range headerOverride {
-		headers.Set(key, value)
-	}
+	applyHeaderOverrideToRequest(req, headerOverride)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)
@@ -156,9 +167,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	if err != nil {
 		return nil, err
 	}
-	for key, value := range headerOverride {
-		headers.Set(key, value)
-	}
+	applyHeaderOverrideToRequest(req, headerOverride)
 	resp, err := doRequest(c, req, info)
 	if err != nil {
 		return nil, fmt.Errorf("do request failed: %w", err)


### PR DESCRIPTION
fix #2795 
# test：
设置 Host
<img width="1427" height="387" alt="image" src="https://github.com/user-attachments/assets/9ffceeb2-a6e2-41b8-83d6-32b9311e121c" />

## in
<img width="3031" height="1517" alt="Screenshot_20260202_144345" src="https://github.com/user-attachments/assets/15f5e507-08b6-4b31-bd2f-abbbf060b391" />

## out

<img width="2467" height="1157" alt="Screenshot_20260202_144850" src="https://github.com/user-attachments/assets/d1333529-a2cc-4468-8292-690573204fe0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host header overrides are now properly applied to API requests with correct priority handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->