### PR TITLE
feat: add global API video rate limit

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -160,6 +160,7 @@ var (
 var (
 	GlobalApiRateLimitEnable   bool
 	GlobalApiRateLimitNum      int
+	GlobalApiVideoRateLimitNum int
 	GlobalApiRateLimitDuration int64
 
 	GlobalWebRateLimitEnable   bool

--- a/common/init.go
+++ b/common/init.go
@@ -111,6 +111,7 @@ func InitEnv() {
 	// Initialize rate limit variables
 	GlobalApiRateLimitEnable = GetEnvOrDefaultBool("GLOBAL_API_RATE_LIMIT_ENABLE", true)
 	GlobalApiRateLimitNum = GetEnvOrDefault("GLOBAL_API_RATE_LIMIT", 180)
+	GlobalApiVideoRateLimitNum = GetEnvOrDefault("GLOBAL_API_VIDEO_RATE_LIMIT", GlobalApiRateLimitNum)
 	GlobalApiRateLimitDuration = int64(GetEnvOrDefault("GLOBAL_API_RATE_LIMIT_DURATION", 180))
 
 	GlobalWebRateLimitEnable = GetEnvOrDefaultBool("GLOBAL_WEB_RATE_LIMIT_ENABLE", true)

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -101,6 +101,13 @@ func GlobalAPIRateLimit() func(c *gin.Context) {
 	return defNext
 }
 
+func GlobalAPIVideoRateLimit() func(c *gin.Context) {
+	if common.GlobalApiRateLimitEnable {
+		return rateLimitFactory(common.GlobalApiVideoRateLimitNum, common.GlobalApiRateLimitDuration, "GAV")
+	}
+	return defNext
+}
+
 func CriticalRateLimit() func(c *gin.Context) {
 	if common.CriticalRateLimitEnable {
 		return rateLimitFactory(common.CriticalRateLimitNum, common.CriticalRateLimitDuration, "CT")

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -9,7 +9,7 @@ import (
 
 func SetVideoRouter(router *gin.Engine) {
 	videoV1Router := router.Group("/v1")
-	videoV1Router.Use(middleware.TokenAuth(), middleware.Distribute())
+	videoV1Router.Use(middleware.GlobalAPIRateLimit(), middleware.TokenAuth(), middleware.Distribute())
 	{
 		videoV1Router.GET("/videos/:task_id/content", controller.VideoProxy)
 		videoV1Router.POST("/video/generations", controller.RelayTask)
@@ -19,7 +19,7 @@ func SetVideoRouter(router *gin.Engine) {
 	// openai compatible API video routes
 	// docs: https://platform.openai.com/docs/api-reference/videos/create
 	{
-		videoV1Router.POST("/videos", controller.RelayTask)
+		videoV1Router.POST("/videos", middleware.GlobalAPIVideoRateLimit(), controller.RelayTask)
 		videoV1Router.GET("/videos/:task_id", controller.RelayTask)
 	}
 


### PR DESCRIPTION
视频任务增加接口限流,默认走原来的API限流, 
支持单独设置: GLOBAL_API_VIDEO_RATE_LIMIT, 因为视频任务通常比普通API更重

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent rate-limiting control for video API endpoints via environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->