### PR TITLE
feat(responses): route /v1/responses through non-OpenAI adaptors via chat completions conversion

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -373,17 +373,20 @@ const (
 
 // ResponsesStreamResponse 用于处理 /v1/responses 流式响应
 type ResponsesStreamResponse struct {
-	Type     string                   `json:"type"`
-	Response *OpenAIResponsesResponse `json:"response,omitempty"`
-	Delta    string                   `json:"delta,omitempty"`
-	Item     *ResponsesOutput         `json:"item,omitempty"`
+	Type       string                   `json:"type"`
+	ResponseID string                   `json:"response_id,omitempty"`
+	Response   *OpenAIResponsesResponse `json:"response,omitempty"`
+	Delta      string                   `json:"delta,omitempty"`
+	Text       string                   `json:"text,omitempty"`
+	Arguments  string                   `json:"arguments,omitempty"`
+	Item       *ResponsesOutput         `json:"item,omitempty"`
 	// - response.function_call_arguments.delta
 	// - response.function_call_arguments.done
-	OutputIndex  *int                           `json:"output_index,omitempty"`
-	ContentIndex *int                           `json:"content_index,omitempty"`
-	SummaryIndex *int                           `json:"summary_index,omitempty"`
-	ItemID       string                         `json:"item_id,omitempty"`
-	Part         *ResponsesReasoningSummaryPart `json:"part,omitempty"`
+	OutputIndex  *int                    `json:"output_index,omitempty"`
+	ContentIndex *int                    `json:"content_index,omitempty"`
+	SummaryIndex *int                    `json:"summary_index,omitempty"`
+	ItemID       string                  `json:"item_id,omitempty"`
+	Part         *ResponsesOutputContent `json:"part,omitempty"`
 }
 
 // GetOpenAIError 从动态错误类型中提取OpenAIError结构

--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/QuantumNous/new-api/types"
 
@@ -86,8 +87,11 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 }
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
-	// TODO implement me
-	return nil, errors.New("not implemented")
+	chatReq, err := service.ResponsesRequestToChatCompletionsRequest(&request)
+	if err != nil {
+		return nil, err
+	}
+	return a.ConvertOpenAIRequest(c, info, chatReq)
 }
 
 func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -16,6 +16,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/relay/reasonmap"
 	"github.com/QuantumNous/new-api/service"
+	openaicompat "github.com/QuantumNous/new-api/service/openaicompat"
 	"github.com/QuantumNous/new-api/setting/model_setting"
 	"github.com/QuantumNous/new-api/setting/reasoning"
 	"github.com/QuantumNous/new-api/types"
@@ -547,12 +548,13 @@ func ResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.OpenAITextRe
 }
 
 type ClaudeResponseInfo struct {
-	ResponseId   string
-	Created      int64
-	Model        string
-	ResponseText strings.Builder
-	Usage        *dto.Usage
-	Done         bool
+	ResponseId           string
+	Created              int64
+	Model                string
+	ResponseText         strings.Builder
+	Usage                *dto.Usage
+	Done                 bool
+	ResponsesStreamState *openaicompat.ChatToResponsesStreamState
 }
 
 func buildMessageDeltaPatchUsage(claudeResponse *dto.ClaudeResponse, claudeInfo *ClaudeResponseInfo) *dto.ClaudeUsage {
@@ -740,6 +742,22 @@ func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		if err != nil {
 			logger.LogError(c, "send_stream_response_failed: "+err.Error())
 		}
+	} else if info.RelayFormat == types.RelayFormatOpenAIResponses {
+		response := StreamResponseClaude2OpenAI(&claudeResponse)
+		if !FormatClaudeResponseInfo(&claudeResponse, response, claudeInfo) {
+			return nil
+		}
+		if claudeInfo.ResponsesStreamState == nil {
+			claudeInfo.ResponsesStreamState = openaicompat.NewChatToResponsesStreamState(claudeInfo.ResponseId, claudeInfo.Created, claudeInfo.Model)
+		}
+		for _, event := range claudeInfo.ResponsesStreamState.HandleChatChunk(response) {
+			jsonData, marshalErr := common.Marshal(event)
+			if marshalErr != nil {
+				logger.LogError(c, "send_stream_response_failed: "+marshalErr.Error())
+				continue
+			}
+			helper.ResponseChunkData(c, event, string(jsonData))
+		}
 	}
 	return nil
 }
@@ -764,6 +782,19 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 			if err != nil {
 				common.SysLog("send final response failed: " + err.Error())
 			}
+		}
+		helper.Done(c)
+	} else if info.RelayFormat == types.RelayFormatOpenAIResponses {
+		if claudeInfo.ResponsesStreamState == nil {
+			claudeInfo.ResponsesStreamState = openaicompat.NewChatToResponsesStreamState(claudeInfo.ResponseId, claudeInfo.Created, claudeInfo.Model)
+		}
+		for _, event := range claudeInfo.ResponsesStreamState.FinalEvents(claudeInfo.Usage) {
+			jsonData, err := common.Marshal(event)
+			if err != nil {
+				common.SysLog("send final response failed: " + err.Error())
+				continue
+			}
+			helper.ResponseChunkData(c, event, string(jsonData))
 		}
 		helper.Done(c)
 	}
@@ -821,6 +852,17 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		openaiResponse := ResponseClaude2OpenAI(&claudeResponse)
 		openaiResponse.Usage = *claudeInfo.Usage
 		responseData, err = json.Marshal(openaiResponse)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeBadResponseBody)
+		}
+	case types.RelayFormatOpenAIResponses:
+		openaiResponse := ResponseClaude2OpenAI(&claudeResponse)
+		openaiResponse.Usage = *claudeInfo.Usage
+		responsesResp, convErr := service.ChatCompletionsResponseToResponsesResponse(openaiResponse, info.UpstreamModelName)
+		if convErr != nil {
+			return types.NewError(convErr, types.ErrorCodeBadResponseBody)
+		}
+		responseData, err = json.Marshal(responsesResp)
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeBadResponseBody)
 		}

--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -65,6 +65,24 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
 	}
 
