### PR TITLE
fix: 修复通过new-api代理api后缓存命中太低的bug

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -287,6 +287,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
+	req.Header = c.Request.Header
 	headers := req.Header
 	err = a.SetupRequestHeader(c, &headers, info)
 	if err != nil {
@@ -318,6 +319,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
+	req.Header = c.Request.Header
 	// set form data
 	req.Header.Set("Content-Type", c.Request.Header.Get("Content-Type"))
 	headers := req.Header
@@ -344,7 +346,7 @@ func DoWssRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if err != nil {
 		return nil, fmt.Errorf("get request url failed: %w", err)
 	}
-	targetHeader := http.Header{}
+	targetHeader := c.Request.Header
 	err = a.SetupRequestHeader(c, &targetHeader, info)
 	if err != nil {
 		return nil, fmt.Errorf("setup request header failed: %w", err)


### PR DESCRIPTION
#  修复通过new-api代理api后缓存命中太低的bug

因为代理请求时候没有将原始请求的请求头带上去访问代理的api,导致codex和claude code客户端请求无法命中缓存

将原始请求头带到代理请求,缓存命中正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Forward incoming request headers to outbound API, form, and WebSocket requests to prevent missing authentication, session, and locale information.
  * Improves reliability of downstream integrations and proxies by preserving client headers end-to-end.
  * Reduces intermittent authorization errors and connection issues caused by dropped headers.
  * Ensures more consistent behavior across HTTP and WebSocket flows, including content type and custom header handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->