### PR TITLE
fix: skip Accept-Encoding during header passthrough (#2214)

### DIFF
--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -61,8 +61,9 @@ var passthroughSkipHeaderNamesLower = map[string]struct{}{
 	"cookie": {},
 
 	// Additional headers that should not be forwarded by name-matching passthrough rules.
-	"host":           {},
-	"content-length": {},
+	"host":            {},
+	"content-length":  {},
+	"accept-encoding": {},
 
 	// Do not passthrough credentials by wildcard/regex.
 	"authorization":  {},


### PR DESCRIPTION

  ## 背景
  开启请求头透传后，使用 `curl` 请求可能报错：
  `invalid character '\x1f' looking for beginning of value`（`bad_response_body`）。

  ## 根因
  透传规则（`*` / `re:`）把客户端 `Accept-Encoding` 也转发到了上游。
  在这种情况下，上游可能返回 gzip 压缩响应体，而当前链路会把该二进制内容按 JSON 解析，导致首字节 `0x1f` 触发解析失败。

  ## 修复内容
  - 在请求头透传黑名单中新增 `accept-encoding`，避免通过通配/正则透传该头。
  - 新增测试 `TestProcessHeaderOverride_PassthroughSkipsAcceptEncoding`，验证透传时会跳过 `Accept-Encoding`。

  ## 验证
  - `go test ./relay/channel -run TestProcessHeaderOverride -count=1`
  - `go test ./relay/channel -count=1`

  ## 影响范围
  - 仅影响“按名称透传”的头部规则（`*` / `re:` / `regex:`）。
  - 不影响其他头透传逻辑。
  - 显式 header override 仍可按配置覆盖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved incorrect header forwarding behavior in API requests to properly exclude accept-encoding headers while maintaining request traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->