### PR TITLE
修复 Codex(OpenAI OAuth) 渠道 endpoint 找不到问题

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -105,7 +105,8 @@ func testChannel(channel *model.Channel, testModel string, endpointType string) 
 		}
 
 		// responses-only models
-		if strings.Contains(strings.ToLower(testModel), "codex") {
+		if strings.Contains(strings.ToLower(testModel), "codex") ||
+			strings.Contains(strings.ToLower(testModel), "gpt") {
 			requestPath = "/v1/responses"
 		}
 


### PR DESCRIPTION
在使用 Codex (OpenAI OAuth) 登陆时如果上游不支持 chat complations API 会导致报错找不到 endpoint，但是 Codex 上游是一定支持 responses api 的，所以对名称包含 gpt 的测试模型的验证接口改成 responses api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded model support to include additional AI models with correct endpoint routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->