### PR TITLE
feat: 令牌多分组优先级选择

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -19,6 +19,10 @@ const (
 	ContextKeyTokenModelLimitEnabled ContextKey = "token_model_limit_enabled"
 	ContextKeyTokenModelLimit        ContextKey = "token_model_limit"
 	ContextKeyTokenCrossGroupRetry   ContextKey = "token_cross_group_retry"
+	// ContextKeyTokenOrderedGroups 存储多分组令牌的有序 GroupPriority 列表。
+	ContextKeyTokenOrderedGroups ContextKey = "token_ordered_groups"
+	// ContextKeyTokenModelMergeMode 存储多分组令牌的模型合并模式（"union" 或 "intersection"）。
+	ContextKeyTokenModelMergeMode ContextKey = "token_model_merge_mode"
 
 	/* channel related keys */
 	ContextKeyChannelId                ContextKey = "channel_id"

--- a/controller/token.go
+++ b/controller/token.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GetAllTokens 返回当前用户的所有令牌列表。
 func GetAllTokens(c *gin.Context) {
 	userId := c.GetInt("id")
 	pageInfo := common.GetPageQuery(c)
@@ -29,6 +30,7 @@ func GetAllTokens(c *gin.Context) {
 	return
 }
 
+// SearchTokens 根据关键字搜索当前用户的令牌。
 func SearchTokens(c *gin.Context) {
 	userId := c.GetInt("id")
 	keyword := c.Query("keyword")
@@ -137,6 +139,7 @@ func GetTokenUsage(c *gin.Context) {
 	})
 }
 
+// AddToken 处理为已认证用户创建新的 API 令牌。
 func AddToken(c *gin.Context) {
 	token := model.Token{}
 	err := c.ShouldBindJSON(&token)
@@ -194,6 +197,7 @@ func AddToken(c *gin.Context) {
 		AllowIps:           token.AllowIps,
 		Group:              token.Group,
 		CrossGroupRetry:    token.CrossGroupRetry,
+		ModelMergeMode:     token.ModelMergeMode,
 	}
 	err = cleanToken.Insert()
 	if err != nil {
@@ -222,6 +226,7 @@ func DeleteToken(c *gin.Context) {
 	return
 }
 
+// UpdateToken 处理更新已有 API 令牌的配置。
 func UpdateToken(c *gin.Context) {
 	userId := c.GetInt("id")
 	statusOnly := c.Query("status_only")
@@ -274,6 +279,7 @@ func UpdateToken(c *gin.Context) {
 		cleanToken.AllowIps = token.AllowIps
 		cleanToken.Group = token.Group
 		cleanToken.CrossGroupRetry = token.CrossGroupRetry
+		cleanToken.ModelMergeMode = token.ModelMergeMode
 	}
 	err = cleanToken.Update()
 	if err != nil {

--- a/web/src/components/table/tokens/TokensColumnDefs.jsx
+++ b/web/src/components/table/tokens/TokensColumnDefs.jsx
@@ -104,6 +104,63 @@ const renderGroupColumn = (text, record, t) => {
       </Tooltip>
     );
   }
+  // Handle multi-group JSON array
+  if (text && typeof text === 'string' && text.trim().startsWith('[')) {
+    try {
+      const groups = JSON.parse(text);
+      groups.sort((a, b) => a.priority - b.priority);
+      const circledNumbers = '\u2460\u2461\u2462\u2463\u2464\u2465\u2466\u2467\u2468\u2469';
+      const MAX_SHOW = 1;
+      const visibleGroups = groups.slice(0, MAX_SHOW);
+      const hiddenGroups = groups.slice(MAX_SHOW);
+
+      const renderTag = (item, idx) => (
+        <Tag
+          key={item.group}
+          color={stringToColor(item.group)}
+          shape='circle'
+          size='small'
+          style={{ marginRight: 2, marginBottom: 2 }}
+        >
+          {circledNumbers[idx] || (idx + 1)}{item.group}
+        </Tag>
+      );
+
+      return (
+        <span style={{ display: 'inline-flex', alignItems: 'center', flexWrap: 'wrap' }}>
+          {visibleGroups.map((item, idx) => renderTag(item, idx))}
+          {hiddenGroups.length > 0 && (
+            <Popover
+              content={
+                <div style={{ padding: '4px 0', maxWidth: 300 }}>
+                  <div style={{ marginBottom: 4, fontSize: 12, color: 'var(--semi-color-text-2)' }}>
+                    {t('多分组优先级模式，按优先级顺序依次尝试')}
+                  </div>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+                    {groups.map((item, idx) => renderTag(item, idx))}
+                  </div>
+                </div>
+              }
+              position='bottomLeft'
+              trigger='click'
+              showArrow
+            >
+              <Tag
+                color='grey'
+                shape='circle'
+                size='small'
+                style={{ marginRight: 2, cursor: 'pointer' }}
+              >
+                +{hiddenGroups.length} ▾
+              </Tag>
+            </Popover>
+          )}
+        </span>
+      );
+    } catch {
+      // Fall through to renderGroup
+    }
+  }
   return renderGroup(text);
 };
 


### PR DESCRIPTION
支持令牌绑定多个分组并设置优先级顺序，当高优先级分组渠道失败时自动降级到下一个分组。

- 新增 GroupPriority 结构体和多分组解析/编码函数
- 令牌支持 ModelMergeMode 字段（并集/交集模式）
- middleware/auth.go 支持多分组令牌验证和 context 设置
- service/channel_select.go 新增 cacheGetChannelForOrderedGroups 按优先级分组重试
- controller/relay.go 多分组失败时聚合所有分组错误信息
- controller/model.go ListModels 支持多分组 union/intersection
- middleware/distributor.go 显示所有尝试过的分组名
- 前端 EditTokenModal 支持单分组/多分组模式切换、优先级排序、合并模式选择
- 前端令牌列表分组列支持折叠显示+Popover 展开

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-group token support with ordered priorities and selectable model-merge mode (union/intersection).
  * Token management UI: reorderable multi-group selector, circled group tags, popover list, and merge-mode controls.
  * New model endpoints: channel model list, dashboard-grouped models, enabled models, and single-model detail.

* **Improvements**
  * Aggregated, clearer error messages across group retries and improved token/context handling for multi-group flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->