### PR TITLE
feat: Force beta=true parameter for Anthropic channel

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -27,6 +27,7 @@ type ChannelOtherSettings struct {
 	AzureResponsesVersion string        `json:"azure_responses_version,omitempty"`
 	VertexKeyType         VertexKeyType `json:"vertex_key_type,omitempty"` // "json" or "api_key"
 	OpenRouterEnterprise  *bool         `json:"openrouter_enterprise,omitempty"`
+	ClaudeBetaQuery       bool          `json:"claude_beta_query,omitempty"`      // Claude 渠道是否强制追加 ?beta=true
 	AllowServiceTier      bool          `json:"allow_service_tier,omitempty"`      // 是否允许 service_tier 透传（默认过滤以避免额外计费）
 	DisableStore          bool          `json:"disable_store,omitempty"`           // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）
 	AllowSafetyIdentifier bool          `json:"allow_safety_identifier,omitempty"` // 是否允许 safety_identifier 透传（默认过滤以保护用户隐私）

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -316,10 +316,13 @@ func GenRelayInfoClaude(c *gin.Context, request dto.Request) *RelayInfo {
 	info.ClaudeConvertInfo = &ClaudeConvertInfo{
 		LastMessagesType: LastMessageTypeNone,
 	}
-	if c.Query("beta") == "true" {
-		info.IsClaudeBetaQuery = true
-	}
+	info.IsClaudeBetaQuery = c.Query("beta") == "true" || isClaudeBetaForced(c)
 	return info
+}
+
+func isClaudeBetaForced(c *gin.Context) bool {
+	channelOtherSettings, ok := common.GetContextKeyType[dto.ChannelOtherSettings](c, constant.ContextKeyChannelOtherSetting)
+	return ok && channelOtherSettings.ClaudeBetaQuery
 }
 
 func GenRelayInfoRerank(c *gin.Context, request *dto.RerankRequest) *RelayInfo {

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -170,6 +170,7 @@ const EditChannelModal = (props) => {
     allow_service_tier: false,
     disable_store: false, // false = 允许透传（默认开启）
     allow_safety_identifier: false,
+    claude_beta_query: false,
   };
   const [batch, setBatch] = useState(false);
   const [multiToSingle, setMultiToSingle] = useState(false);
@@ -633,6 +634,7 @@ const EditChannelModal = (props) => {
           data.disable_store = parsedSettings.disable_store || false;
           data.allow_safety_identifier =
             parsedSettings.allow_safety_identifier || false;
+          data.claude_beta_query = parsedSettings.claude_beta_query || false;
         } catch (error) {
           console.error('解析其他设置失败:', error);
           data.azure_responses_version = '';
@@ -643,6 +645,7 @@ const EditChannelModal = (props) => {
           data.allow_service_tier = false;
           data.disable_store = false;
           data.allow_safety_identifier = false;
+          data.claude_beta_query = false;
         }
       } else {
         // 兼容历史数据：老渠道没有 settings 时，默认按 json 展示
@@ -652,6 +655,7 @@ const EditChannelModal = (props) => {
         data.allow_service_tier = false;
         data.disable_store = false;
         data.allow_safety_identifier = false;
+        data.claude_beta_query = false;
       }
 
       if (
@@ -1394,6 +1398,9 @@ const EditChannelModal = (props) => {
         settings.allow_safety_identifier =
           localInputs.allow_safety_identifier === true;
       }
+      if (localInputs.type === 14) {
+        settings.claude_beta_query = localInputs.claude_beta_query === true;
+      }
     }
 
     localInputs.settings = JSON.stringify(settings);
@@ -1414,6 +1421,7 @@ const EditChannelModal = (props) => {
     delete localInputs.allow_service_tier;
     delete localInputs.disable_store;
     delete localInputs.allow_safety_identifier;
+    delete localInputs.claude_beta_query;
 
     let res;
     localInputs.auto_ban = localInputs.auto_ban ? 1 : 0;
@@ -3304,6 +3312,24 @@ const EditChannelModal = (props) => {
                         </Text>
                       </div>
                     </div>
+
+                    {inputs.type === 14 && (
+                      <Form.Switch
+                        field='claude_beta_query'
+                        label={t('Claude 强制 beta=true')}
+                        checkedText={t('开')}
+                        uncheckedText={t('关')}
+                        onChange={(value) =>
+                          handleChannelOtherSettingsChange(
+                            'claude_beta_query',
+                            value,
+                          )
+                        }
+                        extraText={t(
+                          '开启后，该渠道请求 Claude 时将强制追加 ?beta=true（无需客户端手动传参）',
+                        )}
+                      />
+                    )}
 
                     {inputs.type === 1 && (
                       <Form.Switch


### PR DESCRIPTION
## WHY
部分 Claude 中转商对请求路径有策略差异，需要显式携带 ?beta=true 才能放行，目前 new-api 缺少按渠道强制 beta query 的配置能力，因此在渠道配置种提供可控开关，在管理后台可配置是否强制追加 ?beta=true。

## WHAT
1) 后端支持渠道配置中指定 beta=true
- 在 ChannelOtherSettings 新增字段：claude_beta_query: boolean
- Claude Relay 判定逻辑更新：请求携带 beta=true 或 渠道配置 claude_beta_query=true 时，启用 IsClaudeBetaQuery
2) 前端管理页新增配置开关
- 在渠道编辑页（Claude 渠道），“渠道额外设置”部分新增开关：
  - Claude 强制 beta=true
- 语义上将该开关放在“渠道额外设置”区域，避免与“字段透传控制”混淆。

## 测试与验证
已完成以下验证，功能通过：
1. 后端构建与测试
- go test ./relay/common ./dto 通过  
- go build ./... 通过
2. 前端构建
- bun run build 通过（生成 web/dist）
3. 功能验证
- Claude 渠道开启 Claude 强制 beta=true 后，即使客户端不传 ?beta=true，请求也能按预期走 beta query 链路；
- 保持向后兼容：客户端显式传 ?beta=true 仍生效；
- 未开启开关的渠道行为不变。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Claude beta query toggle to Claude channel configuration settings
  * New setting in the channel modal to enable forced beta mode for Claude API requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->