### PR TITLE
feat: 自定义错误替换规则（数据库管理）

### DIFF
--- a/controller/custom_error_rule.go
+++ b/controller/custom_error_rule.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-gonic/gin"
+)
+
+// GetCustomErrorRules 返回所有自定义错误替换规则，供管理员管理。
+func GetCustomErrorRules(c *gin.Context) {
+	rules, err := model.GetAllCustomErrorRules()
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+		"data":    rules,
+	})
+}
+
+// CreateCustomErrorRule 处理创建新的自定义错误替换规则。
+func CreateCustomErrorRule(c *gin.Context) {
+	var rule model.CustomErrorRule
+	if err := c.ShouldBindJSON(&rule); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "参数错误: " + err.Error(),
+		})
+		return
+	}
+	if rule.Contains == "" {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "匹配内容不能为空",
+		})
+		return
+	}
+	if err := model.CreateCustomErrorRule(&rule); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+	})
+}
+
+// UpdateCustomErrorRule 处理更新已有的自定义错误替换规则。
+func UpdateCustomErrorRule(c *gin.Context) {
+	var rule model.CustomErrorRule
+	if err := c.ShouldBindJSON(&rule); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "参数错误: " + err.Error(),
+		})
+		return
+	}
+	if rule.Id == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "ID不能为空",
+		})
+		return
+	}
+	if rule.Contains == "" {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "匹配内容不能为空",
+		})
+		return
+	}
+	if err := model.UpdateCustomErrorRule(&rule); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+	})
+}
+
+// DeleteCustomErrorRule 处理根据 ID 删除自定义错误替换规则。
+func DeleteCustomErrorRule(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "无效的ID",
+		})
+		return
+	}
+	if err := model.DeleteCustomErrorRule(id); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": err.Error(),
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+	})
+}

