### PR TITLE
feat: add max top-up amount limit for Epay and Stripe

### DIFF
--- a/controller/topup.go
+++ b/controller/topup.go
@@ -56,7 +56,7 @@ func GetTopUpInfo(c *gin.Context) {
 		"creem_products":      setting.CreemProducts,
 		"pay_methods":         payMethods,
 		"min_topup":           operation_setting.MinTopUp,
-		"max_topup":           operation_setting.MaxTopUp,
+		"max_topup":           operation_setting.GetPaymentSetting().MaxTopUp,
 		"stripe_min_topup":    setting.StripeMinTopUp,
 		"stripe_max_topup":    setting.StripeMaxTopUp,
 		"amount_options":      operation_setting.GetPaymentSetting().AmountOptions,
@@ -129,7 +129,7 @@ func getMinTopup() int64 {
 }
 
 func getMaxTopup() int64 {
-	maxTopup := operation_setting.MaxTopUp
+	maxTopup := operation_setting.GetPaymentSetting().MaxTopUp
 	if maxTopup <= 0 {
 		return 0
 	}

--- a/model/option.go
+++ b/model/option.go
@@ -79,7 +79,7 @@ func InitOptionMap() {
 	common.OptionMap["Price"] = strconv.FormatFloat(operation_setting.Price, 'f', -1, 64)
 	common.OptionMap["USDExchangeRate"] = strconv.FormatFloat(operation_setting.USDExchangeRate, 'f', -1, 64)
 	common.OptionMap["MinTopUp"] = strconv.Itoa(operation_setting.MinTopUp)
-	common.OptionMap["MaxTopUp"] = strconv.Itoa(operation_setting.MaxTopUp)
+	common.OptionMap["MaxTopUp"] = strconv.Itoa(operation_setting.GetPaymentSetting().MaxTopUp)
 	common.OptionMap["StripeMinTopUp"] = strconv.Itoa(setting.StripeMinTopUp)
 	common.OptionMap["StripeMaxTopUp"] = strconv.Itoa(setting.StripeMaxTopUp)
 	common.OptionMap["StripeApiSecret"] = setting.StripeApiSecret
@@ -341,7 +341,8 @@ func updateOptionMap(key string, value string) (err error) {
 	case "MinTopUp":
 		operation_setting.MinTopUp, _ = strconv.Atoi(value)
 	case "MaxTopUp":
-		operation_setting.MaxTopUp, _ = strconv.Atoi(value)
+		val, _ := strconv.Atoi(value)
+		operation_setting.GetPaymentSetting().MaxTopUp = val
 	case "StripeApiSecret":
 		setting.StripeApiSecret = value
 	case "StripeWebhookSecret":

--- a/setting/operation_setting/payment_setting.go
+++ b/setting/operation_setting/payment_setting.go
@@ -5,12 +5,14 @@ import "github.com/QuantumNous/new-api/setting/config"
 type PaymentSetting struct {
 	AmountOptions  []int           `json:"amount_options"`
 	AmountDiscount map[int]float64 `json:"amount_discount"` // 充值金额对应的折扣，例如 100 元 0.9 表示 100 元充值享受 9 折优惠
+	MaxTopUp       int             `json:"max_topup"`       // 0 means no limit
 }
 
 // 默认配置
 var paymentSetting = PaymentSetting{
 	AmountOptions:  []int{10, 20, 50, 100, 200, 500},
 	AmountDiscount: map[int]float64{},
+	MaxTopUp:       0,
 }
 
 func init() {

--- a/setting/operation_setting/payment_setting_old.go
+++ b/setting/operation_setting/payment_setting_old.go
@@ -15,7 +15,6 @@ var EpayId = ""
 var EpayKey = ""
 var Price = 7.3
 var MinTopUp = 1
-var MaxTopUp = 0 // 0 means no limit
 var USDExchangeRate = 7.3
 
 var PayMethods = []map[string]string{

--- a/web/src/components/topup/index.jsx
+++ b/web/src/components/topup/index.jsx
@@ -176,6 +176,10 @@ const TopUp = () => {
         showError(t('充值数量不能小于') + minTopUp);
         return;
       }
+      if (maxTopUp > 0 && topUpCount > maxTopUp) {
+        showError(t('充值数量不能大于') + ' ' + renderQuotaWithAmount(maxTopUp));
+        return;
+      }
       setOpen(true);
     } catch (error) {
       showError(t('获取金额失败'));
@@ -199,6 +203,10 @@ const TopUp = () => {
 
     if (topUpCount < minTopUp) {
       showError(t('充值数量不能小于') + minTopUp);
+      return;
+    }
+    if (maxTopUp > 0 && topUpCount > maxTopUp) {
+      showError(t('充值数量不能大于') + ' ' + renderQuotaWithAmount(maxTopUp));
       return;
     }
     setConfirmLoading(true);

--- a/web/src/pages/Setting/Payment/SettingsPaymentGateway.jsx
+++ b/web/src/pages/Setting/Payment/SettingsPaymentGateway.jsx
@@ -143,6 +143,13 @@ export default function SettingsPaymentGateway(props) {
       }
     }
 
+    if (inputs.MaxTopUp !== '' && inputs.MaxTopUp !== undefined) {
+      if (inputs.MaxTopUp > 0 && inputs.MaxTopUp < inputs.MinTopUp) {
+        showError(t('最高充值数量不能小于最低充值数量'));
+        return;
+      }
+    }
+
     setLoading(true);
     try {
       const options = [
@@ -162,10 +169,6 @@ export default function SettingsPaymentGateway(props) {
         options.push({ key: 'MinTopUp', value: inputs.MinTopUp.toString() });
       }
       if (inputs.MaxTopUp !== '' && inputs.MaxTopUp !== undefined) {
-        if (inputs.MaxTopUp > 0 && inputs.MaxTopUp < inputs.MinTopUp) {
-          showError(t('最高充值数量不能小于最低充值数量'));
-          return;
-        }
         options.push({ key: 'MaxTopUp', value: inputs.MaxTopUp.toString() });
       }
       if (inputs.CustomCallbackAddress !== '') {

--- a/web/src/pages/Setting/Payment/SettingsPaymentGatewayStripe.jsx
+++ b/web/src/pages/Setting/Payment/SettingsPaymentGatewayStripe.jsx
@@ -90,6 +90,16 @@ export default function SettingsPaymentGateway(props) {
       return;
     }
 
+    if (
+      inputs.StripeMaxTopUp !== undefined &&
+      inputs.StripeMaxTopUp !== null &&
+      inputs.StripeMaxTopUp > 0 &&
+      inputs.StripeMaxTopUp < inputs.StripeMinTopUp
+    ) {
+      showError(t('最高充值数量不能小于最低充值数量'));
+      return;
+    }
+
     setLoading(true);
     try {
       const options = [];
@@ -128,10 +138,6 @@ export default function SettingsPaymentGateway(props) {
         inputs.StripeMaxTopUp !== undefined &&
         inputs.StripeMaxTopUp !== null
       ) {
-        if (inputs.StripeMaxTopUp > 0 && inputs.StripeMaxTopUp < inputs.StripeMinTopUp) {
-          showError(t('最高充值数量不能小于最低充值数量'));
-          return;
-        }
         options.push({
           key: 'StripeMaxTopUp',
           value: inputs.StripeMaxTopUp.toString(),


### PR DESCRIPTION
## Summary
- Add configurable maximum top-up amount for both Epay and Stripe payment gateways to prevent users from intentionally placing orders with excessive amounts
- **This is an optional feature**: MaxTopUp defaults to 0 (no limit), admins can configure it in payment settings if needed
- Backend validation with i18n error messages (en, zh-CN, zh-TW)
- Frontend: inline warning + disable payment buttons when exceeded, skip redundant API calls



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum top-up limits with UI controls for general and Stripe-specific settings.
  * Frontend enforces and displays max/min top-up bounds and disables payment options when limits are exceeded.
  * API now surfaces max top-up values so the UI can reflect limits.

* **Internationalization**
  * Added localized validation messages for top-up minimum/maximum in multiple languages (en, fr, ja, ru, vi, zh-CN, zh-TW).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->