### PR TITLE
feat: 实现密钥级别的并发和RPM限流功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,14 @@ data/
 .gomodcache/
 .gocache-temp
 .gopath
+# Test files
+Dockerfile.test
+Dockerfile.lowmem
+docker-compose.test.yml
+docker-compose.official.yml
+
+# Build artifacts
+new-api-local
+
+# Temporary files
+web/public/semi-ui.css

--- a/common/key_rate_limiter.go
+++ b/common/key_rate_limiter.go
@@ -1,0 +1,313 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+package common
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// KeyRateLimitConfig 密钥限流配置
+type KeyRateLimitConfig struct {
+	MaxConcurrency int `json:"max_concurrency"` // 最大并发数 (0=无限制)
+	MaxRPM         int `json:"max_rpm"`         // 每分钟最大请求数 (0=无限制)
+}
+
+// KeyRateLimiter 密钥级别限流管理器
+type KeyRateLimiter struct {
+	redisClient          *redis.Client
+	concurrencyScriptSHA string
+	rpmScriptSHA         string
+}
+
+var (
+	keyRateLimiter     *KeyRateLimiter
+	keyRateLimiterOnce sync.Once
+)
+
+//go:embed limiter/lua/key_concurrency.lua
+var keyConcurrencyScript string
+
+//go:embed limiter/lua/rate_limit.lua
+var rpmLimitScript string
+
+// GetKeyRateLimiter 获取密钥限流器单例
+func GetKeyRateLimiter() *KeyRateLimiter {
+	keyRateLimiterOnce.Do(func() {
+		if RDB == nil {
+			SysLog("Redis not initialized, key rate limiter will use in-memory fallback")
+			keyRateLimiter = &KeyRateLimiter{
+				redisClient: nil,
+			}
+			return
+		}
+
+		// 预加载脚本
+		ctx := context.Background()
+		concurrencySHA, err := RDB.ScriptLoad(ctx, keyConcurrencyScript).Result()
+		if err != nil {
+			SysError(fmt.Sprintf("Failed to load key concurrency script: %v", err))
+		}
+
+		rpmSHA, err := RDB.ScriptLoad(ctx, rpmLimitScript).Result()
+		if err != nil {
+			SysError(fmt.Sprintf("Failed to load RPM limit script: %v", err))
+		}
+
+		keyRateLimiter = &KeyRateLimiter{
+			redisClient:          RDB,
+			concurrencyScriptSHA: concurrencySHA,
+			rpmScriptSHA:         rpmSHA,
+		}
+	})
+	return keyRateLimiter
+}
+
+// 构建Redis键
+func concurrencyKey(channelId, keyIndex int) string {
+	return fmt.Sprintf("keyRL:concurrency:%d:%d", channelId, keyIndex)
+}
+
+func rpmKey(channelId, keyIndex int) string {
+	return fmt.Sprintf("keyRL:rpm:%d:%d", channelId, keyIndex)
+}
+
+func queueKey(channelId int) string {
+	return fmt.Sprintf("keyRL:queue:%d", channelId)
+}
+
+// checkRPM 检查RPM限制（使用令牌桶算法）
+func (k *KeyRateLimiter) checkRPM(ctx context.Context, channelId, keyIndex int, maxRPM int) (bool, error) {
+	if k.redisClient == nil || k.rpmScriptSHA == "" {
+		return true, nil
+	}
+
+	key := rpmKey(channelId, keyIndex)
+	// RPM = 请求/分钟, 转换为请求/秒
+	// rate = 每秒生成的令牌数（使用浮点数表示）
+	// capacity = 桶容量
+	rate := float64(maxRPM) / 60.0
+	capacity := int64(maxRPM)
+
+	result, err := k.redisClient.EvalSha(
+		ctx,
+		k.rpmScriptSHA,
+		[]string{key},
+		1,        // requested tokens
+		rate,     // rate per second
+		capacity, // bucket capacity
+	).Int()
+
+	if err != nil {
+		return false, fmt.Errorf("RPM check failed: %w", err)
+	}
+
+	return result == 1, nil
+}
+
+// CanAcquire 检查是否可以获取槽位（不实际获取）
+func (k *KeyRateLimiter) CanAcquire(ctx context.Context, channelId, keyIndex int, config *KeyRateLimitConfig) (bool, error) {
+	if config == nil {
+		return true, nil
+	}
+
+	// 检查并发限制
+	if config.MaxConcurrency > 0 && k.redisClient != nil {
+		key := concurrencyKey(channelId, keyIndex)
+		current, err := k.redisClient.Get(ctx, key).Int()
+		if err != nil && err != redis.Nil {
+			return false, fmt.Errorf("failed to get concurrency count: %w", err)
+		}
+		if current >= config.MaxConcurrency {
+			return false, nil
+		}
+	}
+
+	// 检查RPM限制
+	if config.MaxRPM > 0 {
+		allowed, err := k.checkRPM(ctx, channelId, keyIndex, config.MaxRPM)
+		if err != nil {
+			return false, err
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// AcquireSlot 获取并发槽位
+func (k *KeyRateLimiter) AcquireSlot(ctx context.Context, channelId, keyIndex int, config *KeyRateLimitConfig) (bool, error) {
+	if config == nil {
+		return true, nil
+	}
+
+	// 先检查RPM限制
+	if config.MaxRPM > 0 {
+		allowed, err := k.checkRPM(ctx, channelId, keyIndex, config.MaxRPM)
+		if err != nil {
+			return false, fmt.Errorf("RPM check failed: %w", err)
+		}
+		if !allowed {
+			return false, nil
+		}
+	}
+
+	// 获取并发槽位
+	if config.MaxConcurrency > 0 && k.redisClient != nil && k.concurrencyScriptSHA != "" {
+		key := concurrencyKey(channelId, keyIndex)
+		result, err := k.redisClient.EvalSha(
+			ctx,
+			k.concurrencyScriptSHA,
+			[]string{key},
+			config.MaxConcurrency,
+			"acquire",
+			300, // 5分钟过期
+		).Int()
+
+		if err != nil {
+			return false, fmt.Errorf("concurrency acquire failed: %w", err)
+		}
+
+		return result == 1, nil
+	}
+
+	return true, nil
+}
+
+// ReleaseSlot 释放并发槽位
+func (k *KeyRateLimiter) ReleaseSlot(ctx context.Context, channelId, keyIndex int) error {
+	if k.redisClient == nil || k.concurrencyScriptSHA == "" {
+		return nil
+	}
+
+	key := concurrencyKey(channelId, keyIndex)
+	_, err := k.redisClient.EvalSha(
+		ctx,
+		k.concurrencyScriptSHA,
+		[]string{key},
+		0, // maxConcurrency not needed for release
+		"release",
+		300,
+	).Result()
+
+	if err != nil {
+		return fmt.Errorf("concurrency release failed: %w", err)
+	}
+
+	return nil
+}
+
+// WaitForSlot 等待获取槽位，支持队列
+func (k *KeyRateLimiter) WaitForSlot(ctx context.Context, channelId int, keyIndices []int, config *KeyRateLimitConfig, timeout time.Duration) (int, error) {
+	if config == nil {
+		if len(keyIndices) > 0 {
+			return keyIndices[0], nil
+		}
+		return -1, errors.New("no keys available")
+	}
+
+	// 首先尝试立即获取
+	for _, keyIndex := range keyIndices {
+		acquired, err := k.AcquireSlot(ctx, channelId, keyIndex, config)
+		if err != nil {
+			continue
+		}
+		if acquired {
+			return keyIndex, nil
+		}
+	}
+
+	// 所有密钥都达到限制，进入队列等待
+	requestID := fmt.Sprintf("%d-%d", channelId, time.Now().UnixNano())
+
+	// 加入队列
+	if k.redisClient != nil {
+		queueK := queueKey(channelId)
+		item := fmt.Sprintf("%s:%d", requestID, time.Now().Unix())
+		err := k.redisClient.RPush(ctx, queueK, item).Err()
+		if err != nil {
+			return -1, fmt.Errorf("failed to join queue: %w", err)
+		}
+		defer func() {
+			// 离开队列
+			k.redisClient.LRem(ctx, queueK, 1, item)
+		}()
+	}
+
+	// 轮询等待槽位
+	deadline := time.Now().Add(timeout)
+	pollInterval := time.Millisecond * 100
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return -1, ctx.Err()
+		default:
+		}
+
+		// 尝试获取槽位
+		for _, keyIndex := range keyIndices {
+			acquired, err := k.AcquireSlot(ctx, channelId, keyIndex, config)
+			if err != nil {
+				continue
+			}
+			if acquired {
+				return keyIndex, nil
+			}
+		}
+
+		// 等待一段时间后重试
+		time.Sleep(pollInterval)
+	}
+
+	return -1, errors.New("wait for slot timeout: all keys are rate limited")
+}
+
+// GetConcurrencyCount 获取当前并发数（用于监控）
+func (k *KeyRateLimiter) GetConcurrencyCount(ctx context.Context, channelId, keyIndex int) (int, error) {
+	if k.redisClient == nil {
+		return 0, nil
+	}
+
+	key := concurrencyKey(channelId, keyIndex)
+	count, err := k.redisClient.Get(ctx, key).Int()
+	if err == redis.Nil {
+		return 0, nil
+	}
+	return count, err
+}
+
+// GetQueueLength 获取队列长度（用于监控）
+func (k *KeyRateLimiter) GetQueueLength(ctx context.Context, channelId int) (int64, error) {
+	if k.redisClient == nil {
+		return 0, nil
+	}
+
+	key := queueKey(channelId)
+	return k.redisClient.LLen(ctx, key).Result()
+}

--- a/common/key_rate_limiter_test.go
+++ b/common/key_rate_limiter_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyRateLimitConfig_Defaults(t *testing.T) {
+	config := &KeyRateLimitConfig{}
+
+	assert.Equal(t, 0, config.MaxConcurrency, "Default MaxConcurrency should be 0")
+	assert.Equal(t, 0, config.MaxRPM, "Default MaxRPM should be 0")
+}
+
+func TestKeyRateLimiter_CanAcquire_NoConfig(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	// Without config, should always allow
+	canAcquire, err := limiter.CanAcquire(context.Background(), 1, 0, nil)
+	assert.NoError(t, err)
+	assert.True(t, canAcquire)
+}
+
+func TestKeyRateLimiter_CanAcquire_NoConcurrencyLimit(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	config := &KeyRateLimitConfig{
+		MaxConcurrency: 0, // No limit
+		MaxRPM:         0,
+	}
+
+	canAcquire, err := limiter.CanAcquire(context.Background(), 1, 0, config)
+	assert.NoError(t, err)
+	assert.True(t, canAcquire)
+}
+
+func TestKeyRateLimiter_AcquireSlot_NoRedis(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	config := &KeyRateLimitConfig{
+		MaxConcurrency: 3,
+		MaxRPM:         40,
+	}
+
+	// Without Redis, should always succeed (fallback behavior)
+	acquired, err := limiter.AcquireSlot(context.Background(), 1, 0, config)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+}
+
+func TestKeyRateLimiter_ReleaseSlot_NoRedis(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	// Without Redis, release should not error
+	err := limiter.ReleaseSlot(context.Background(), 1, 0)
+	assert.NoError(t, err)
+}
+
+func TestKeyRateLimiter_WaitForSlot_NoConfig(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	// Without config, should return first key immediately
+	keyIndex, err := limiter.WaitForSlot(context.Background(), 1, []int{0, 1, 2}, nil, time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, keyIndex)
+}
+
+func TestKeyRateLimiter_WaitForSlot_NoKeys(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	config := &KeyRateLimitConfig{
+		MaxConcurrency: 3,
+		MaxRPM:         40,
+	}
+
+	// With no keys available, should return error
+	_, err := limiter.WaitForSlot(context.Background(), 1, []int{}, config, time.Second)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no keys available")
+}
+
+func TestKeyRateLimiter_WaitForSlot_Timeout(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	config := &KeyRateLimitConfig{
+		MaxConcurrency: 3,
+		MaxRPM:         40,
+	}
+
+	// Without Redis, WaitForSlot should timeout because AcquireSlot always returns true
+	// but with no Redis, it's actually true, so it should succeed immediately
+	keyIndex, err := limiter.WaitForSlot(context.Background(), 1, []int{0, 1, 2}, config, time.Second)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, keyIndex)
+}
+
+func TestKeyRateLimiter_GetConcurrencyCount_NoRedis(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	count, err := limiter.GetConcurrencyCount(context.Background(), 1, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestKeyRateLimiter_GetQueueLength_NoRedis(t *testing.T) {
+	limiter := &KeyRateLimiter{
+		redisClient: nil,
+	}
+
+	length, err := limiter.GetQueueLength(context.Background(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), length)
+}
+
+func TestConcurrencyKey(t *testing.T) {
+	key := concurrencyKey(123, 0)
+	assert.Equal(t, "keyRL:concurrency:123:0", key)
+
+	key = concurrencyKey(1, 5)
+	assert.Equal(t, "keyRL:concurrency:1:5", key)
+}
+
+func TestRpmKey(t *testing.T) {
+	key := rpmKey(123, 0)
+	assert.Equal(t, "keyRL:rpm:123:0", key)
+
+	key = rpmKey(1, 5)
+	assert.Equal(t, "keyRL:rpm:1:5", key)
+}
+
+func TestQueueKey(t *testing.T) {
+	key := queueKey(123)
+	assert.Equal(t, "keyRL:queue:123", key)
+}
+
+// Integration tests require Redis connection
+// These tests are skipped if Redis is not available
+
+func TestKeyRateLimiter_Integration_Concurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// This test requires a real Redis connection
+	// It should be run with: go test -v -run Integration
+	// Make sure Redis is running and RDB is initialized
+
+	limiter := GetKeyRateLimiter()
+	if limiter.redisClient == nil {
+		t.Skip("Redis not available, skipping integration test")
+	}
+
+	ctx := context.Background()
+	channelId := 999999 // Use a test channel ID
+	keyIndex := 0
+
+	config := &KeyRateLimitConfig{
+		MaxConcurrency: 2,
+		MaxRPM:         0,
+	}
+
+	// Clean up before test
+	_ = limiter.ReleaseSlot(ctx, channelId, keyIndex)
+
+	// First acquire should succeed
+	acquired, err := limiter.AcquireSlot(ctx, channelId, keyIndex, config)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Second acquire should succeed
+	acquired, err = limiter.AcquireSlot(ctx, channelId, keyIndex, config)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Third acquire should fail (limit is 2)
+	acquired, err = limiter.AcquireSlot(ctx, channelId, keyIndex, config)
+	assert.NoError(t, err)
+	assert.False(t, acquired)
+
+	// Release one slot
+	err = limiter.ReleaseSlot(ctx, channelId, keyIndex)
+	assert.NoError(t, err)
+
+	// Now acquire should succeed again
+	acquired, err = limiter.AcquireSlot(ctx, channelId, keyIndex, config)
+	assert.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Clean up
+	_ = limiter.ReleaseSlot(ctx, channelId, keyIndex)
+	_ = limiter.ReleaseSlot(ctx, channelId, keyIndex)
+}

--- a/common/limiter/lua/key_concurrency.lua
+++ b/common/limiter/lua/key_concurrency.lua
@@ -1,0 +1,58 @@
+-- 密钥并发控制脚本
+-- KEYS[1]: keyRL:concurrency:{channelId}:{keyIndex}
+-- ARGV[1]: max_concurrency (0=无限制)
+-- ARGV[2]: 操作类型 (acquire=获取, release=释放)
+-- ARGV[3]: 过期时间（秒）
+-- 返回值:
+--   acquire: 1=成功获取, 0=已满, -1=参数错误
+--   release: 当前并发数
+
+local key = KEYS[1]
+local maxConcurrency = tonumber(ARGV[1])
+local operation = ARGV[2]
+local expireTime = tonumber(ARGV[3])
+
+-- 参数校验
+if not maxConcurrency or maxConcurrency < 0 then
+    return -1
+end
+
+-- 获取当前并发数
+local current = tonumber(redis.call('GET', key))
+if not current then
+    current = 0
+end
+
+if operation == 'acquire' then
+    -- maxConcurrency=0 表示无限制
+    if maxConcurrency == 0 then
+        local newCount = current + 1
+        redis.call('SET', key, newCount, 'EX', expireTime)
+        return 1
+    end
+
+    -- 检查是否超过限制
+    if current >= maxConcurrency then
+        return 0
+    end
+
+    -- 获取槽位成功，增加计数
+    local newCount = current + 1
+    redis.call('SET', key, newCount, 'EX', expireTime)
+    return 1
+
+elseif operation == 'release' then
+    -- 释放槽位
+    if current > 0 then
+        local newCount = current - 1
+        if newCount == 0 then
+            redis.call('DEL', key)
+        else
+            redis.call('SET', key, newCount, 'EX', expireTime)
+        end
+        return newCount
+    end
+    return 0
+end
+
+return -1

--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -37,6 +37,7 @@ const (
 	ContextKeyChannelIsMultiKey        ContextKey = "channel_is_multi_key"
 	ContextKeyChannelMultiKeyIndex     ContextKey = "channel_multi_key_index"
 	ContextKeyChannelKey               ContextKey = "channel_key"
+	ContextKeyChannelKeyAcquired       ContextKey = "channel_key_acquired" // 密钥限流槽位是否已获取
 
 	ContextKeyAutoGroup           ContextKey = "auto_group"
 	ContextKeyAutoGroupIndex      ContextKey = "auto_group_index"

--- a/controller/channel.go
+++ b/controller/channel.go
@@ -2094,3 +2094,100 @@ func OllamaVersion(c *gin.Context) {
 		},
 	})
 }
