### PR TITLE
fix: normalize input_text content blocks in Claude-to-OpenAI conversion

### DIFF
--- a/service/convert.go
+++ b/service/convert.go
@@ -127,7 +127,7 @@ func ClaudeToOpenAIRequest(claudeRequest dto.ClaudeRequest, info *relaycommon.Re
 
 			for _, mediaMsg := range contents {
 				switch mediaMsg.Type {
-				case "text":
+				case "text", "input_text":
 					message := dto.MediaContent{
 						Type:         "text",
 						Text:         mediaMsg.GetText(),

--- a/service/openaicompat/chat_to_responses.go
+++ b/service/openaicompat/chat_to_responses.go
@@ -214,8 +214,12 @@ func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*d
 		for _, part := range parts {
 			switch part.Type {
 			case dto.ContentTypeText:
+				textType := "input_text"
+				if role == "assistant" {
+					textType = "output_text"
+				}
 				contentParts = append(contentParts, map[string]any{
-					"type": "input_text",
+					"type": textType,
 					"text": part.Text,
 				})
 			case dto.ContentTypeImageURL:


### PR DESCRIPTION
- Map `input_text` → `text` in `ClaudeToOpenAIRequest` so clients sending Responses API content types via `/v1/messages` don't get silently dropped
- Fixes `Invalid value: 'input_text'` errors from upstream providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of text messages so content is converted consistently across formats.
  * Message text now distinguishes sender role (assistant vs. others) to ensure correct interpretation of incoming and outgoing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->