### PR TITLE
fix: force stream=true for codex model channel test

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -685,12 +685,12 @@ func buildTestRequest(model string, endpointType string, channel *model.Channel,
 		}
 	}
 
-	// Responses-only models (e.g. codex series)
+	// Responses-only models (e.g. codex series) — always stream
 	if strings.Contains(strings.ToLower(model), "codex") {
 		return &dto.OpenAIResponsesRequest{
 			Model:  model,
 			Input:  json.RawMessage(`[{"role":"user","content":"hi"}]`),
-			Stream: isStream,
+			Stream: true,
 		}
 	}
 


### PR DESCRIPTION
## Problem

When testing channels with codex-series models (e.g. `gpt-5.3-codex`), the channel test sends `stream: false` by default. Many upstream providers only support streaming for the `/v1/responses` endpoint, causing the test to fail with:

```
bad response status code 400, body: only support stream
```

## Fix

Force `Stream: true` in `buildTestRequest` for codex models (auto-detected via model name containing "codex"). This matches the real-world behavior where codex models are always called with streaming enabled.

## Changes

- `controller/channel-test.go`: Set `Stream: true` instead of `Stream: isStream` for codex model test requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test behavior to ensure consistent streaming mode handling for specific model types.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->