### PR TITLE
fix: 修复 token 表 model_limits 字段长度限制问题

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -23,7 +23,7 @@ type Token struct {
 	RemainQuota        int            `json:"remain_quota" gorm:"default:0"`
 	UnlimitedQuota     bool           `json:"unlimited_quota"`
 	ModelLimitsEnabled bool           `json:"model_limits_enabled"`
-	ModelLimits        string         `json:"model_limits" gorm:"type:varchar(1024);default:''"`
+	ModelLimits        string         `json:"model_limits" gorm:"type:text;default:''"`
 	AllowIps           *string        `json:"allow_ips" gorm:"default:''"`
 	UsedQuota          int            `json:"used_quota" gorm:"default:0"` // used quota
 	Group              string         `json:"group" gorm:"default:''"`

--- a/scripts/migrations/README.md
+++ b/scripts/migrations/README.md
@@ -1,0 +1,33 @@
+# 数据库迁移脚本
+
+本目录包含数据库结构变更的迁移脚本。
+
+## 使用说明
+
+### fix_token_model_limits_postgresql.sql
+
+**问题描述：**
+当 token 的 `model_limits` 字段内容过长时（超过 1024 字符），PostgreSQL 会报错：
+```
+ERROR: value too long for type character varying(1024) (SQLSTATE 22001)
+```
+
+**解决方案：**
+将 `tokens` 表的 `model_limits` 字段类型从 `varchar(1024)` 改为 `text`。
+
+**适用数据库：**
+- PostgreSQL
+
+**执行方法：**
+```bash
+# 连接到 PostgreSQL 数据库
+psql -U your_username -d your_database -f fix_token_model_limits_postgresql.sql
+```
+
+**注意事项：**
+1. 此变更向后兼容，不会影响现有数据
+2. MySQL 和 SQLite 用户：GORM 会在下次启动时自动应用 `text` 类型
+3. 建议在执行前备份数据库
+
+**相关代码变更：**
+- `model/token.go` 第 26 行：`gorm:"type:varchar(1024)"` → `gorm:"type:text"`

--- a/scripts/migrations/fix_token_model_limits_postgresql.sql
+++ b/scripts/migrations/fix_token_model_limits_postgresql.sql
@@ -1,0 +1,6 @@
+-- 修复 tokens 表 model_limits 字段长度限制问题
+-- 问题：当模型列表过长时，varchar(1024) 会导致 "value too long for type character varying(1024)" 错误
+-- 解决：将字段类型从 varchar(1024) 改为 text
+
+-- PostgreSQL
+ALTER TABLE tokens ALTER COLUMN model_limits TYPE TEXT;


### PR DESCRIPTION
- 将 model_limits 字段类型从 varchar(1024) 改为 text
- 添加 PostgreSQL 迁移脚本
- 添加迁移说明文档

问题：当模型列表过长时，PostgreSQL 报错 'value too long for type character varying(1024)' 解决：使用 text 类型支持任意长度的模型列表，兼容 SQLite/MySQL/PostgreSQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased storage capacity for model limits configuration, removing the previous 1024-character limitation.

* **Documentation**
  * Added migration documentation and PostgreSQL migration script for updating the database structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->