### PR TITLE
fix: 移除不必要的 unescapeMapOrSlice 调用，修复 Windows 路径转义问题

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -988,11 +988,9 @@ func unescapeMapOrSlice(data interface{}) interface{} {
 func getResponseToolCall(item *dto.GeminiPart) *dto.ToolCallResponse {
 	var argsBytes []byte
 	var err error
-	if result, ok := item.FunctionCall.Arguments.(map[string]interface{}); ok {
-		argsBytes, err = json.Marshal(unescapeMapOrSlice(result))
-	} else {
-		argsBytes, err = json.Marshal(item.FunctionCall.Arguments)
-	}
+	// 移除 unescapeMapOrSlice 调用，直接使用 json.Marshal
+	// JSON 序列化/反序列化已经正确处理了转义字符
+	argsBytes, err = json.Marshal(item.FunctionCall.Arguments)
 
 	if err != nil {
 		return nil


### PR DESCRIPTION
## 问题描述

修复 Windows 路径中包含转义字符（如 \"\t\", \"\n\", \"\b\", \"\f\" 等）时被错误转义的问题。

当使用 Gemini 模型时，如果用户发送的消息包含 Windows 路径如 



路径中的 \"\t\" 会被错误地转换为制表符，导致 AI 处理错误。

## 修复内容

- 移除了 \"getResponseToolCall\" 函数中对 \"unescapeMapOrSlice\" 的不必要调用
- JSON 序列化/反序列化已经正确处理了转义字符，无需额外处理

## 测试验证

已本地测试验证：路径中的转义字符现在能正确保持为字面量，不会被错误转义。

## 关联 Issue

fixes #1620