### PR TITLE
feat: openrouter provider

### DIFF
--- a/dto/claude.go
+++ b/dto/claude.go
@@ -218,6 +218,11 @@ type ClaudeRequest struct {
 	ServiceTier string `json:"service_tier,omitempty"`
 }
 
+// OutputConfigForEffort extracts effort from output_config.
+type OutputConfigForEffort struct {
+	Effort string `json:"effort,omitempty"`
+}
+
 // createClaudeFileSource 根据数据内容创建正确类型的 FileSource
 func createClaudeFileSource(data string) *types.FileSource {
 	if strings.HasPrefix(data, "http://") || strings.HasPrefix(data, "https://") {
@@ -407,6 +412,14 @@ func (c *ClaudeRequest) GetTools() []any {
 	default:
 		return nil
 	}
+}
+
+func (c *ClaudeRequest) GetEfforts() string {
+	var outputConfig OutputConfigForEffort
+	if err := common.Unmarshal(c.OutputConfig, &outputConfig); err == nil {
+		return outputConfig.Effort
+	}
+	return ""
 }
 
 // ProcessTools 处理工具列表，支持类型断言

--- a/dto/openrouter.go
+++ b/dto/openrouter.go
@@ -3,6 +3,7 @@ package dto
 import "encoding/json"
 
 type OpenRouterRequestReasoning struct {
+	Enabled   bool   `json:"enabled"`
 	Effort    string `json:"effort,omitempty"`
 	MaxTokens int    `json:"max_tokens,omitempty"`
 	Exclude   bool   `json:"exclude,omitempty"`

--- a/relay/channel/openrouter/adaptor.go
+++ b/relay/channel/openrouter/adaptor.go
@@ -166,7 +166,10 @@ func (a *Adaptor) ConvertOpenAIRequest(_ *gin.Context, info *relaycommon.RelayIn
 				return nil, fmt.Errorf("BudgetTokens is nil when thinking is enabled")
 			}
 
-			reasoning := dto.OpenRouterRequestReasoning{MaxTokens: *thinking.BudgetTokens}
+			reasoning := dto.OpenRouterRequestReasoning{
+				Enabled:   true,
+				MaxTokens: *thinking.BudgetTokens,
+			}
 			marshal, err := common.Marshal(reasoning)
 			if err != nil {
 				return nil, fmt.Errorf("error marshalling reasoning: %w", err)

--- a/service/convert.go
+++ b/service/convert.go
@@ -33,22 +33,40 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 	isOpenRouter := info.ChannelType == constant.ChannelTypeOpenRouter
 
-	if claudeRequest.Thinking != nil && claudeRequest.Thinking.Type == "enabled" {
-		if isOpenRouter {
-			reasoning := dto.OpenRouterRequestReasoning{
-				MaxTokens: claudeRequest.Thinking.GetBudgetTokens(),
-			}
-			reasoningJSON, err := json.Marshal(reasoning)
+	if isOpenRouter {
+		if effort := claudeRequest.GetEfforts(); effort != "" {
+			effortBytes, err := json.Marshal(effort)
 			if err != nil {
-				return nil, fmt.Errorf("failed to marshal reasoning: %w", err)
+				return nil, fmt.Errorf("failed to marshal verbosity: %w", err)
 			}
-			openAIRequest.Reasoning = reasoningJSON
-		} else {
-			thinkingSuffix := "-thinking"
-			if strings.HasSuffix(info.OriginModelName, thinkingSuffix) &&
-				!strings.HasSuffix(openAIRequest.Model, thinkingSuffix) {
-				openAIRequest.Model = openAIRequest.Model + thinkingSuffix
+			openAIRequest.Verbosity = effortBytes
+		}
+		if claudeRequest.Thinking != nil {
+			var reasoning *dto.OpenRouterRequestReasoning
+			switch claudeRequest.Thinking.Type {
+			case "enabled":
+				reasoning = &dto.OpenRouterRequestReasoning{
+					Enabled:   true,
+					MaxTokens: claudeRequest.Thinking.GetBudgetTokens(),
+				}
+			case "adaptive":
+				reasoning = &dto.OpenRouterRequestReasoning{
+					Enabled: true,
+				}
 			}
+			if reasoning != nil {
+				reasoningJSON, err := json.Marshal(reasoning)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal reasoning: %w", err)
+				}
+				openAIRequest.Reasoning = reasoningJSON
+			}
+		}
+	} else {
+		thinkingSuffix := "-thinking"
+		if strings.HasSuffix(info.OriginModelName, thinkingSuffix) &&
+			!strings.HasSuffix(openAIRequest.Model, thinkingSuffix) {
+			openAIRequest.Model = openAIRequest.Model + thinkingSuffix
 		}
 	}
 


### PR DESCRIPTION
独立openrouter provider，支持原生 /v1/messages
#2822 
暂时不合并，根据 #2791 反馈，OpenRouter的claude计费usage和官方不一致，需要进一步确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Complete OpenRouter channel integration with comprehensive request/response handling.
  * Enhanced reasoning and thinking capabilities for Claude models with configurable effort levels.

* **Refactor**
  * Reorganized internal data structures for OpenRouter integration for improved consistency and maintainability.
  * Improved pointer-based field handling across channel adapters for more robust data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->