### PR TITLE
fix: robust responses created_at parsing + multi-value header override with preserved channel-test semantics

### DIFF
--- a/dto/openai_response_test.go
+++ b/dto/openai_response_test.go
@@ -1,0 +1,69 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlexibleUnixTimestamp_UnmarshalValid(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		payload  string
+		expected FlexibleUnixTimestamp
+	}{
+		{
+			name:     "integer",
+			payload:  `{"created_at":1730000000}`,
+			expected: 1730000000,
+		},
+		{
+			name:     "quoted_integer",
+			payload:  `{"created_at":"1730000001"}`,
+			expected: 1730000001,
+		},
+		{
+			name:     "float_scientific_notation",
+			payload:  `{"created_at":1.730000002e+09}`,
+			expected: 1730000002,
+		},
+		{
+			name:     "quoted_float_scientific_notation",
+			payload:  `{"created_at":"1.730000003e+09"}`,
+			expected: 1730000003,
+		},
+		{
+			name:     "null",
+			payload:  `{"created_at":null}`,
+			expected: 0,
+		},
+		{
+			name:     "empty_quoted_value",
+			payload:  `{"created_at":""}`,
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var resp OpenAIResponsesResponse
+			err := common.Unmarshal([]byte(tc.payload), &resp)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, resp.CreatedAt)
+		})
+	}
+}
+
+func TestFlexibleUnixTimestamp_UnmarshalInvalid(t *testing.T) {
+	t.Parallel()
+
+	var resp OpenAIResponsesResponse
+	err := common.Unmarshal([]byte(`{"created_at":"not-a-timestamp"}`), &resp)
+	require.Error(t, err)
+}

--- a/relay/channel/api_request_test.go
+++ b/relay/channel/api_request_test.go
@@ -77,5 +77,5 @@ func TestProcessHeaderOverride_NonTestKeepsClientHeaderPlaceholder(t *testing.T)
 
 	headers, err := processHeaderOverride(info, ctx)
 	require.NoError(t, err)
-	require.Equal(t, "trace-123", headers["X-Upstream-Trace"])
+	require.Equal(t, "trace-123", headers.Get("X-Upstream-Trace"))
 }


### PR DESCRIPTION
## Background / Problem
This change addresses two concrete issues:

1. Upstream `/v1/responses` returns `created_at` in inconsistent formats (integer, string, float, scientific notation). Using a strict `int` caused response unmarshal failures.
2. After refactoring header override to `http.Header`, we need to ensure both:
   - Multi-value headers are preserved and applied consistently for HTTP and WSS.
   - Existing `IsChannelTest` behavior is unchanged (channel tests should still skip passthrough rules and `{client_header:*}` placeholders).

## Code Changes
### 1) Robust `created_at` parsing (fixes unmarshal failures)
- File: `dto/openai_response.go`
- Added `FlexibleUnixTimestamp` to accept:
  - Integer: `1730000000`
  - Quoted integer: `"1730000000"`
  - Float/scientific notation: `1.73e+09` / `"1.73e+09"`
  - `null` / empty string (treated as `0`)
- Changed `OpenAIResponsesResponse.CreatedAt` from `int` to `FlexibleUnixTimestamp`.

### 2) Multi-value header override support (while preserving channel-test semantics)
- File: `relay/channel/api_request.go`
- `processHeaderOverride` now returns `http.Header`, and passthrough preserves multiple values instead of only taking one.
- Added `applyHeaderOverrideToHeader` for shared header application in HTTP requests and WSS dial headers.
- Explicit override still takes precedence over passthrough (`Set` overwrites same key).
- Preserved previous behavior:
  - `IsChannelTest=true`: do not parse passthrough rules.
  - `IsChannelTest=true`: skip `{client_header:*}` placeholder overrides.

### 3) Tests added/updated
- File: `dto/openai_response_test.go`
  - Added regression tests for `FlexibleUnixTimestamp` (valid and invalid inputs).
- File: `relay/channel/api_request_test.go`
  - Updated assertions to `headers.Get(...)` to match `http.Header` type.

## Reproducible Input Examples
### A) `/v1/responses` `created_at` parsing
Input example from upstream:
```json
{
  "id": "resp_123",
  "object": "response",
  "created_at": 1.730000002e+09,
  "status": "completed",
  "model": "gpt-4.1",
  "output": []
}
```
Before:
- Unmarshal could fail when `created_at` was not a plain integer.

After:
- `created_at` is accepted and normalized to unix seconds (`1730000002`).

### B) Header passthrough with multi-value incoming headers
Incoming request headers:
```http
X-Trace-Id: trace-a
X-Trace-Id: trace-b
Authorization: Bearer user-token
```
Channel header override config:
```json
{
  "*": "",
  "X-Upstream-Trace": "{client_header:X-Trace-Id}",
  "Authorization": "Bearer {api_key}"
}
```
Before:
- Only one header value could be kept in map-based override.

After:
- Multi-value passthrough is preserved via `http.Header`.
- Explicit `Authorization` override still wins over passthrough.
- In channel test mode, passthrough and `{client_header:*}` are still skipped (unchanged behavior).

## Behavior Impact
- This is a **bug fix + compatibility hardening**, not a new product feature.
- External behavior change: `created_at` now accepts more upstream formats and avoids parse failures.
- Existing channel-test header semantics remain unchanged.

## Validation
- `go test ./relay/channel -count=1`
- `go test ./dto -count=1`
- `go test ./... -count=1`
