### PR TITLE
fix(channel-test): use global Responses API policy instead of model name heuristic

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -121,8 +121,8 @@ func testChannel(channel *model.Channel, testModel string, endpointType string, 
 			requestPath = "/v1/images/generations"
 		}
 
-		// responses-only models
-		if strings.Contains(strings.ToLower(testModel), "codex") {
+		// Use Responses API if the global policy says this channel+model should use it
+		if service.ShouldChatCompletionsUseResponsesGlobal(channel.Id, channel.Type, testModel) {
 			requestPath = "/v1/responses"
 		}
 
@@ -685,8 +685,8 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 		}
 	}
 
-	// Responses-only models (e.g. codex series)
-	if strings.Contains(strings.ToLower(model), "codex") {
+	// Use Responses API if the global policy says this channel+model should use it
+	if channel != nil && service.ShouldChatCompletionsUseResponsesGlobal(channel.Id, channel.Type, model) {
 		return &dto.OpenAIResponsesRequest{
 			Model:  model,
 			Input:  json.RawMessage(`[{"role":"user","content":"hi"}]`),

--- a/web/src/pages/Playground/index.jsx
+++ b/web/src/pages/Playground/index.jsx
@@ -251,6 +251,14 @@ const Playground = () => {
         setMessage((prevMessage) => {
           const newMessages = [...prevMessage, userMessage, loadingMessage];
 
+          // Inject the user's new message into the custom payload's messages array
+          if (Array.isArray(customPayload.messages)) {
+            customPayload.messages = [
+              ...customPayload.messages,
+              { role: MESSAGE_ROLES.USER, content },
+            ];
+          }
+
           // 发送自定义请求体
           sendRequest(customPayload, customPayload.stream !== false);
 


### PR DESCRIPTION
- Channel test: use `ShouldChatCompletionsUseResponsesGlobal()` instead of hardcoded codex name check
- Playground: inject user message into custom body before sending

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom request payloads now properly include the latest user message when using custom request bodies.

* **Improvements**
  * Request routing now uses policy-driven selection for API endpoint determination instead of heuristic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->