+	// Image generation models may not be supported via /v1/responses on
+	// upstream proxies. Convert to /v1/chat/completions and convert the
+	// response back to Responses format.
+	if !model_setting.GetGlobalSettings().PassThroughRequestEnabled &&
+		!info.ChannelSetting.PassThroughBodyEnabled &&
+		shouldResponsesUseChatCompletions(info) {
+		adaptor := GetAdaptor(info.ApiType)
+		if adaptor != nil {
+			adaptor.Init(info)
+			usage, newApiErr := responsesViaChatCompletions(c, info, adaptor, request)
+			if newApiErr != nil {
+				return newApiErr
+			}
+			postConsumeQuota(c, info, usage)
+			return nil
+		}
+	}
+
 	adaptor := GetAdaptor(info.ApiType)
 	if adaptor == nil {
 		return types.NewError(fmt.Errorf("invalid api type: %d", info.ApiType), types.ErrorCodeInvalidApiType, types.ErrOptionWithSkipRetry())

--- a/relay/responses_via_chat_completions.go
+++ b/relay/responses_via_chat_completions.go
@@ -1,0 +1,256 @@
+package relay
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/types"
+
+	"github.com/gin-gonic/gin"
+)
+
+// responsesViaChatCompletions converts a Responses API request to a Chat
+// Completions request, sends it upstream via /v1/chat/completions, and
+// converts the response back to Responses format. This is the inverse of
+// chatCompletionsViaResponses and is used for models that do not support the
+// Responses API natively (e.g. image generation models on upstream proxies).
+func responsesViaChatCompletions(c *gin.Context, info *relaycommon.RelayInfo, adaptor channel.Adaptor, request *dto.OpenAIResponsesRequest) (*dto.Usage, *types.NewAPIError) {
+	chatReq, err := service.ResponsesRequestToChatCompletionsRequest(request)
+	if err != nil {
+		return nil, types.NewErrorWithStatusCode(err, types.ErrorCodeConvertRequestFailed, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	info.AppendRequestConversion(types.RelayFormatOpenAI)
+
+	savedRelayMode := info.RelayMode
+	savedRequestURLPath := info.RequestURLPath
+	defer func() {
+		info.RelayMode = savedRelayMode
+		info.RequestURLPath = savedRequestURLPath
+	}()
+
+	info.RelayMode = relayconstant.RelayModeChatCompletions
+	info.RequestURLPath = "/v1/chat/completions"
+
+	convertedRequest, err := adaptor.ConvertOpenAIRequest(c, info, chatReq)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+	relaycommon.AppendRequestConversionFromRequest(info, convertedRequest)
+
+	jsonData, err := common.Marshal(convertedRequest)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+
+	jsonData, err = relaycommon.RemoveDisabledFields(jsonData, info.ChannelOtherSettings, info.ChannelSetting.PassThroughBodyEnabled)
+	if err != nil {
+		return nil, types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
+	}
+
+	if len(info.ParamOverride) > 0 {
+		jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
+		if err != nil {
+			return nil, newAPIErrorFromParamOverride(err)
+		}
+	}
+
+	var requestBody io.Reader = bytes.NewBuffer(jsonData)
+
+	resp, err := adaptor.DoRequest(c, info, requestBody)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeDoRequestFailed, http.StatusInternalServerError)
+	}
+	if resp == nil {
+		return nil, types.NewOpenAIError(nil, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+
+	statusCodeMappingStr := c.GetString("status_code_mapping")
+
+	httpResp := resp.(*http.Response)
+	isStream := strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
+	if httpResp.StatusCode != http.StatusOK {
+		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
+		service.ResetStatusCode(newApiErr, statusCodeMappingStr)
+		return nil, newApiErr
+	}
+
+	// The upstream responded with a chat completions response. Convert it
+	// back to the Responses API format before returning to the caller.
+	var usage *dto.Usage
+	var newApiErr *types.NewAPIError
+	if isStream {
+		usage, newApiErr = oaiChatStreamToResponsesHandler(c, info, httpResp)
+	} else {
+		usage, newApiErr = oaiChatToResponsesHandler(c, info, httpResp)
+	}
+	if newApiErr != nil {
+		service.ResetStatusCode(newApiErr, statusCodeMappingStr)
+		return nil, newApiErr
+	}
+	return usage, nil
+}
+
+// oaiChatToResponsesHandler reads a non-streaming Chat Completions response
+// and re-emits it as a Responses API response.
+func oaiChatToResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	if resp == nil || resp.Body == nil {
+		return nil, types.NewOpenAIError(nil, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeReadResponseBodyFailed, http.StatusInternalServerError)
+	}
+
+	var chatResp dto.OpenAITextResponse
+	if err := common.Unmarshal(body, &chatResp); err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	responsesResp, err := service.ChatCompletionsResponseToResponsesResponse(&chatResp, info.UpstreamModelName)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	usage := &dto.Usage{
+		PromptTokens:     chatResp.Usage.PromptTokens,
+		CompletionTokens: chatResp.Usage.CompletionTokens,
+		TotalTokens:      chatResp.Usage.TotalTokens,
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	usage.PromptTokensDetails = chatResp.Usage.PromptTokensDetails
+	usage.CompletionTokenDetails = chatResp.Usage.CompletionTokenDetails
+
+	responseBody, err := common.Marshal(responsesResp)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+	}
+
+	// Write the Responses API JSON back to the client using the original
+	// HTTP response wrapper so that content-type and status are set correctly.
+	service.IOCopyBytesGracefully(c, resp, responseBody)
+	return usage, nil
+}
+
+// isImageGenerationModelForResponses checks if a model is an image generation
+// model that should be routed through chat completions when called via the
+// Responses API. Uses the upstream model name (after mapping) to catch mapped
+// names like gpt-image-1.5-all.
+func isImageGenerationModelForResponses(modelName string) bool {
+	return common.IsImageGenerationModel(modelName)
+}
+
+// oaiChatStreamToResponsesHandler reads a streaming (SSE) Chat Completions
+// response, accumulates all chunks into a single message, then emits it as a
+// non-streaming Responses API JSON response. This handles upstreams that always
+// return SSE even when stream was not requested (common with image generation
+// proxies).
+func oaiChatStreamToResponsesHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
+	if resp == nil || resp.Body == nil {
+		return nil, types.NewOpenAIError(nil, types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
+	defer service.CloseResponseBodyGracefully(resp)
+
+	var (
+		contentBuilder strings.Builder
+		model          string
+		usage          = &dto.Usage{}
+		finishReason   = "stop"
+	)
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "[DONE]" || data == "" {
+			continue
+		}
+
+		var chunk dto.ChatCompletionsStreamResponse
+		if err := common.UnmarshalJsonStr(data, &chunk); err != nil {
+			continue
+		}
+
+		if chunk.Model != "" {
+			model = chunk.Model
+		}
+
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+
+		for _, choice := range chunk.Choices {
+			if choice.Delta.Content != nil {
+				contentBuilder.WriteString(*choice.Delta.Content)
+			}
+			if choice.FinishReason != nil {
+				finishReason = *choice.FinishReason
+			}
+		}
+	}
+
+	if model == "" {
+		model = info.UpstreamModelName
+	}
+
+	// Build a synthetic OpenAITextResponse from accumulated chunks
+	chatResp := &dto.OpenAITextResponse{
+		Id:      "chatcmpl-" + common.GetUUID(),
+		Object:  "chat.completion",
+		Model:   model,
+		Choices: []dto.OpenAITextResponseChoice{{
+			Index:        0,
+			Message:      dto.Message{Role: "assistant", Content: contentBuilder.String()},
+			FinishReason: finishReason,
+		}},
+		Usage: *usage,
+	}
+
+	if usage.TotalTokens == 0 {
+		text := contentBuilder.String()
+		usage = service.ResponseText2Usage(c, text, info.UpstreamModelName, info.GetEstimatePromptTokens())
+		chatResp.Usage = *usage
+	}
+
+	responsesResp, err := service.ChatCompletionsResponseToResponsesResponse(chatResp, info.UpstreamModelName)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
+	}
+
+	responseBody, err := common.Marshal(responsesResp)
+	if err != nil {
+		return nil, types.NewOpenAIError(err, types.ErrorCodeJsonMarshalFailed, http.StatusInternalServerError)
+	}
+
+	service.IOCopyBytesGracefully(c, resp, responseBody)
+	return usage, nil
+}
+
+// shouldResponsesUseChatCompletions returns true when a /v1/responses request
+// should be internally converted to /v1/chat/completions. Currently this
+// applies to image generation models whose upstream providers do not support
+// the Responses API for image generation.
+func shouldResponsesUseChatCompletions(info *relaycommon.RelayInfo) bool {
+	modelToCheck := info.UpstreamModelName
+	if modelToCheck == "" {
+		modelToCheck = info.OriginModelName
+	}
+	return isImageGenerationModelForResponses(modelToCheck)
+}

