### PR TITLE
修复 Codex(OpenAI OAuth) 渠道 endpoint 找不到问题

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -113,6 +113,15 @@ func testChannel(channel *model.Channel, testModel string, endpointType string) 
 		if strings.HasSuffix(testModel, ratio_setting.CompactModelSuffix) {
 			requestPath = "/v1/responses/compact"
 		}
+
+		// Codex channel only supports responses endpoints.
+		if channel.Type == constant.ChannelTypeCodex {
+			if strings.HasSuffix(testModel, ratio_setting.CompactModelSuffix) {
+				requestPath = "/v1/responses/compact"
+			} else {
+				requestPath = "/v1/responses"
+			}
+		}
 	}
 	if strings.HasPrefix(requestPath, "/v1/responses/compact") {
 		testModel = ratio_setting.WithCompactModelSuffix(testModel)
@@ -559,6 +568,14 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel)
 		return &dto.OpenAIResponsesCompactionRequest{
 			Model: model,
 			Input: testResponsesInput,
+		}
+	}
+
+	// Codex channel only supports responses endpoints.
+	if channel != nil && channel.Type == constant.ChannelTypeCodex {
+		return &dto.OpenAIResponsesRequest{
+			Model: model,
+			Input: json.RawMessage(`[{"role":"user","content":"hi"}]`),
 		}
 	}
 

--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -96,6 +96,14 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 		request.Instructions = json.RawMessage(`""`)
 	}
 
+	// Codex backend requires streaming; force stream when unset.
+	if !request.Stream {
+		request.Stream = true
+		if info != nil {
+			info.IsStream = true
+		}
+	}
+
 	if isCompact {
 		return request, nil
 	}


### PR DESCRIPTION
在使用 Codex (OpenAI OAuth) 登陆时如果上游不支持 chat complations API 会导致报错找不到 endpoint，但是 Codex 上游是一定支持 responses api 的，所以把用于验证的借口换成 responses api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex channel endpoint routing to properly direct requests to responses endpoints based on model type.
  * Enabled streaming mode enforcement for Codex backend processing to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->