--- a/model/custom_error_rule.go
+++ b/model/custom_error_rule.go
@@ -1,0 +1,169 @@
+package model
+
+import (
+	"sync"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"gorm.io/gorm"
+)
+
+// CustomErrorRule 定义 API 错误消息的匹配和替换规则。
+// 规则缓存在内存中，增删改操作后自动刷新缓存。
+type CustomErrorRule struct {
+	Id          int            `json:"id" gorm:"primaryKey;autoIncrement"`
+	Contains    string         `json:"contains" gorm:"type:varchar(512);not null;default:''"`
+	StatusCode  int            `json:"status_code" gorm:"not null;default:0"`
+	NewMessage  string         `json:"new_message" gorm:"type:varchar(1024);not null;default:''"`
+	Enabled     bool           `json:"enabled" gorm:"not null;default:true"`
+	Priority    int            `json:"priority" gorm:"not null;default:0"`
+	CreatedTime int64          `json:"created_time" gorm:"type:bigint"`
+	UpdatedTime int64          `json:"updated_time" gorm:"type:bigint"`
+	DeletedAt   gorm.DeletedAt `json:"-" gorm:"index"`
+}
+
+// TableName 返回 CustomErrorRule 的数据库表名。
+func (CustomErrorRule) TableName() string {
+	return "custom_error_rules"
+}
+
+// 已启用规则的内存缓存
+var (
+	customErrorRulesCache        []CustomErrorRule
+	customErrorReplacementsCache []common.CustomErrorReplacement
+	customErrorRulesCacheLock    sync.RWMutex
+	customErrorRulesCacheInit    bool
+)
+
+// GetCachedCustomErrorRules 返回缓存中已启用的规则，按优先级排序。
+func GetCachedCustomErrorRules() []CustomErrorRule {
+	customErrorRulesCacheLock.RLock()
+	if customErrorRulesCacheInit {
+		rules := customErrorRulesCache
+		customErrorRulesCacheLock.RUnlock()
+		return rules
+	}
+	customErrorRulesCacheLock.RUnlock()
+
+	// Initialize cache
+	refreshCustomErrorRulesCache()
+
+	customErrorRulesCacheLock.RLock()
+	defer customErrorRulesCacheLock.RUnlock()
+	return customErrorRulesCache
+}
+
+// refreshCustomErrorRulesCache 从数据库重新加载已启用的规则到缓存。
+// 同时构建 []common.CustomErrorReplacement 缓存，避免每次请求重复分配。
+func refreshCustomErrorRulesCache() {
+	var rules []CustomErrorRule
+	err := DB.Where("enabled = ?", true).Order("priority ASC").Find(&rules).Error
+	if err != nil {
+		common.SysLog("failed to load custom error rules: " + err.Error())
+		return
+	}
+
+	replacements := make([]common.CustomErrorReplacement, len(rules))
+	for i, r := range rules {
+		replacements[i] = common.CustomErrorReplacement{
+			Contains:   r.Contains,
+			StatusCode: r.StatusCode,
+			NewMessage: r.NewMessage,
+		}
+	}
+
+	customErrorRulesCacheLock.Lock()
+	defer customErrorRulesCacheLock.Unlock()
+	customErrorRulesCache = rules
+	customErrorReplacementsCache = replacements
+	customErrorRulesCacheInit = true
+}
+
+// GetCachedCustomErrorReplacements 返回缓存中预构建的替换规则列表，避免每次请求重新分配。
+func GetCachedCustomErrorReplacements() []common.CustomErrorReplacement {
+	customErrorRulesCacheLock.RLock()
+	if customErrorRulesCacheInit {
+		result := customErrorReplacementsCache
+		customErrorRulesCacheLock.RUnlock()
+		return result
+	}
+	customErrorRulesCacheLock.RUnlock()
+
+	refreshCustomErrorRulesCache()
+
+	customErrorRulesCacheLock.RLock()
+	defer customErrorRulesCacheLock.RUnlock()
+	return customErrorReplacementsCache
+}
+
+// GetAllCustomErrorRules 返回所有规则（包括已禁用的），供管理员管理使用。
+func GetAllCustomErrorRules() ([]CustomErrorRule, error) {
+	var rules []CustomErrorRule
+	err := DB.Order("priority ASC").Find(&rules).Error
+	return rules, err
+}
+
+// CreateCustomErrorRule 创建新规则并刷新缓存。
+func CreateCustomErrorRule(rule *CustomErrorRule) error {
+	now := time.Now().Unix()
+	rule.CreatedTime = now
+	rule.UpdatedTime = now
+	err := DB.Create(rule).Error
+	if err == nil {
+		refreshCustomErrorRulesCache()
+	}
+	return err
+}
+
+// UpdateCustomErrorRule 更新已有规则并刷新缓存。
+func UpdateCustomErrorRule(rule *CustomErrorRule) error {
+	rule.UpdatedTime = time.Now().Unix()
+	// Use map to ensure zero-value fields like Enabled=false are updated
+	err := DB.Model(&CustomErrorRule{}).Where("id = ?", rule.Id).Updates(map[string]interface{}{
+		"contains":     rule.Contains,
+		"status_code":  rule.StatusCode,
+		"new_message":  rule.NewMessage,
+		"enabled":      rule.Enabled,
+		"priority":     rule.Priority,
+		"updated_time": rule.UpdatedTime,
+	}).Error
+	if err == nil {
+		refreshCustomErrorRulesCache()
+	}
+	return err
+}
+
+// DeleteCustomErrorRule 根据 ID 软删除规则并刷新缓存。
+func DeleteCustomErrorRule(id int) error {
+	err := DB.Delete(&CustomErrorRule{}, id).Error
+	if err == nil {
+		refreshCustomErrorRulesCache()
+	}
+	return err
+}
+
+// InitCustomErrorRulesCache 在启动时初始化缓存。
+// 如果表中无任何记录（包括已软删除的），则插入一条示例规则。
+func InitCustomErrorRulesCache() {
+	var count int64
+	DB.Unscoped().Model(&CustomErrorRule{}).Count(&count)
+	if count == 0 {
+		seedDefaultErrorRules()
+	}
+	refreshCustomErrorRulesCache()
+}
+
+// seedDefaultErrorRules 插入一条示例规则供参考。
+func seedDefaultErrorRules() {
+	now := time.Now().Unix()
+	sample := CustomErrorRule{
+		Contains:    "当前分组上游负载已饱和",
+		StatusCode:  429,
+		NewMessage:  "当前服务繁忙，请稍后重试",
+		Enabled:     true,
+		Priority:    1,
+		CreatedTime: now,
+		UpdatedTime: now,
+	}
+	DB.Create(&sample)
+}

