### PR TITLE
fix: handle nil usage in channel test to prevent panic when upstream omits usage field

### DIFF
--- a/web/src/hooks/channels/useChannelsData.jsx
+++ b/web/src/hooks/channels/useChannelsData.jsx
@@ -903,22 +903,23 @@ export const useChannelsData = () => {
           channel.test_time = Date.now() / 1000;
         });
 
+        let successMsg;
         if (!model || model === '') {
-          showInfo(
-            t('通道 ${name} 测试成功，耗时 ${time.toFixed(2)} 秒。')
+          successMsg = t('通道 ${name} 测试成功，耗时 ${time.toFixed(2)} 秒。')
               .replace('${name}', record.name)
-              .replace('${time.toFixed(2)}', time.toFixed(2)),
-          );
+              .replace('${time.toFixed(2)}', time.toFixed(2));
         } else {
-          showInfo(
-            t(
+          successMsg = t(
               '通道 ${name} 测试成功，模型 ${model} 耗时 ${time.toFixed(2)} 秒。',
             )
               .replace('${name}', record.name)
               .replace('${model}', model)
-              .replace('${time.toFixed(2)}', time.toFixed(2)),
-          );
+              .replace('${time.toFixed(2)}', time.toFixed(2));
         }
+        if (message) {
+          successMsg += ' ' + message;
+        }
+        showInfo(successMsg);
       } else {
         showError(`${t('模型')} ${model}: ${message}`);
       }


### PR DESCRIPTION
### descrption

When the channel returns a response missing the usage field, the channel test will throw a null pointer exception.

This prevents the UI from determining whether the test succeeded, potentially resulting in scenarios where the feature is actually available but the channel test fails.

### content

This PR improves the backend channel test's handling of missing usage fields.

Adding the message return value to the frontend.

### before:

<img width="2230" height="547" alt="image" src="https://github.com/user-attachments/assets/a3c2c9f9-1148-4113-887d-756e541d777b" />

<img width="1762" height="840" alt="image" src="https://github.com/user-attachments/assets/52d3b05e-5007-4cdf-a182-705e8a67ff11" />

```log
[SYS] 2026/02/27 - 12:48:28 | 任务进度轮询开始
[SYS] 2026/02/27 - 12:48:28 | 任务进度轮询完成
[SYS] 2026/02/27 - 12:48:29 | testing channel 2 with model grok-3 , info RelayInfo{ RelayFormat: openai, RelayMode: 1, IsStream: false, IsPlayground: false, RequestURLPath: "/v1/chat/completions", OriginModelName: "grok-3", EstimatePromptTokens: 0, ShouldIncludeUsage: false, DisablePing: false, SendResponseCount: 0, FinalPreConsumedQuota: 0, User{ Id: 0, Email: "***masked***", Group: "default", UsingGroup: "default", Quota: 98789936 }, Token{ Id: 0, Unlimited: false, Key: ***masked*** }, Timing{ Start: 2026-02-27T12:48:29.015371797+08:00, FirstResponse: 2026-02-27T12:48:28.015371797+08:00, LatencyMs: -1000 }, ChannelMeta{ Type: 48, Id: 2, IsMultiKey: false, MultiKeyIndex: 0, BaseURL: "https://***masked***.workers.dev", ApiType: 27, ApiVersion: "", Organization: "", CreateTime: 1772125941, UpstreamModelName: "grok-3", IsModelMapped: false, SupportStreamOptions: true, ApiKey: ***masked*** }, }

2026/02/27 12:48:30 [Recovery] 2026/02/27 - 12:48:30 panic recovered:
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:336 (0x4902f7)
/usr/local/go/src/runtime/signal_unix.go:931 (0x4902c5)
/build/controller/channel-test.go:462 (0x14b0e25)
/build/controller/channel-test.go:750 (0x14b2e11)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x12d3215)
/build/middleware/auth.go:137 (0x12d2aec)
/build/middleware/auth.go:159 (0x15481d7)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/build/middleware/body_cleanup.go:14 (0x1544b37)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x1538546)
/go/pkg/mod/github.com/gin-contrib/gzip@v0.0.6/handler.go:60 (0x153852e)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/build/middleware/logger.go:15 (0x153f3bb)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/go/pkg/mod/github.com/gin-contrib/sessions@v0.0.5/sessions.go:54 (0x15790c4)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9f665c)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x9f6643)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/build/middleware/i18n.go:17 (0x157afe6)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/build/middleware/cors.go:21 (0x157af7b)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9eacaa)
/build/middleware/request-id.go:17 (0x157af17)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9f756e)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x9f755b)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x9f5bea)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x9f5880)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x9f53cc)
/usr/local/go/src/net/http/server.go:3311 (0x74696d)
/usr/local/go/src/net/http/server.go:2073 (0x72540f)
/usr/local/go/src/runtime/asm_amd64.s:1771 (0x495860)

[SYS] 2026/02/27 - 12:48:30 | panic detected: runtime error: invalid memory address or nil pointer dereference
```

### after:

<img width="2203" height="516" alt="image" src="https://github.com/user-attachments/assets/f0c769f3-c9b8-42ea-aa85-4927a8b38f06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test results now display detailed messages from test runs to users, providing better feedback on test status.

* **Bug Fixes**
  * Improved resilience and error handling when usage data is unavailable during test operations.
  * Prevents potential errors with missing critical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->