### PR TITLE
🐛 fix: sidebar scroll on mobile dynamic viewport

### DIFF
--- a/web/src/components/layout/PageLayout.jsx
+++ b/web/src/components/layout/PageLayout.jsx
@@ -121,8 +121,8 @@ const PageLayout = () => {
 
   return (
     <Layout
+      className='app-layout'
       style={{
-        height: '100vh',
         display: 'flex',
         flexDirection: 'column',
         overflow: isMobile ? 'visible' : 'hidden',
@@ -153,6 +153,7 @@ const PageLayout = () => {
       >
         {showSider && (
           <Sider
+            className='app-sider'
             style={{
               position: 'fixed',
               left: 0,
@@ -160,7 +161,6 @@ const PageLayout = () => {
               zIndex: 99,
               border: 'none',
               paddingRight: '0',
-              height: 'calc(100vh - 64px)',
               width: 'var(--sidebar-current-width)',
             }}
           >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -31,6 +31,16 @@ body {
   background-color: var(--semi-color-bg-0);
 }
 
+.app-layout {
+  height: 100vh;
+  height: 100dvh;
+}
+
+.app-sider {
+  height: calc(100vh - 64px);
+  height: calc(100dvh - 64px);
+}
+
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
@@ -107,6 +117,7 @@ code {
   height: 100%;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   transition: width 0.3s ease;
   background: var(--semi-color-bg-0);
 }
@@ -116,9 +127,11 @@ code {
   width: 100%;
   background: var(--semi-color-bg-0);
   height: 100%;
-  overflow: hidden;
+  overflow-x: hidden;
   border-right: none;
   overflow-y: auto;
+  min-height: 0;
+  -webkit-overflow-scrolling: touch;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }


### PR DESCRIPTION
Use dynamic viewport height to prevent sidebar scroll lock in mobile browsers Harden sidebar scroll container with min-height and momentum scrolling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout styling with improved viewport height handling for better responsiveness
  * Improved scrolling behavior in sidebar and code block areas
  * Added touch scrolling support for enhanced mobile experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->