--- a/service/openai_chat_responses_compat.go
+++ b/service/openai_chat_responses_compat.go
@@ -16,3 +16,11 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 func ExtractOutputTextFromResponses(resp *dto.OpenAIResponsesResponse) string {
 	return openaicompat.ExtractOutputTextFromResponses(resp)
 }
+
+func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (*dto.GeneralOpenAIRequest, error) {
+	return openaicompat.ResponsesRequestToChatCompletionsRequest(req)
+}
+
+func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, model string) (*dto.OpenAIResponsesResponse, error) {
+	return openaicompat.ChatCompletionsResponseToResponsesResponse(resp, model)
+}

--- a/service/openaicompat/chat_stream_to_responses_stream.go
+++ b/service/openaicompat/chat_stream_to_responses_stream.go
@@ -1,0 +1,500 @@
+package openaicompat
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+)
+
+// ChatToResponsesStreamState tracks state for converting a chat completions
+// stream into Responses API SSE events. It is adaptor-agnostic: each adaptor
+// converts its native chunk into a *dto.ChatCompletionsStreamResponse and
+// feeds it to HandleChatChunk; the state machine emits the correct Responses
+// API events in return.
+type ChatToResponsesStreamState struct {
+	ResponseID     string
+	CreatedAt      int64
+	Model          string
+	SentCreated    bool
+	SentInProgress bool
+
+	MessageItemID       string
+	MessageOutputIndex  int
+	MessageContentIndex int
+	MessageItemAdded    bool
+	MessageContentAdded bool
+
+	NextOutputIndex int
+
+	OutputText       strings.Builder
+	ToolCallArgs     map[string]string
+	ToolCallName     map[string]string
+	ToolCallSent     map[string]bool
+	ToolCallOrder    []string
+	ToolCallOutIndex map[string]int
+}
+
+func NewChatToResponsesStreamState(responseID string, createdAt int64, model string) *ChatToResponsesStreamState {
+	return &ChatToResponsesStreamState{
+		ResponseID:          normalizeResponsesID(responseID),
+		CreatedAt:           createdAt,
+		Model:               model,
+		MessageOutputIndex:  -1,
+		MessageContentIndex: 0,
+		NextOutputIndex:     0,
+		ToolCallArgs:        make(map[string]string),
+		ToolCallName:        make(map[string]string),
+		ToolCallSent:        make(map[string]bool),
+		ToolCallOutIndex:    make(map[string]int),
+	}
+}
+
+// HandleChatChunk converts one chat completions stream chunk into zero or more
+// Responses API events.
+func (s *ChatToResponsesStreamState) HandleChatChunk(chunk *dto.ChatCompletionsStreamResponse) []dto.ResponsesStreamResponse {
+	if chunk == nil || len(chunk.Choices) == 0 {
+		return nil
+	}
+
+	if chunk.Model != "" {
+		s.Model = chunk.Model
+	}
+	if s.CreatedAt == 0 && chunk.Created != 0 {
+		s.CreatedAt = chunk.Created
+	}
+
+	events := s.baseEvents()
+
+	delta := chunk.Choices[0].Delta
+
+	// Text content
+	if delta.Content != nil {
+		content := *delta.Content
+		if content != "" {
+			events = append(events, s.ensureMessageItemEvents()...)
+			events = append(events, s.ensureContentPartEvents()...)
+			s.OutputText.WriteString(content)
+			events = append(events, s.outputTextDeltaEvent(content))
+		}
+	}
+
+	// Reasoning content (for models that emit reasoning_content)
+	reasoningContent := delta.GetReasoningContent()
+	if reasoningContent != "" {
+		outIndex := 0
+		summaryIndex := 0
+		events = append(events, dto.ResponsesStreamResponse{
+			Type:         "response.reasoning_summary_text.delta",
+			ResponseID:   s.ResponseID,
+			ItemID:       "rs_" + strings.TrimPrefix(s.ResponseID, "resp_"),
+			OutputIndex:  &outIndex,
+			SummaryIndex: &summaryIndex,
+			Delta:        reasoningContent,
+		})
+	}
+
+	// Tool calls
+	if len(delta.ToolCalls) > 0 {
+		for idx, call := range delta.ToolCalls {
+			callID := strings.TrimSpace(call.ID)
+			if callID == "" {
+				// For subsequent argument deltas, use the last known call ID
+				if call.Index != nil && *call.Index < len(s.ToolCallOrder) {
+					callID = s.ToolCallOrder[*call.Index]
+				} else if len(s.ToolCallOrder) > 0 {
+					callID = s.ToolCallOrder[len(s.ToolCallOrder)-1]
+				} else {
+					callID = fmt.Sprintf("call_%d", idx)
+				}
+			}
+			if call.Function.Name != "" {
+				s.ToolCallName[callID] = call.Function.Name
+			}
+			if !s.ToolCallSent[callID] {
+				s.ToolCallSent[callID] = true
+				s.ToolCallOrder = append(s.ToolCallOrder, callID)
+				outIndex := s.allocOutputIndex(callID)
+				events = append(events, s.toolItemAddedEvent(callID, outIndex))
+			}
+
+			args := call.Function.Arguments
+			if args == "" {
+				continue
+			}
+			s.ToolCallArgs[callID] = s.ToolCallArgs[callID] + args
+
+			events = append(events, dto.ResponsesStreamResponse{
+				Type:        "response.function_call_arguments.delta",
+				ResponseID:  s.ResponseID,
+				ItemID:      callID,
+				OutputIndex: s.outputIndexPtr(callID),
+				Delta:       args,
+			})
+		}
+	}
+
+	return events
+}
+
+// HandleUsageChunk processes a usage-only chunk (no choices).
+func (s *ChatToResponsesStreamState) HandleUsageChunk(chunk *dto.ChatCompletionsStreamResponse) *dto.Usage {
+	if chunk == nil || chunk.Usage == nil {
+		return nil
+	}
+	usage := &dto.Usage{
+		PromptTokens:     chunk.Usage.PromptTokens,
+		CompletionTokens: chunk.Usage.CompletionTokens,
+		TotalTokens:      chunk.Usage.TotalTokens,
+		InputTokens:      chunk.Usage.PromptTokens,
+		OutputTokens:     chunk.Usage.CompletionTokens,
+	}
+	usage.PromptTokensDetails = chunk.Usage.PromptTokensDetails
+	usage.CompletionTokenDetails = chunk.Usage.CompletionTokenDetails
+	return usage
+}
+
+// FinalEvents emits the closing events: content done, tool calls done, and
+// response.completed.
+func (s *ChatToResponsesStreamState) FinalEvents(usage *dto.Usage) []dto.ResponsesStreamResponse {
+	events := s.baseEvents()
+
+	// Finalize message item
+	if s.MessageItemAdded {
+		text := s.OutputText.String()
+		if s.MessageContentAdded {
+			events = append(events, s.outputTextDoneEvent(text))
+			events = append(events, s.contentPartDoneEvent(text))
+		}
+		events = append(events, s.messageItemDoneEvent(text))
+	}
+
+	// Finalize tool calls
+	for _, callID := range s.ToolCallOrder {
+		outIndex := s.outputIndexPtr(callID)
+		args := s.ToolCallArgs[callID]
+		if args != "" {
+			events = append(events, dto.ResponsesStreamResponse{
+				Type:        "response.function_call_arguments.done",
+				ResponseID:  s.ResponseID,
+				ItemID:      callID,
+				OutputIndex: outIndex,
+				Arguments:   args,
+			})
+		}
+		events = append(events, dto.ResponsesStreamResponse{
+			Type:        "response.output_item.done",
+			ResponseID:  s.ResponseID,
+			ItemID:      callID,
+			OutputIndex: outIndex,
+			Item: &dto.ResponsesOutput{
+				Type:      "function_call",
+				ID:        callID,
+				Status:    "completed",
+				CallId:    callID,
+				Name:      s.ToolCallName[callID],
+				Arguments: args,
+			},
+		})
+	}
+
+	// Build final output and usage
+	output := s.buildFinalOutput()
+	finalUsage := s.buildFinalUsage(usage)
+
+	resp := &dto.OpenAIResponsesResponse{
+		ID:        s.ResponseID,
+		Object:    "response",
+		CreatedAt: int(s.CreatedAt),
+		Status:    json.RawMessage(`"completed"`),
+		Model:     s.Model,
+		Output:    output,
+		Usage:     finalUsage,
+	}
+	events = append(events, dto.ResponsesStreamResponse{
+		Type:       "response.completed",
+		ResponseID: s.ResponseID,
+		Response:   resp,
+	})
+
+	return events
+}
+
+func (s *ChatToResponsesStreamState) baseEvents() []dto.ResponsesStreamResponse {
+	events := make([]dto.ResponsesStreamResponse, 0, 2)
+	if !s.SentCreated {
+		events = append(events, s.createdEvent())
+		s.SentCreated = true
+	}
+	if !s.SentInProgress {
+		events = append(events, s.inProgressEvent())
+		s.SentInProgress = true
+	}
+	return events
+}
+
+func (s *ChatToResponsesStreamState) createdEvent() dto.ResponsesStreamResponse {
+	resp := &dto.OpenAIResponsesResponse{
+		ID:        s.ResponseID,
+		Object:    "response",
+		CreatedAt: int(s.CreatedAt),
+		Status:    json.RawMessage(`"in_progress"`),
+		Model:     s.Model,
+		Output:    []dto.ResponsesOutput{},
+	}
+	return dto.ResponsesStreamResponse{
+		Type:       "response.created",
+		ResponseID: s.ResponseID,
+		Response:   resp,
+	}
+}
+
+func (s *ChatToResponsesStreamState) inProgressEvent() dto.ResponsesStreamResponse {
+	resp := &dto.OpenAIResponsesResponse{
+		ID:        s.ResponseID,
+		Object:    "response",
+		CreatedAt: int(s.CreatedAt),
+		Status:    json.RawMessage(`"in_progress"`),
+		Model:     s.Model,
+		Output:    []dto.ResponsesOutput{},
+	}
+	return dto.ResponsesStreamResponse{
+		Type:       "response.in_progress",
+		ResponseID: s.ResponseID,
+		Response:   resp,
+	}
+}
+
+func (s *ChatToResponsesStreamState) ensureMessageItemEvents() []dto.ResponsesStreamResponse {
+	if s.MessageItemAdded {
+		return nil
+	}
+	s.MessageItemAdded = true
+	if s.MessageOutputIndex < 0 {
+		s.MessageOutputIndex = s.NextOutputIndex
+		s.NextOutputIndex++
+	}
+	if s.MessageItemID == "" {
+		s.MessageItemID = "msg_" + common.GetUUID()
+	}
+	outIndex := s.MessageOutputIndex
+	return []dto.ResponsesStreamResponse{
+		{
+			Type:        "response.output_item.added",
+			ResponseID:  s.ResponseID,
+			OutputIndex: &outIndex,
+			Item: &dto.ResponsesOutput{
+				ID:      s.MessageItemID,
+				Type:    "message",
+				Status:  "in_progress",
+				Role:    "assistant",
+				Content: []dto.ResponsesOutputContent{},
+			},
+		},
+	}
+}
+
+func (s *ChatToResponsesStreamState) ensureContentPartEvents() []dto.ResponsesStreamResponse {
+	if s.MessageContentAdded {
+		return nil
+	}
+	s.MessageContentAdded = true
+	outIndex := s.MessageOutputIndex
+	contentIndex := s.MessageContentIndex
+	part := dto.ResponsesOutputContent{
+		Type:        "output_text",
+		Text:        "",
+		Annotations: []interface{}{},
+	}
+	return []dto.ResponsesStreamResponse{
+		{
+			Type:         "response.content_part.added",
+			ResponseID:   s.ResponseID,
+			ItemID:       s.MessageItemID,
+			OutputIndex:  &outIndex,
+			ContentIndex: &contentIndex,
+			Part:         &part,
+		},
+	}
+}
+
+func (s *ChatToResponsesStreamState) outputTextDeltaEvent(delta string) dto.ResponsesStreamResponse {
+	outIndex := s.MessageOutputIndex
+	contentIndex := s.MessageContentIndex
+	return dto.ResponsesStreamResponse{
+		Type:         "response.output_text.delta",
+		ResponseID:   s.ResponseID,
+		ItemID:       s.MessageItemID,
+		OutputIndex:  &outIndex,
+		ContentIndex: &contentIndex,
+		Delta:        delta,
+	}
+}
+
+func (s *ChatToResponsesStreamState) outputTextDoneEvent(text string) dto.ResponsesStreamResponse {
+	outIndex := s.MessageOutputIndex
+	contentIndex := s.MessageContentIndex
+	return dto.ResponsesStreamResponse{
+		Type:         "response.output_text.done",
+		ResponseID:   s.ResponseID,
+		ItemID:       s.MessageItemID,
+		OutputIndex:  &outIndex,
+		ContentIndex: &contentIndex,
+		Text:         text,
+	}
+}
+
+func (s *ChatToResponsesStreamState) contentPartDoneEvent(text string) dto.ResponsesStreamResponse {
+	outIndex := s.MessageOutputIndex
+	contentIndex := s.MessageContentIndex
+	part := dto.ResponsesOutputContent{
+		Type:        "output_text",
+		Text:        text,
+		Annotations: []interface{}{},
+	}
+	return dto.ResponsesStreamResponse{
+		Type:         "response.content_part.done",
+		ResponseID:   s.ResponseID,
+		ItemID:       s.MessageItemID,
+		OutputIndex:  &outIndex,
+		ContentIndex: &contentIndex,
+		Part:         &part,
+	}
+}
+
+func (s *ChatToResponsesStreamState) messageItemDoneEvent(text string) dto.ResponsesStreamResponse {
+	outIndex := s.MessageOutputIndex
+	item := dto.ResponsesOutput{
+		ID:     s.MessageItemID,
+		Type:   "message",
+		Status: "completed",
+		Role:   "assistant",
+		Content: []dto.ResponsesOutputContent{
+			{
+				Type:        "output_text",
+				Text:        text,
+				Annotations: []interface{}{},
+			},
+		},
+	}
+	return dto.ResponsesStreamResponse{
+		Type:        "response.output_item.done",
+		ResponseID:  s.ResponseID,
+		ItemID:      s.MessageItemID,
+		OutputIndex: &outIndex,
+		Item:        &item,
+	}
+}
+
+func (s *ChatToResponsesStreamState) toolItemAddedEvent(callID string, outIndex int) dto.ResponsesStreamResponse {
+	item := dto.ResponsesOutput{
+		Type:   "function_call",
+		ID:     callID,
+		Status: "in_progress",
+		CallId: callID,
+		Name:   s.ToolCallName[callID],
+	}
+	return dto.ResponsesStreamResponse{
+		Type:        "response.output_item.added",
+		ResponseID:  s.ResponseID,
+		ItemID:      callID,
+		OutputIndex: &outIndex,
+		Item:        &item,
+	}
+}
+
+func (s *ChatToResponsesStreamState) allocOutputIndex(callID string) int {
+	if idx, ok := s.ToolCallOutIndex[callID]; ok {
+		return idx
+	}
+	idx := s.NextOutputIndex
+	s.NextOutputIndex++
+	s.ToolCallOutIndex[callID] = idx
+	return idx
+}
+
+func (s *ChatToResponsesStreamState) outputIndexPtr(callID string) *int {
+	idx, ok := s.ToolCallOutIndex[callID]
+	if !ok {
+		return nil
+	}
+	return &idx
+}
+
+func (s *ChatToResponsesStreamState) buildFinalOutput() []dto.ResponsesOutput {
+	itemsByIndex := make(map[int]dto.ResponsesOutput)
+	if s.MessageItemAdded {
+		text := s.OutputText.String()
+		itemsByIndex[s.MessageOutputIndex] = dto.ResponsesOutput{
+			ID:     s.MessageItemID,
+			Type:   "message",
+			Status: "completed",
+			Role:   "assistant",
+			Content: []dto.ResponsesOutputContent{
+				{
+					Type:        "output_text",
+					Text:        text,
+					Annotations: []interface{}{},
+				},
+			},
+		}
+	}
+	for _, callID := range s.ToolCallOrder {
+		idx, ok := s.ToolCallOutIndex[callID]
+		if !ok {
+			continue
+		}
+		itemsByIndex[idx] = dto.ResponsesOutput{
+			Type:      "function_call",
+			ID:        callID,
+			Status:    "completed",
+			CallId:    callID,
+			Name:      s.ToolCallName[callID],
+			Arguments: s.ToolCallArgs[callID],
+		}
+	}
+	output := make([]dto.ResponsesOutput, 0, len(itemsByIndex))
+	for i := 0; i < s.NextOutputIndex; i++ {
+		if item, ok := itemsByIndex[i]; ok {
+			output = append(output, item)
+		}
+	}
+	return output
+}
+
+func (s *ChatToResponsesStreamState) buildFinalUsage(usage *dto.Usage) *dto.Usage {
+	if usage == nil {
+		return &dto.Usage{}
+	}
+	final := &dto.Usage{}
+	*final = *usage
+	if final.InputTokens == 0 {
+		final.InputTokens = final.PromptTokens
+	}
+	if final.OutputTokens == 0 {
+		final.OutputTokens = final.CompletionTokens
+	}
+	if final.TotalTokens == 0 {
+		final.TotalTokens = final.PromptTokens + final.CompletionTokens
+	}
+	return final
+}
+
+func normalizeResponsesID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "resp_" + common.GetUUID()
+	}
+	if strings.HasPrefix(id, "resp_") {
+		return id
+	}
+	if strings.HasPrefix(id, "chatcmpl-") {
+		return "resp_" + strings.TrimPrefix(id, "chatcmpl-")
+	}
+	if strings.HasPrefix(id, "chatcmpl_") {
+		return "resp_" + strings.TrimPrefix(id, "chatcmpl_")
+	}
+	return "resp_" + id
+}

