### PR TITLE
feat: 分组群功能（用户端 API + 前端快捷填充）

### DIFF
--- a/controller/group_cluster.go
+++ b/controller/group_cluster.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-gonic/gin"
+)
+
+// GetGroupClusters 返回所有类型为 'group_cluster' 的预填充分组，供用户端令牌创建时快捷选择。
+func GetGroupClusters(c *gin.Context) {
+	groups, err := model.GetAllPrefillGroups("group_cluster")
+	if err != nil {
+		common.SysError("failed to get group clusters: " + err.Error())
+		c.JSON(http.StatusOK, gin.H{
+			"success": false,
+			"message": "获取分组群失败，请稍后重试",
+		})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+		"data":    groups,
+	})
+}

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -68,6 +68,7 @@ func SetApiRouter(router *gin.Engine) {
 			selfRoute.Use(middleware.UserAuth())
 			{
 				selfRoute.GET("/self/groups", controller.GetUserGroups)
+				selfRoute.GET("/self/group_clusters", controller.GetGroupClusters)
 				selfRoute.GET("/self", controller.GetSelf)
 				selfRoute.GET("/models", controller.GetUserModels)
 				selfRoute.PUT("/self", controller.UpdateSelf)


### PR DESCRIPTION
新增分组群（Group Clusters）功能，允许管理员预定义分组组合，用户创建令牌时可一键填充。

- 新增 controller/group_cluster.go 用户端接口，返回 type='group_cluster' 的预填组
- router/api-router.go 新增 GET /api/user/self/group_clusters 路由
- EditTokenModal.jsx 加载分组群数据，显示快捷填充按钮
- 悬浮显示分组群包含的分组列表

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token editor: added a "group clusters" quick-fill — browse clusters, hover to view details, and apply a cluster to populate the group field with one click.
  * Backend support: API added so the UI can load available group clusters asynchronously for the quick-fill feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->