### PR TITLE
fix(token-search): use TrimPrefix for sk- token normalization

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -113,7 +113,7 @@ func SearchUserTokens(userId int, keyword string, token string, offset int, limi
 	}
 
 	if token != "" {
-		token = strings.Trim(token, "sk-")
+		token = strings.TrimPrefix(token, "sk-")
 	}
 
 	// 超量用户（令牌数超过上限）只允许精确搜索，禁止模糊搜索


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

修复后端 token 搜索逻辑中的字符串处理问题。

在 `SearchUserTokens` 中，原先使用 `strings.Trim(token, "sk-")` 对输入做处理，该方法会移除首尾所有属于 `s` / `k` /
`-` 的字符，可能错误修改 token 内容，导致搜索匹配失败。
本 PR 改为 `strings.TrimPrefix(token, "sk-")`，仅去除预期的 `sk-` 前缀，避免误删字符，恢复 token 搜索的正确性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed token normalization to exclusively remove the "sk-" prefix from the beginning of tokens, replacing the previous approach of trimming any 's', 'k', or '-' characters from either end. Token searching and matching may behave differently for affected tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->