### PR TITLE
feat: 支持通过 CHANNEL_WRITE_TIMEOUT 环境变量配置 channel 写入超时

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -147,6 +147,7 @@ func initConstantEnv() {
 	constant.TaskQueryLimit = GetEnvOrDefault("TASK_QUERY_LIMIT", 1000)
 	// 异步任务超时时间（分钟），超过此时间未完成的任务将被标记为失败并退款。0 表示禁用。
 	constant.TaskTimeoutMinutes = GetEnvOrDefault("TASK_TIMEOUT_MINUTES", 1440)
+	constant.ChannelWriteTimeout = GetEnvOrDefault("CHANNEL_WRITE_TIMEOUT", 10)
 
 	soraPatchStr := GetEnvOrDefaultString("TASK_PRICE_PATCH", "")
 	if soraPatchStr != "" {

--- a/constant/env.go
+++ b/constant/env.go
@@ -17,6 +17,7 @@ var GenerateDefaultToken bool
 var ErrorLogEnabled bool
 var TaskQueryLimit int
 var TaskTimeoutMinutes int
+var ChannelWriteTimeout int
 
 // temporary variable for sora patch, will be removed in future
 var TaskPricePatches []string

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -153,7 +153,7 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 						if common.DebugEnabled {
 							println("ping data sent")
 						}
-					case <-time.After(10 * time.Second):
+					case <-time.After(time.Duration(constant.ChannelWriteTimeout) * time.Second):
 						logger.LogError(c, "ping data send timeout")
 						return
 					case <-ctx.Done():


### PR DESCRIPTION
## Summary

Closes #2999

新增 `CHANNEL_WRITE_TIMEOUT` 环境变量，用于配置 `stream_scanner.go` 中 ping send 的 channel 写入超时时间。

### 改动说明（适配上游重构后）

上游已重构 `StreamScannerHandler`，将 data handler 改为 `dataChan` 直接传递，原有的 data handler 超时已不存在。本 PR 仅针对剩余的 **ping send 超时** 进行配置化：

- `constant/env.go`: 新增 `ChannelWriteTimeout` 变量
- `common/init.go`: 读取 `CHANNEL_WRITE_TIMEOUT` 环境变量（默认 10 秒，完全向后兼容）
- `relay/helper/stream_scanner.go`: 将 ping send 的 `time.After` 替换为可配置的 `constant.ChannelWriteTimeout`

### 使用方式

```bash
# 设置 channel 写入超时为 60 秒（适用于高负载场景下 ping 写入可能阻塞的情况）
CHANNEL_WRITE_TIMEOUT=60
```

### 修改原因

在高负载场景下，ping send 的 channel 写入可能因为 writer mutex 竞争而阻塞超过默认 10 秒。`STREAMING_TIMEOUT` 已支持环境变量配置，ping send 超时也应当支持。

默认值保持 10 秒，完全向后兼容，不影响现有用户。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout for channel write operations, allowing adjustment from the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->