### PR TITLE
feat: add Ambient as a channel provider

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -75,6 +75,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeReplicate
 	case constant.ChannelTypeCodex:
 		apiType = constant.APITypeCodex
+	case constant.ChannelTypeAmbient:
+		apiType = constant.APITypeOpenAI
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -55,6 +55,7 @@ const (
 	ChannelTypeSora           = 55
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
+	ChannelTypeAmbient        = 58
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -118,6 +119,7 @@ var ChannelBaseURLs = []string{
 	"https://api.openai.com",                    //55
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
+	"https://api.ambient.xyz",                   //58
 }
 
 var ChannelTypeNames = map[int]string{
@@ -175,6 +177,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSora:           "Sora",
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "Codex",
+	ChannelTypeAmbient:        "Ambient",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -313,6 +313,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMoonshot:    true,
 	constant.ChannelTypeMiniMax:     true,
 	constant.ChannelTypeSiliconFlow: true,
+	constant.ChannelTypeAmbient:     true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/web/src/constants/channel.constants.js
+++ b/web/src/constants/channel.constants.js
@@ -189,6 +189,11 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'Codex (OpenAI OAuth)',
   },
+  {
+    value: 58,
+    color: 'indigo',
+    label: 'Ambient',
+  },
 ];
 
 export const MODEL_TABLE_PAGE_SIZE = 10;


### PR DESCRIPTION
### Summary

- Add Ambient as a new channel provider 
- Ambient is an OpenAI-compatible API (`https://api.ambient.xyz/v1`) serving GLM 4.6 on a Solana-based Proof of Logits (PoL) network with verifiable LLM inference
- Supports chat completions with streaming and `stream_options`

### Links ( for context)

- Website: https://ambient.xyz
- Litepaper: https://ambient.xyz/Ambient_Litepaper_V1.pdf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ambient channel integration with streaming enabled
  * Ambient channel is now available as a selectable option in the UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->