--- a/model/main.go
+++ b/model/main.go
@@ -276,6 +276,7 @@ func migrateDB() error {
 		&SubscriptionPreConsumeRecord{},
 		&CustomOAuthProvider{},
 		&UserOAuthBinding{},
+		&CustomErrorRule{},
 	)
 	if err != nil {
 		return err
@@ -288,6 +289,11 @@ func migrateDB() error {
 		if err := DB.AutoMigrate(&SubscriptionPlan{}); err != nil {
 			return err
 		}
+	}
+	// 初始化自定义错误规则缓存并注册 provider
+	InitCustomErrorRulesCache()
+	common.CustomErrorRulesProvider = func() []common.CustomErrorReplacement {
+		return GetCachedCustomErrorReplacements()
 	}
 	return nil
 }

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -359,5 +359,15 @@ func SetApiRouter(router *gin.Engine) {
 			deploymentsRoute.POST("/:id/extend", controller.ExtendDeployment)
 			deploymentsRoute.DELETE("/:id", controller.DeleteDeployment)
 		}
+
+		// Custom error rule management (admin only)
+		customErrorRuleRoute := apiRouter.Group("/custom_error_rule")
+		customErrorRuleRoute.Use(middleware.RootAuth())
+		{
+			customErrorRuleRoute.GET("/", controller.GetCustomErrorRules)
+			customErrorRuleRoute.POST("/", controller.CreateCustomErrorRule)
+			customErrorRuleRoute.PUT("/", controller.UpdateCustomErrorRule)
+			customErrorRuleRoute.DELETE("/:id", controller.DeleteCustomErrorRule)
+		}
 	}
 }