--- a/service/openaicompat/responses_to_chat.go
+++ b/service/openaicompat/responses_to_chat.go
@@ -1,9 +1,13 @@
 package openaicompat
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
+	"time"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/dto"
 )
 
@@ -42,7 +46,7 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	created := resp.CreatedAt
 
 	var toolCalls []dto.ToolCallResponse
-	if text == "" && len(resp.Output) > 0 {
+	if len(resp.Output) > 0 {
 		for _, out := range resp.Output {
 			if out.Type != "function_call" {
 				continue
@@ -77,7 +81,6 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	}
 	if len(toolCalls) > 0 {
 		msg.SetToolCalls(toolCalls)
-		msg.Content = ""
 	}
 
 	out := &dto.OpenAITextResponse{
@@ -96,6 +99,434 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 	}
 
 	return out, usage, nil
+}
+
+// ResponsesRequestToChatCompletionsRequest converts a Responses API request
+// to a Chat Completions API request. This is the inverse of
+// ChatCompletionsRequestToResponsesRequest in chat_to_responses.go.
+func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (*dto.GeneralOpenAIRequest, error) {
+	if req == nil {
+		return nil, errors.New("request is nil")
+	}
+	if req.Model == "" {
+		return nil, errors.New("model is required")
+	}
+
+	var messages []dto.Message
+
+	// Instructions → system message
+	if len(req.Instructions) > 0 {
+		var instructions string
+		if err := common.Unmarshal(req.Instructions, &instructions); err == nil && strings.TrimSpace(instructions) != "" {
+			messages = append(messages, dto.Message{
+				Role:    "system",
+				Content: instructions,
+			})
+		}
+	}
+
+	// Input → messages
+	if len(req.Input) > 0 {
+		// Input can be a string or an array
+		switch common.GetJsonType(req.Input) {
+		case "string":
+			var inputStr string
+			if err := common.Unmarshal(req.Input, &inputStr); err == nil {
+				messages = append(messages, dto.Message{
+					Role:    "user",
+					Content: inputStr,
+				})
+			}
+		case "array":
+			var inputItems []map[string]any
+			if err := common.Unmarshal(req.Input, &inputItems); err != nil {
+				return nil, fmt.Errorf("failed to parse input: %w", err)
+			}
+
+			// Collect consecutive function_call items to merge into one assistant message
+			var pendingToolCalls []dto.ToolCallResponse
+
+			flushToolCalls := func() {
+				if len(pendingToolCalls) == 0 {
+					return
+				}
+				msg := dto.Message{
+					Role:    "assistant",
+					Content: "",
+				}
+				msg.SetToolCalls(pendingToolCalls)
+				messages = append(messages, msg)
+				pendingToolCalls = nil
+			}
+
+			for _, item := range inputItems {
+				itemType, _ := item["type"].(string)
+				role, _ := item["role"].(string)
+
+				switch {
+				case itemType == "function_call":
+					callID, _ := item["call_id"].(string)
+					name, _ := item["name"].(string)
+					arguments, _ := item["arguments"].(string)
+					pendingToolCalls = append(pendingToolCalls, dto.ToolCallResponse{
+						ID:   callID,
+						Type: "function",
+						Function: dto.FunctionResponse{
+							Name:      name,
+							Arguments: arguments,
+						},
+					})
+
+				case itemType == "function_call_output":
+					flushToolCalls()
+					callID, _ := item["call_id"].(string)
+					output := common.Interface2String(item["output"])
+					messages = append(messages, dto.Message{
+						Role:       "tool",
+						Content:    output,
+						ToolCallId: callID,
+					})
+
+				case role == "user" || role == "assistant" || role == "system" || role == "developer":
+					flushToolCalls()
+					msgRole := role
+					if msgRole == "developer" {
+						msgRole = "system"
+					}
+					msg := dto.Message{Role: msgRole}
+					if content, ok := item["content"]; ok {
+						msg.Content = convertResponsesContentToChat(content)
+					}
+					messages = append(messages, msg)
+
+				default:
+					flushToolCalls()
+					// Best-effort: treat as user message
+					if content, ok := item["content"]; ok {
+						msg := dto.Message{Role: "user"}
+						msg.Content = convertResponsesContentToChat(content)
+						messages = append(messages, msg)
+					}
+				}
+			}
+			flushToolCalls()
+		}
+	}
+
+	if len(messages) == 0 {
+		return nil, errors.New("no messages could be derived from input")
+	}
+
+	out := &dto.GeneralOpenAIRequest{
+		Model:                req.Model,
+		Messages:             messages,
+		Stream:               req.Stream,
+		User:                 req.User,
+		Store:                req.Store,
+		Metadata:             req.Metadata,
+		PromptCacheRetention: req.PromptCacheRetention,
+	}
+
+	if len(req.PromptCacheKey) > 0 {
+		var key string
+		if err := common.Unmarshal(req.PromptCacheKey, &key); err == nil {
+			out.PromptCacheKey = key
+		}
+	}
+	if req.MaxOutputTokens != nil && *req.MaxOutputTokens > 0 {
+		out.MaxCompletionTokens = req.MaxOutputTokens
+	}
+	if req.Temperature != nil {
+		out.Temperature = req.Temperature
+	}
+	if req.TopP != nil {
+		out.TopP = req.TopP
+	}
+	if req.Reasoning != nil && req.Reasoning.Effort != "" && req.Reasoning.Effort != "none" {
+		out.ReasoningEffort = req.Reasoning.Effort
+	}
+
+	// Stream options
+	if req.Stream != nil && *req.Stream {
+		out.StreamOptions = &dto.StreamOptions{IncludeUsage: true}
+	}
+
+	// ParallelToolCalls
+	if len(req.ParallelToolCalls) > 0 {
+		var ptc bool
+		if err := common.Unmarshal(req.ParallelToolCalls, &ptc); err == nil {
+			out.ParallelTooCalls = &ptc
+		}
+	}
+
+	// Tools
+	if len(req.Tools) > 0 {
+		var tools []map[string]any
+		if err := common.Unmarshal(req.Tools, &tools); err == nil {
+			for _, tool := range tools {
+				toolType, _ := tool["type"].(string)
+				if toolType == "" {
+					continue
+				}
+				if toolType == "function" {
+					name, _ := tool["name"].(string)
+					description, _ := tool["description"].(string)
+					parameters := tool["parameters"]
+					out.Tools = append(out.Tools, dto.ToolCallRequest{
+						Type: "function",
+						Function: dto.FunctionRequest{
+							Name:        name,
+							Description: description,
+							Parameters:  parameters,
+						},
+					})
+					continue
+				}
+				// Non-function tools (web_search_preview, file_search, etc.) — pass through
+				if b, err := common.Marshal(tool); err == nil {
+					out.Tools = append(out.Tools, dto.ToolCallRequest{
+						Type:   toolType,
+						Custom: b,
+					})
+				}
+			}
+		}
+	}
+
+	// ToolChoice
+	if len(req.ToolChoice) > 0 {
+		var tcStr string
+		if err := common.Unmarshal(req.ToolChoice, &tcStr); err == nil {
+			// String values: "auto", "none", "required"
+			out.ToolChoice = tcStr
+		} else {
+			var tcMap map[string]any
+			if err := common.Unmarshal(req.ToolChoice, &tcMap); err == nil {
+				tcType, _ := tcMap["type"].(string)
+				if tcType == "function" {
+					// Responses: {"type": "function", "name": "fn_name"}
+					// Chat:      {"type": "function", "function": {"name": "fn_name"}}
+					name, _ := tcMap["name"].(string)
+					if name != "" {
+						out.ToolChoice = map[string]any{
+							"type":     "function",
+							"function": map[string]any{"name": name},
+						}
+					} else {
+						out.ToolChoice = tcMap
+					}
+				} else {
+					out.ToolChoice = tcMap
+				}
+			}
+		}
+	}
+
+	// Text (response format)
+	if len(req.Text) > 0 {
+		out.ResponseFormat = convertResponsesTextToResponseFormat(req.Text)
+	}
+
+	return out, nil
+}
+
+// convertResponsesContentToChat converts Responses API content to Chat API content.
+func convertResponsesContentToChat(content any) any {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var chatParts []dto.MediaContent
+		for _, part := range v {
+			partMap, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			partType, _ := partMap["type"].(string)
+			switch partType {
+			case "input_text":
+				text, _ := partMap["text"].(string)
+				chatParts = append(chatParts, dto.MediaContent{
+					Type: dto.ContentTypeText,
+					Text: text,
+				})
+			case "input_image":
+				imageURL := partMap["image_url"]
+				switch iu := imageURL.(type) {
+				case string:
+					chatParts = append(chatParts, dto.MediaContent{
+						Type:     dto.ContentTypeImageURL,
+						ImageUrl: &dto.MessageImageUrl{Url: iu},
+					})
+				default:
+					chatParts = append(chatParts, dto.MediaContent{
+						Type:     dto.ContentTypeImageURL,
+						ImageUrl: imageURL,
+					})
+				}
+			case "input_audio":
+				chatParts = append(chatParts, dto.MediaContent{
+					Type:       dto.ContentTypeInputAudio,
+					InputAudio: partMap["input_audio"],
+				})
+			case "input_file":
+				chatParts = append(chatParts, dto.MediaContent{
+					Type: dto.ContentTypeFile,
+					File: partMap["file"],
+				})
+			case "input_video":
+				chatParts = append(chatParts, dto.MediaContent{
+					Type:     dto.ContentTypeVideoUrl,
+					VideoUrl: partMap["video_url"],
+				})
+			default:
+				chatParts = append(chatParts, dto.MediaContent{
+					Type: partType,
+				})
+			}
+		}
+		if len(chatParts) > 0 {
+			return chatParts
+		}
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// convertResponsesTextToResponseFormat converts Responses API text field to Chat API response_format.
+// Inverse of convertChatResponseFormatToResponsesText in chat_to_responses.go.
+func convertResponsesTextToResponseFormat(textRaw json.RawMessage) *dto.ResponseFormat {
+	if len(textRaw) == 0 {
+		return nil
+	}
+	var textObj map[string]any
+	if err := common.Unmarshal(textRaw, &textObj); err != nil {
+		return nil
+	}
+	formatRaw, ok := textObj["format"]
+	if !ok {
+		return nil
+	}
+	formatMap, ok := formatRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	formatType, _ := formatMap["type"].(string)
+	if formatType == "" {
+		return nil
+	}
+
+	rf := &dto.ResponseFormat{Type: formatType}
+	if formatType == "json_schema" {
+		// Reconstruct the json_schema field
+		schemaCopy := make(map[string]any)
+		for k, v := range formatMap {
+			if k == "type" {
+				continue
+			}
+			schemaCopy[k] = v
+		}
+		if len(schemaCopy) > 0 {
+			rf.JsonSchema, _ = common.Marshal(schemaCopy)
+		}
+	}
+	return rf
+}
+
+// ChatCompletionsResponseToResponsesResponse converts a Chat Completions response
+// to a Responses API response. This is the inverse of ResponsesResponseToChatCompletionsResponse.
+func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, model string) (*dto.OpenAIResponsesResponse, error) {
+	if resp == nil {
+		return nil, errors.New("response is nil")
+	}
+
+	respID := "resp_" + common.GetUUID()
+	now := int(time.Now().Unix())
+	if model == "" {
+		model = resp.Model
+	}
+
+	var outputs []dto.ResponsesOutput
+	var usage *dto.Usage
+
+	if len(resp.Choices) > 0 {
+		choice := resp.Choices[0]
+
+		// Text content
+		if choice.Message.IsStringContent() {
+			text := choice.Message.StringContent()
+			if text != "" {
+				outputs = append(outputs, dto.ResponsesOutput{
+					Type:   "message",
+					ID:     "msg_" + common.GetUUID(),
+					Status: "completed",
+					Role:   "assistant",
+					Content: []dto.ResponsesOutputContent{
+						{
+							Type:        "output_text",
+							Text:        text,
+							Annotations: []interface{}{},
+						},
+					},
+				})
+			}
+		}
+
+		// Tool calls
+		for _, tc := range choice.Message.ParseToolCalls() {
+			if tc.Type != "" && tc.Type != "function" {
+				continue
+			}
+			callID := strings.TrimSpace(tc.ID)
+			if callID == "" {
+				continue
+			}
+			outputs = append(outputs, dto.ResponsesOutput{
+				Type:      "function_call",
+				ID:        "fc_" + common.GetUUID(),
+				Status:    "completed",
+				CallId:    callID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			})
+		}
+	}
+
+	// Usage conversion
+	usage = &dto.Usage{
+		PromptTokens:     resp.Usage.PromptTokens,
+		CompletionTokens: resp.Usage.CompletionTokens,
+		TotalTokens:      resp.Usage.TotalTokens,
+		InputTokens:      resp.Usage.PromptTokens,
+		OutputTokens:     resp.Usage.CompletionTokens,
+	}
+	if usage.TotalTokens == 0 {
+		usage.TotalTokens = usage.PromptTokens + usage.CompletionTokens
+	}
+	usage.PromptTokensDetails = resp.Usage.PromptTokensDetails
+	usage.CompletionTokenDetails = resp.Usage.CompletionTokenDetails
+	if resp.Usage.PromptTokensDetails.CachedTokens > 0 ||
+		resp.Usage.PromptTokensDetails.ImageTokens > 0 ||
+		resp.Usage.PromptTokensDetails.AudioTokens > 0 {
+		usage.InputTokensDetails = &dto.InputTokenDetails{
+			CachedTokens: resp.Usage.PromptTokensDetails.CachedTokens,
+			ImageTokens:  resp.Usage.PromptTokensDetails.ImageTokens,
+			AudioTokens:  resp.Usage.PromptTokensDetails.AudioTokens,
+		}
+	}
+
+	out := &dto.OpenAIResponsesResponse{
+		ID:        respID,
+		Object:    "response",
+		CreatedAt: now,
+		Status:    json.RawMessage(`"completed"`),
+		Model:     model,
+		Output:    outputs,
+		Usage:     usage,
+	}
+
+	return out, nil
 }
 
 func ExtractOutputTextFromResponses(resp *dto.OpenAIResponsesResponse) string {


### PR DESCRIPTION
## Summary

Enable channels without native Responses API support (starting with Claude) to serve `/v1/responses` requests by converting Responses to Chat Completions format, routing through the existing adaptor pipeline, and converting responses back. Any future adaptor (Gemini, Deepseek, etc.) gets support by adding the same 3-line pattern.

Related: #2941, #2043, #1527

## Why not use existing PRs directly?

### vs #2892 (494 lines, Claude-only)
- Reimplements all logic already in `RequestOpenAI2ClaudeMessage` (max tokens, thinking, tools, instructions, tool choice)
- Naive SSE passthrough piping raw Claude events without converting to Responses API format. Clients expecting Responses SSE events will not work
- Only works for Claude with no reusable converter for other adaptors
- **Adopted from #2892:** the 2-line bug fix for tool calls being dropped when text content exists

### vs #2817 (1039 lines)
- Similar adaptor-level approach (good), but includes its own stream state and converter
- Our stream state machine handles additional cases: reasoning content, usage chunks, `SummaryIndex` field
- **Adopted from #2817:** adaptor-level `ConvertOpenAIResponsesRequest` pattern, `GetJsonType()` for input detection, `developer` to `system` role mapping, `PromptCacheKey`/`PromptCacheRetention` passthrough, non-function tool passthrough via `Custom` field

## Architecture (1006 lines, adaptor-agnostic)

**Converters** (reusable for any adaptor):
- `ResponsesRequestToChatCompletionsRequest`: handles developer role mapping, function_call/function_call_output merging into tool messages, content type detection via `GetJsonType()`, response format conversion, PromptCacheKey/PromptCacheRetention passthrough
- `ChatCompletionsResponseToResponsesResponse`: non-streaming response conversion
- `ChatToResponsesStreamState`: streaming state machine emitting proper Responses SSE events (`response.created`, `response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`, usage)

**Claude adaptor**: 3 lines chaining `ResponsesRequestToChatCompletionsRequest` then `ConvertOpenAIRequest` (reuses all existing Claude conversion logic)

## Files changed

| File | Change |
|------|--------|
| `relay/channel/claude/adaptor.go` | Implement `ConvertOpenAIResponsesRequest` (+5 lines) |
| `relay/channel/claude/relay-claude.go` | Add `RelayFormatOpenAIResponses` to stream/non-stream handlers |
| `service/openaicompat/responses_to_chat.go` | Add converters + bug fix from #2892 |
| `service/openaicompat/chat_stream_to_responses_stream.go` | New: reusable stream state machine |
| `service/openai_chat_responses_compat.go` | Service wrapper functions |
| `dto/openai_response.go` | Add fields to `ResponsesStreamResponse` |

## Test plan

- [ ] Streaming `/v1/responses` through Claude channel (verify SSE events match Responses API format)
- [ ] Non-streaming `/v1/responses` through Claude channel
- [ ] Tool calls with text content (both appear in output)
- [ ] Multi-turn with function_call + function_call_output in input