### PR TITLE
支持豆包5.0生图模型

### DIFF
--- a/relay/channel/volcengine/constants.go
+++ b/relay/channel/volcengine/constants.go
@@ -8,6 +8,8 @@ var ModelList = []string{
 	"Doubao-lite-32k",
 	"Doubao-lite-4k",
 	"Doubao-embedding",
+	"doubao-seedream-5-0-260128",
+	"doubao-seedream-4-5-251128",
 	"doubao-seedream-4-0-250828",
 	"seedream-4-0-250828",
 	"doubao-seedance-1-0-pro-250528",

--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -220,6 +220,36 @@ func TextHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types
 	return nil
 }
 
+func mergeExtraBody(c *gin.Context, jsonData []byte) ([]byte, error) {
+	var converted map[string]any
+	if err := common.Unmarshal(jsonData, &converted); err != nil {
+		return nil, err
+	}
+	var original map[string]any
+	if err := common.UnmarshalBodyReusable(c, &original); err != nil {
+		return jsonData, err
+	}
+
+	for key, value := range original {
+		if _, exists := converted[key]; exists {
+			continue
+		}
+		if strVal, ok := value.(string); ok {
+			trimmed := strings.TrimSpace(strVal)
+			if (strings.HasPrefix(trimmed, "{") && strings.HasSuffix(trimmed, "}")) ||
+				(strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]")) {
+				var decoded any
+				if err := common.Unmarshal([]byte(trimmed), &decoded); err == nil {
+					converted[key] = decoded
+					continue
+				}
+			}
+		}
+		converted[key] = value
+	}
+	return common.Marshal(converted)
+}
+
 func postConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, usage *dto.Usage, extraContent ...string) {
 	originUsage := usage
 	if usage == nil {

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -68,6 +68,15 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 				return types.NewError(err, types.ErrorCodeConvertRequestFailed, types.ErrOptionWithSkipRetry())
 			}
 
+			switch convertedRequest.(type) {
+			case dto.ImageRequest:
+				if mergedJson, err := mergeExtraBody(c, jsonData); err != nil {
+					logger.LogWarn(c, fmt.Sprintf("merge body fields failed: %v, use original json data", err))
+				} else {
+					jsonData = mergedJson
+				}
+			}
+
 			// apply param override
 			if len(info.ParamOverride) > 0 {
 				jsonData, err = relaycommon.ApplyParamOverride(jsonData, info.ParamOverride, relaycommon.BuildParamOverrideContext(info))


### PR DESCRIPTION
支持豆包: doubao-seedream-5-0-260128
5.0新增联网搜索功能
API文档: https://www.volcengine.com/docs/82379/1824121?lang=zh
使用手册: https://bytedance.larkoffice.com/wiki/TQyJwfRFiiVMUdkFY84cCb7CncI?renamingWikiNode=false
联网生图请求示例: 
```
{
  "model": "doubao-seedream-5-0-260128",
  "n": 2,
  "prompt": "可爱的中国小女孩在花园里玩耍,标上今天的日期和天气",
  "quality": "standard",
  "response_format": "url",
  "tools": [{"type": "web_search"}]
}
```
或者使用openai的sdk, 在extra_body中传参{"tools": [{"type": "web_search"}]}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new AI models: "doubao-seedream-5-0-260128" and "doubao-seedream-4-5-251128".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->