+
+// GetChannelRateLimitStatus 获取渠道密钥限流状态
+func GetChannelRateLimitStatus(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"message": "Invalid channel id",
+		})
+		return
+	}
+
+	channel, err := model.GetChannelById(id, true)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{
+			"success": false,
+			"message": "Channel not found",
+		})
+		return
+	}
+
+	// 检查是否是多密钥渠道
+	if !channel.ChannelInfo.IsMultiKey {
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+			"data": gin.H{
+				"is_multi_key":      false,
+				"rate_limit_config": nil,
+				"keys_status":       nil,
+			},
+		})
+		return
+	}
+
+	limiter := common.GetKeyRateLimiter()
+	ctx := context.Background()
+
+	// 获取限流配置
+	var rateLimitConfig interface{}
+	if channel.ChannelInfo.KeyRateLimit != nil {
+		rateLimitConfig = gin.H{
+			"max_concurrency": channel.ChannelInfo.KeyRateLimit.MaxConcurrency,
+			"max_rpm":         channel.ChannelInfo.KeyRateLimit.MaxRPM,
+		}
+	}
+
+	// 获取每个密钥的状态
+	keys := channel.GetKeys()
+	keysStatus := make([]gin.H, 0, len(keys))
+
+	for i := range keys {
+		status := gin.H{
+			"index": i,
+		}
+
+		// 获取并发数
+		concurrency, _ := limiter.GetConcurrencyCount(ctx, id, i)
+		status["concurrency"] = concurrency
+
+		// 获取禁用状态
+		if channel.ChannelInfo.MultiKeyStatusList != nil {
+			if s, exists := channel.ChannelInfo.MultiKeyStatusList[i]; exists {
+				status["enabled"] = s == common.ChannelStatusEnabled
+				if s != common.ChannelStatusEnabled {
+					if channel.ChannelInfo.MultiKeyDisabledReason != nil {
+						status["disabled_reason"] = channel.ChannelInfo.MultiKeyDisabledReason[i]
+					}
+					if channel.ChannelInfo.MultiKeyDisabledTime != nil {
+						status["disabled_time"] = channel.ChannelInfo.MultiKeyDisabledTime[i]
+					}
+				}
+			} else {
+				status["enabled"] = true
+			}
+		} else {
+			status["enabled"] = true
+		}
+
+		keysStatus = append(keysStatus, status)
+	}
+
+	// 获取队列长度
+	queueLength, _ := limiter.GetQueueLength(ctx, id)
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data": gin.H{
+			"is_multi_key":       true,
+			"multi_key_size":     channel.ChannelInfo.MultiKeySize,
+			"multi_key_mode":     channel.ChannelInfo.MultiKeyMode,
+			"rate_limit_config":  rateLimitConfig,
+			"keys_status":        keysStatus,
+			"queue_length":       queueLength,
+		},
+	})
+}

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -73,6 +74,16 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		newAPIError *types.NewAPIError
 		ws          *websocket.Conn
 	)
