### PR TITLE
feat(aws): add claude-sonnet-4-6 Bedrock mapping and cross-region support

### DIFF
--- a/relay/channel/aws/constants.go
+++ b/relay/channel/aws/constants.go
@@ -14,6 +14,7 @@ var awsModelIDMap = map[string]string{
 	"claude-opus-4-20250514":     "anthropic.claude-opus-4-20250514-v1:0",
 	"claude-opus-4-1-20250805":   "anthropic.claude-opus-4-1-20250805-v1:0",
 	"claude-sonnet-4-5-20250929": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+	"claude-sonnet-4-6":          "anthropic.claude-sonnet-4-6",
 	"claude-haiku-4-5-20251001":  "anthropic.claude-haiku-4-5-20251001-v1:0",
 	"claude-opus-4-5-20251101":   "anthropic.claude-opus-4-5-20251101-v1:0",
 	"claude-opus-4-6":            "anthropic.claude-opus-4-6-v1",
@@ -71,6 +72,11 @@ var awsModelCanCrossRegionMap = map[string]map[string]bool{
 		"us": true,
 	},
 	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
+		"us": true,
+		"ap": true,
+		"eu": true,
+	},
+	"anthropic.claude-sonnet-4-6": {
 		"us": true,
 		"ap": true,
 		"eu": true,


### PR DESCRIPTION
## Summary
- add AWS Bedrock model mapping for `claude-sonnet-4-6` -> `anthropic.claude-sonnet-4-6`
- add cross-region availability entry for `anthropic.claude-sonnet-4-6` (`us`, `eu`, `ap`)
- scope is AWS constants only, following the `claude-opus-4-6` AWS constants pattern

## Verification
- confirmed entries exist in `relay/channel/aws/constants.go`
- attempted `go test ./relay/channel/aws/...` with local `GOCACHE`/`GOMODCACHE`
- test execution is blocked in this environment by inability to resolve `proxy.golang.org`

## Reference
- AWS CLI model ID confirmation used: `anthropic.claude-sonnet-4-6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Claude Sonnet 4.6 model
  * Enabled multi-region availability across US, Asia Pacific, and EU regions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->