--- a/types/error.go
+++ b/types/error.go
@@ -204,6 +204,7 @@ func (e *NewAPIError) ToOpenAIError() OpenAIError {
 	if e.errorCode != ErrorCodeCountTokenFailed {
 		result.Message = common.MaskSensitiveInfo(result.Message)
 	}
+	result.Message = common.ReplaceCustomErrorMessage(e.StatusCode, result.Message)
 	if result.Message == "" {
 		result.Message = string(e.errorType)
 	}
@@ -233,6 +234,7 @@ func (e *NewAPIError) ToClaudeError() ClaudeError {
 	if e.errorCode != ErrorCodeCountTokenFailed {
 		result.Message = common.MaskSensitiveInfo(result.Message)
 	}
+	result.Message = common.ReplaceCustomErrorMessage(e.StatusCode, result.Message)
 	if result.Message == "" {
 		result.Message = string(e.errorType)
 	}

--- a/web/src/pages/Setting/Operation/SettingsCustomErrorRules.jsx
+++ b/web/src/pages/Setting/Operation/SettingsCustomErrorRules.jsx
@@ -1,0 +1,330 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+import React, { useState, useEffect, useRef } from 'react';
+import {
+  Button,
+  Table,
+  Tag,
+  Space,
+  Popconfirm,
+  SideSheet,
+  Form,
+  Typography,
+  Switch,
+  Spin,
+  Row,
+  Col,
+} from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+import { API, showError, showSuccess } from '../../../helpers';
+import { useTranslation } from 'react-i18next';
+
+const { Text } = Typography;
+
+export default function SettingsCustomErrorRules() {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+  const [rules, setRules] = useState([]);
+  const [editVisible, setEditVisible] = useState(false);
+  const [editingRule, setEditingRule] = useState(null);
+  const formRef = useRef(null);
+
+  const loadRules = async () => {
+    setLoading(true);
+    try {
+      const res = await API.get('/api/custom_error_rule/');
+      if (res.data.success) {
+        setRules(res.data.data || []);
+      } else {
+        showError(res.data.message || t('获取错误规则失败'));
+      }
+    } catch {
+      showError(t('获取错误规则失败'));
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadRules();
+  }, []);
+
+  const handleDelete = async (id) => {
+    try {
+      const res = await API.delete(`/api/custom_error_rule/${id}`);
+      if (res.data.success) {
+        showSuccess(t('删除成功'));
+        loadRules();
+      } else {
+        showError(res.data.message || t('删除失败'));
+      }
+    } catch {
+      showError(t('删除失败'));
+    }
+  };
+
+  const handleToggleEnabled = async (rule) => {
+    try {
+      const res = await API.put('/api/custom_error_rule/', {
+        ...rule,
+        enabled: !rule.enabled,
+      });
+      if (res.data.success) {
+        loadRules();
+      } else {
+        showError(res.data.message || t('更新失败'));
+      }
+    } catch {
+      showError(t('更新失败'));
+    }
+  };
+
+  const handleEdit = (rule = null) => {
+    setEditingRule(rule);
+    setEditVisible(true);
+  };
+
+  const handleEditClose = () => {
+    setEditVisible(false);
+    setEditingRule(null);
+  };
+
+  const handleSubmit = async (values) => {
+    setLoading(true);
+    try {
+      if (editingRule && editingRule.id) {
+        const res = await API.put('/api/custom_error_rule/', {
+          ...values,
+          id: editingRule.id,
+        });
+        if (res.data.success) {
+          showSuccess(t('更新成功'));
+          handleEditClose();
+          loadRules();
+        } else {
+          showError(res.data.message || t('更新失败'));
+        }
+      } else {
+        const res = await API.post('/api/custom_error_rule/', values);
+        if (res.data.success) {
+          showSuccess(t('创建成功'));
+          handleEditClose();
+          loadRules();
+        } else {
+          showError(res.data.message || t('创建失败'));
+        }
+      }
+    } catch {
+      showError(t('操作失败'));
+    }
+    setLoading(false);
+  };
+
+  const columns = [
+    {
+      title: t('匹配内容'),
+      dataIndex: 'contains',
+      key: 'contains',
+      render: (text) => (
+        <Text ellipsis={{ showTooltip: true }} style={{ maxWidth: 200 }}>
+          {text}
+        </Text>
+      ),
+    },
+    {
+      title: t('状态码'),
+      dataIndex: 'status_code',
+      key: 'status_code',
+      width: 80,
+      render: (val) => (
+        <Tag color={val === 0 ? 'grey' : 'blue'} shape='circle' size='small'>
+          {val === 0 ? t('任意') : val}
+        </Tag>
+      ),
+    },
+    {
+      title: t('替换消息'),
+      dataIndex: 'new_message',
+      key: 'new_message',
+      render: (text) => (
+        <Text ellipsis={{ showTooltip: true }} style={{ maxWidth: 200 }}>
+          {text}
+        </Text>
+      ),
+    },
+    {
+      title: t('优先级'),
+      dataIndex: 'priority',
+      key: 'priority',
+      width: 70,
+    },
+    {
+      title: t('启用'),
+      dataIndex: 'enabled',
+      key: 'enabled',
+      width: 70,
+      render: (val, record) => (
+        <Switch
+          checked={val}
+          size='small'
+          onChange={() => handleToggleEnabled(record)}
+        />
+      ),
+    },
+    {
+      title: '',
+      key: 'action',
+      width: 140,
+      render: (_, record) => (
+        <Space>
+          <Button size='small' onClick={() => handleEdit(record)}>
+            {t('编辑')}
+          </Button>
+          <Popconfirm
+            title={t('确定删除此规则？')}
+            onConfirm={() => handleDelete(record.id)}
+          >
+            <Button size='small' type='danger'>
+              {t('删除')}
+            </Button>
+          </Popconfirm>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Spin spinning={loading}>
+        <Form.Section text={t('自定义错误替换规则')}>
+          <Typography.Text
+            type='tertiary'
+            style={{ marginBottom: 16, display: 'block' }}
+          >
+            {t('当API返回的错误消息包含指定字符串时，将自动替换为自定义消息')}
+          </Typography.Text>
+          <div className='flex justify-end mb-2'>
+            <Button
+              type='primary'
+              theme='solid'
+              size='small'
+              icon={<IconPlus />}
+              onClick={() => handleEdit()}
+            >
+              {t('新增规则')}
+            </Button>
+          </div>
+          <Table
+            columns={columns}
+            dataSource={rules}
+            rowKey='id'
+            pagination={false}
+            size='small'
+            empty={t('暂无自定义错误规则')}
+          />
+        </Form.Section>
+      </Spin>
+
+      <SideSheet
+        title={editingRule?.id ? t('编辑错误规则') : t('新增错误规则')}
+        visible={editVisible}
+        onCancel={handleEditClose}
+        width={450}
+      >
+        <Form
+          key={editingRule?.id ?? 'new'}
+          getFormApi={(api) => (formRef.current = api)}
+          initValues={
+            editingRule
+              ? {
+                  contains: editingRule.contains,
+                  status_code: editingRule.status_code,
+                  new_message: editingRule.new_message,
+                  priority: editingRule.priority,
+                  enabled: editingRule.enabled,
+                }
+              : {
+                  contains: '',
+                  status_code: 0,
+                  new_message: '',
+                  priority: 0,
+                  enabled: true,
+                }
+          }
+          onSubmit={handleSubmit}
+        >
+          <Row gutter={12}>
+            <Col span={24}>
+              <Form.TextArea
+                field='contains'
+                label={t('匹配内容')}
+                placeholder={t('错误消息中包含此字符串时触发替换')}
+                rules={[{ required: true, message: t('请输入匹配内容') }]}
+                rows={2}
+              />
+            </Col>
+            <Col span={12}>
+              <Form.InputNumber
+                field='status_code'
+                label={t('状态码')}
+                placeholder={t('0表示不限')}
+                min={0}
+                max={599}
+              />
+            </Col>
+            <Col span={12}>
+              <Form.InputNumber
+                field='priority'
+                label={t('优先级')}
+                placeholder={t('数字越小优先级越高')}
+                min={0}
+              />
+            </Col>
+            <Col span={24}>
+              <Form.TextArea
+                field='new_message'
+                label={t('替换消息')}
+                placeholder={t('替换后展示给用户的消息')}
+                rules={[{ required: true, message: t('请输入替换消息') }]}
+                rows={2}
+              />
+            </Col>
+            <Col span={24}>
+              <Form.Switch
+                field='enabled'
+                label={t('启用')}
+                size='default'
+              />
+            </Col>
+            <Col span={24}>
+              <Button
+                theme='solid'
+                type='primary'
+                htmlType='submit'
+                loading={loading}
+              >
+                {t('提交')}
+              </Button>
+            </Col>
+          </Row>
+        </Form>
+      </SideSheet>
+    </>
+  );
+}


### PR DESCRIPTION
支持通过后台管理界面增删改查错误消息替换规则，取代硬编码方式。

- 新增 CustomErrorRule 模型，带内存缓存和自动刷新
- 新增 CRUD 接口 /api/custom_error_rule/（管理员权限）
- common/str.go 新增 CustomErrorRulesProvider 和 ReplaceCustomErrorMessage
- types/error.go 在 ToOpenAIError/ToClaudeError 中调用替换逻辑
- model/main.go 启动时初始化缓存并注册 Provider
- 首次启动时自动插入一条示例规则
- 新增前端管理页面 SettingsCustomErrorRules.jsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Administrators can define priority-based custom error message replacements (match text, optional status code, replacement message, enabled/disabled).
  * New admin UI to list, create, edit, toggle, and delete custom error rules with immediate effect.
  * Error messages shown to users are now automatically transformed according to configured rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->