### PR TITLE
fix: update modelPrice default setting

### DIFF
--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -148,7 +148,7 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) types.
 	if !success {
 		defaultPrice, ok := ratio_setting.GetDefaultModelPriceMap()[info.OriginModelName]
 		if !ok {
-			modelPrice = 0.1
+			modelPrice = float64(common.PreConsumedQuota) / common.QuotaPerUnit
 		} else {
 			modelPrice = defaultPrice
 		}


### PR DESCRIPTION
未配置固定价格的视频模型使用后台默认预扣费值而不是固定0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model pricing calculation to use dynamic quota-based computation instead of fixed default values when explicit model prices are unavailable, ensuring more accurate pricing calculations throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->