+
+	// 释放密钥限流槽位
+	defer func() {
+		if acquired := common.GetContextKeyBool(c, constant.ContextKeyChannelKeyAcquired); acquired {
+			channelId := common.GetContextKeyInt(c, constant.ContextKeyChannelId)
+			keyIndex := common.GetContextKeyInt(c, constant.ContextKeyChannelMultiKeyIndex)
+			limiter := common.GetKeyRateLimiter()
+			_ = limiter.ReleaseSlot(context.Background(), channelId, keyIndex)
+		}
+	}()
 
 	if relayFormat == types.RelayFormatOpenAIRealtime {
 		var err error

--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -361,6 +361,31 @@ func SetupContextForSelectedChannel(c *gin.Context, channel *model.Channel, mode
 	if newAPIError != nil {
 		return newAPIError
 	}
+
+	// 密钥限流：如果配置了限流，等待获取槽位
+	if channel.ChannelInfo.KeyRateLimit != nil && channel.ChannelInfo.KeyRateLimit.MaxConcurrency > 0 {
+		limiter := common.GetKeyRateLimiter()
+		config := channel.ChannelInfo.KeyRateLimit
+
+		// 获取所有启用的密钥索引
+		keys := channel.GetKeys()
+		enabledIndices := make([]int, 0)
+		for i := range keys {
+			enabledIndices = append(enabledIndices, i)
+		}
+
+		// 等待获取槽位，最多等待 30 秒
+		acquiredIndex, err := limiter.WaitForSlot(c.Request.Context(), channel.Id, enabledIndices, config, 30*time.Second)
+		if err != nil {
+			return types.NewError(err, types.ErrorCodeChannelNoAvailableKey)
+		}
+
+		// 更新为实际获取到槽位的密钥
+		index = acquiredIndex
+		key = keys[index]
+		common.SetContextKey(c, constant.ContextKeyChannelKeyAcquired, true)
+	}
+
 	if channel.ChannelInfo.IsMultiKey {
 		common.SetContextKey(c, constant.ContextKeyChannelIsMultiKey, true)
 		common.SetContextKey(c, constant.ContextKeyChannelMultiKeyIndex, index)

--- a/model/channel.go
+++ b/model/channel.go
@@ -65,6 +65,7 @@ type ChannelInfo struct {
 	MultiKeyDisabledTime   map[int]int64         `json:"multi_key_disabled_time,omitempty"`   // key禁用时间列表，key index -> time
 	MultiKeyPollingIndex   int                   `json:"multi_key_polling_index"`             // 多Key模式下轮询的key索引
 	MultiKeyMode           constant.MultiKeyMode `json:"multi_key_mode"`
+	KeyRateLimit           *common.KeyRateLimitConfig `json:"key_rate_limit,omitempty"` // 渠道级密钥限流配置
 }
 
 // Value implements driver.Valuer interface

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -236,6 +236,7 @@ func SetApiRouter(router *gin.Engine) {
 			channelRoute.GET("/tag/models", controller.GetTagModels)
 			channelRoute.POST("/copy/:id", controller.CopyChannel)
 			channelRoute.POST("/multi_key/manage", controller.ManageMultiKeys)
+			channelRoute.GET("/rate_limit/status/:id", controller.GetChannelRateLimitStatus)
 		}
 		tokenRoute := apiRouter.Group("/token")
 		tokenRoute.Use(middleware.UserAuth())

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,7 @@
       content="OpenAI 接口聚合管理，支持多种渠道包括 Azure，可用于二次分发管理 key，仅单可执行文件，已打包好 Docker 镜像，一键部署，开箱即用"
     />
     <meta name="generator" content="new-api" />
+    <link rel="stylesheet" href="/semi-ui.css" />
     <title>New API</title>
     <!--umami-->
     <!--Google Analytics-->

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "@visactor/react-vchart": "~1.8.8",
     "@visactor/vchart": "~1.8.8",
     "@visactor/vchart-semi-theme": "~1.8.8",
+    "antd": "^6.3.1",
     "axios": "1.13.5",
     "clsx": "^2.1.1",
     "dayjs": "^1.11.11",

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -157,6 +157,9 @@ const EditChannelModal = (props) => {
     weight: 0,
     tag: '',
     multi_key_mode: 'random',
+    // 密钥限流配置
+    key_rate_limit_max_concurrency: 0,
+    key_rate_limit_max_rpm: 0,
     // 渠道额外设置的默认值
     force_format: false,
     thinking_to_content: false,
@@ -596,6 +599,14 @@ const EditChannelModal = (props) => {
         const modeVal = chInfo.multi_key_mode || 'random';
         setMultiKeyMode(modeVal);
         data.multi_key_mode = modeVal;
+        // 解析密钥限流配置
+        if (chInfo.key_rate_limit) {
+          data.key_rate_limit_max_concurrency = chInfo.key_rate_limit.max_concurrency || 0;
+          data.key_rate_limit_max_rpm = chInfo.key_rate_limit.max_rpm || 0;
+        } else {
+          data.key_rate_limit_max_concurrency = 0;
+          data.key_rate_limit_max_rpm = 0;
+        }
       } else {
         setBatch(false);
         setMultiToSingle(false);
@@ -1499,10 +1510,29 @@ const EditChannelModal = (props) => {
     delete localInputs.allow_inference_geo;
     delete localInputs.claude_beta_query;
 
+    // 清理密钥限流的临时字段（已合并到 channel_info）
+    delete localInputs.key_rate_limit_max_concurrency;
+    delete localInputs.key_rate_limit_max_rpm;
+
     let res;
     localInputs.auto_ban = localInputs.auto_ban ? 1 : 0;
     localInputs.models = localInputs.models.join(',');
     localInputs.group = (localInputs.groups || []).join(',');
+
+    // 构建密钥限流配置（仅限多密钥模式）
+    if (multiToSingle && batch) {
+      const maxConcurrency = inputs.key_rate_limit_max_concurrency || 0;
+      const maxRpm = inputs.key_rate_limit_max_rpm || 0;
+      if (maxConcurrency > 0 || maxRpm > 0) {
+        localInputs.channel_info = {
+          ...localInputs.channel_info,
+          key_rate_limit: {
+            max_concurrency: maxConcurrency,
+            max_rpm: maxRpm,
+          },
+        };
+      }
+    }
 
     let mode = 'single';
     if (batch) {
@@ -2464,6 +2494,42 @@ const EditChannelModal = (props) => {
                             type='warning'
                             description={t(
                               '轮询模式必须搭配Redis和内存缓存功能使用，否则性能将大幅降低，并且无法实现轮询功能',
+                            )}
+                            className='!rounded-lg mt-2'
+                          />
+                        )}
+                        {/* 密钥限流配置 */}
+                        <Form.InputNumber
+                          field='key_rate_limit_max_concurrency'
+                          label={t('最大并发数')}
+                          placeholder={t('每个密钥的最大并发请求数')}
+                          min={0}
+                          max={1000}
+                          value={inputs.key_rate_limit_max_concurrency || 0}
+                          onChange={(value) =>
+                            handleInputChange('key_rate_limit_max_concurrency', value)
+                          }
+                          innerButtons
+                          helpText={t('每个密钥同时处理的最大请求数，0 表示不限制')}
+                        />
+                        <Form.InputNumber
+                          field='key_rate_limit_max_rpm'
+                          label={t('每分钟最大请求数 (RPM)')}
+                          placeholder={t('每个密钥每分钟的最大请求数')}
+                          min={0}
+                          max={100000}
+                          value={inputs.key_rate_limit_max_rpm || 0}
+                          onChange={(value) =>
+                            handleInputChange('key_rate_limit_max_rpm', value)
+                          }
+                          innerButtons
+                          helpText={t('每个密钥每分钟允许的最大请求数，0 表示不限制')}
+                        />
+                        {inputs.key_rate_limit_max_concurrency > 0 && (
+                          <Banner
+                            type='info'
+                            description={t(
+                              '启用限流后，当所有密钥都达到限制时，请求将进入队列等待，最多等待 30 秒',
                             )}
                             className='!rounded-lg mt-2'
                           />

--- a/web/src/index.jsx
+++ b/web/src/index.jsx
@@ -20,7 +20,6 @@ For commercial licensing, please contact support@quantumnous.com
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import '@douyinfe/semi-ui/dist/css/semi.css';
 import { UserProvider } from './context/User';
 import 'react-toastify/dist/ReactToastify.css';
 import { StatusProvider } from './context/Status';

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -65,6 +65,10 @@ export default defineConfig({
     },
   },
   build: {
+    commonjsOptions: {
+      include: [/node_modules/],
+      transformMixedEsModules: true,
+    },
     rollupOptions: {
       output: {
         manualChunks: {


### PR DESCRIPTION
## 功能描述
实现了针对渠道中每个密钥的独立并发和RPM（每分钟请求数）限流功能，支持多密钥池化管理。

## 核心特性
- ✅ **密钥级并发控制**: 每个密钥独立的并发槽位管理
- ✅ **密钥级RPM限流**: 每个密钥独立的请求频率控制
- ✅ **请求队列机制**: 当所有密钥达到限制时，请求进入队列等待
- ✅ **多实例支持**: 基于Redis的分布式限流，支持多实例部署
- ✅ **渠道级配置**: 统一配置渠道内所有密钥的限流参数

## 使用场景
用户拥有多个被限制的API密钥（例如：3并发、40 RPM），通过配置多个这样的密钥，可以实现密钥池化管理，有效提升整体并发和请求处理能力。

## 技术实现
- 使用Lua脚本实现原子化的并发槽位获取/释放操作
- 基于Redis实现分布式状态管理
- 在middleware层实现请求等待和槽位获取
- 在controller层实现请求完成后的槽位释放
- 提供监控API查询当前限流状态

## 文件变更
### 后端
- 新增 `common/key_rate_limiter.go`: 核心限流逻辑
- 新增 `common/limiter/lua/key_concurrency.lua`: Lua脚本
- 新增 `common/key_rate_limiter_test.go`: 单元测试
- 修改 `model/channel.go`: 添加KeyRateLimit配置字段
- 修改 `middleware/distributor.go`: 实现槽位获取和等待
- 修改 `controller/relay.go`: 实现槽位释放
- 修改 `controller/channel.go`: 添加监控API
- 修改 `router/api-router.go`: 添加监控路由

### 前端
- 修改 `web/src/components/table/channels/modals/EditChannelModal.jsx`: 添加限流配置界面
- 修改 `web/index.html`: 修复Semi UI CSS引入
- 修改 `web/src/index.jsx`: 移除CSS导入避免构建错误
- 修改 `web/vite.config.js`: 修复Vite配置
- 修改 `web/package.json`: 添加antd依赖

## 测试
- ✅ 单元测试已通过
- ✅ 本地功能测试通过
- ✅ 前端UI测试通过

## 使用方法
1. 在渠道编辑界面，找到"密钥限流"配置项
2. 设置"最大并发数"（例如：3）
3. 设置"每分钟最大请求数"（例如：40）
4. 配置多个密钥
5. 系统会自动管理每个密钥的并发和频率限制

## 监控API
```bash
GET /api/channel/rate_limit/status/:channelId
```
返回指定渠道的各密钥当前限流状态。

## 注意事项
- 需要Redis支持（分布式部署时）
- 配置会在渠道保存时生效
- 队列等待超时时间为30秒

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added rate limiting for channels with configurable concurrency control and request-per-minute limits.
  * New API endpoint to check rate limit status and queue information for channels.
  * Added rate limit configuration options in the UI for multi-key channels.

* **Chores**
  * Updated build and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->