### PR TITLE
feat(relay): add Responses API → Chat Completions conversion for upst…

### DIFF
--- a/relay/responses_handler.go
+++ b/relay/responses_handler.go
@@ -83,11 +83,7 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		if newApiErr != nil {
 			return newApiErr
 		}
-		if strings.HasPrefix(info.OriginModelName, "gpt-4o-audio") {
-			service.PostAudioConsumeQuota(c, info, usage, "")
-		} else {
-			postConsumeQuota(c, info, usage)
-		}
+		postQuotaForModel(c, info, usage)
 		return nil
 	}
 
@@ -173,10 +169,17 @@ func ResponsesHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *
 		return nil
 	}
 
-	if strings.HasPrefix(info.OriginModelName, "gpt-4o-audio") {
-		service.PostAudioConsumeQuota(c, info, usageDto, "")
-	} else {
-		postConsumeQuota(c, info, usageDto)
-	}
+	postQuotaForModel(c, info, usageDto)
 	return nil
+}
+
+// postQuotaForModel dispatches quota consumption to the correct handler
+// based on the model name.  gpt-4o-audio models use audio-specific
+// billing; everything else goes through the standard path.
+func postQuotaForModel(c *gin.Context, info *relaycommon.RelayInfo, usage *dto.Usage) {
+	if strings.HasPrefix(info.OriginModelName, "gpt-4o-audio") {
+		service.PostAudioConsumeQuota(c, info, usage, "")
+	} else {
+		postConsumeQuota(c, info, usage)
+	}
 }

--- a/relay/responses_via_chat_completions.go
+++ b/relay/responses_via_chat_completions.go
@@ -87,7 +87,11 @@ func responsesViaChatCompletions(c *gin.Context, info *relaycommon.RelayInfo, ad
 
 	statusCodeMappingStr := c.GetString("status_code_mapping")
 
-	httpResp = resp.(*http.Response)
+	var ok bool
+	httpResp, ok = resp.(*http.Response)
+	if !ok {
+		return nil, types.NewOpenAIError(fmt.Errorf("unexpected response type: %T", resp), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+	}
 	info.IsStream = info.IsStream || strings.HasPrefix(httpResp.Header.Get("Content-Type"), "text/event-stream")
 	if httpResp.StatusCode != http.StatusOK {
 		newApiErr := service.RelayErrorHandler(c.Request.Context(), httpResp, false)
@@ -384,16 +388,20 @@ func chatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, r
 		return nil, streamErr
 	}
 
-	// Send content_part.done and output_item.done if we emitted text content
+	// Send content_part.done and output_item.done if we emitted text content.
+	// These are best-effort cleanup events — if the client already disconnected
+	// we still return whatever usage we collected.
 	if sentContentPart {
-		sendEvent(map[string]any{
+		if !sendEvent(map[string]any{
 			"type":          "response.output_text.done",
 			"item_id":       msgID,
 			"output_index":  0,
 			"content_index": 0,
 			"text":          fullText.String(),
-		})
-		sendEvent(map[string]any{
+		}) {
+			return usage, streamErr
+		}
+		if !sendEvent(map[string]any{
 			"type":          "response.content_part.done",
 			"item_id":       msgID,
 			"output_index":  0,
@@ -402,10 +410,12 @@ func chatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, r
 				"type": "output_text",
 				"text": fullText.String(),
 			},
-		})
+		}) {
+			return usage, streamErr
+		}
 	}
 	if sentOutputItem {
-		sendEvent(map[string]any{
+		if !sendEvent(map[string]any{
 			"type":         "response.output_item.done",
 			"output_index": 0,
 			"item": map[string]any{
@@ -420,7 +430,9 @@ func chatToResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, r
 					},
 				},
 			},
-		})
+		}) {
+			return usage, streamErr
+		}
 	}
 
 	// Send tool call done events

--- a/service/openai_chat_responses_compat.go
+++ b/service/openai_chat_responses_compat.go
@@ -5,26 +5,44 @@ import (
 	"github.com/QuantumNous/new-api/service/openaicompat"
 )
 
+// ChatCompletionsRequestToResponsesRequest converts a Chat Completions
+// request into a Responses API request.  Delegates to the openaicompat
+// package.
 func ChatCompletionsRequestToResponsesRequest(req *dto.GeneralOpenAIRequest) (*dto.OpenAIResponsesRequest, error) {
 	return openaicompat.ChatCompletionsRequestToResponsesRequest(req)
 }
 
+// ResponsesResponseToChatCompletionsResponse converts a Responses API
+// response into a Chat Completions response.  Delegates to the
+// openaicompat package.
 func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesResponse, id string) (*dto.OpenAITextResponse, *dto.Usage, error) {
 	return openaicompat.ResponsesResponseToChatCompletionsResponse(resp, id)
 }
 
+// ExtractOutputTextFromResponses extracts the concatenated output text
+// from a Responses API response object.
 func ExtractOutputTextFromResponses(resp *dto.OpenAIResponsesResponse) string {
 	return openaicompat.ExtractOutputTextFromResponses(resp)
 }
 
+// ResponsesRequestToChatCompletionsRequest converts a Responses API
+// request into a Chat Completions request.  This is the reverse of
+// ChatCompletionsRequestToResponsesRequest and is used when the upstream
+// channel only supports /v1/chat/completions.
 func ResponsesRequestToChatCompletionsRequest(req *dto.OpenAIResponsesRequest) (*dto.GeneralOpenAIRequest, error) {
 	return openaicompat.ResponsesRequestToChatCompletionsRequest(req)
 }
 
+// ChatCompletionsResponseToResponsesResponse converts a non-streaming
+// Chat Completions response into a Responses API response.
 func ChatCompletionsResponseToResponsesResponse(resp *dto.OpenAITextResponse, model string) (*dto.OpenAIResponsesResponse, error) {
 	return openaicompat.ChatCompletionsResponseToResponsesResponse(resp, model)
 }
 
+// ShouldResponsesUseChatCompletionsGlobal checks whether an incoming
+// /v1/responses request should be transparently converted to
+// /v1/chat/completions for the given channel and model, using the
+// global configuration policy.
 func ShouldResponsesUseChatCompletionsGlobal(channelID int, channelType int, model string) bool {
 	return openaicompat.ShouldResponsesUseChatCompletionsGlobal(channelID, channelType, model)
 }

--- a/service/openaicompat/chat_response_to_responses.go
+++ b/service/openaicompat/chat_response_to_responses.go
@@ -155,11 +155,6 @@ func ChatStreamChunkToResponsesEvents(chunk *dto.ChatCompletionsStreamResponse, 
 		}
 	}
 
-	// Finish reason
-	if choice.FinishReason != nil && *choice.FinishReason != "" {
-		// Will be handled by the caller when building the completed event
-	}
-
 	return events
 }
 

--- a/service/openaicompat/policy.go
+++ b/service/openaicompat/policy.go
@@ -2,6 +2,11 @@ package openaicompat
 
 import "github.com/QuantumNous/new-api/setting/model_setting"
 
+// ShouldChatCompletionsUseResponsesPolicy checks whether an incoming
+// /v1/chat/completions request should be converted to /v1/responses
+// for the given channel and model combination, using the supplied
+// policy.  Returns true when the policy is enabled, the channel
+// matches, and the model name matches one of the configured patterns.
 func ShouldChatCompletionsUseResponsesPolicy(policy model_setting.ChatCompletionsToResponsesPolicy, channelID int, channelType int, model string) bool {
 	if !policy.IsChannelEnabled(channelID, channelType) {
 		return false
@@ -9,6 +14,9 @@ func ShouldChatCompletionsUseResponsesPolicy(policy model_setting.ChatCompletion
 	return matchAnyRegex(policy.ModelPatterns, model)
 }
 
+// ShouldChatCompletionsUseResponsesGlobal is a convenience wrapper
+// around ShouldChatCompletionsUseResponsesPolicy that reads the policy
+// from the global settings singleton.
 func ShouldChatCompletionsUseResponsesGlobal(channelID int, channelType int, model string) bool {
 	return ShouldChatCompletionsUseResponsesPolicy(
 		model_setting.GetGlobalSettings().ChatCompletionsToResponsesPolicy,
@@ -19,8 +27,10 @@ func ShouldChatCompletionsUseResponsesGlobal(channelID int, channelType int, mod
 }
 
 // ShouldResponsesUseChatCompletionsPolicy checks whether an incoming
-// /v1/responses request should be converted to /v1/chat/completions for the
-// given channel and model combination.
+// /v1/responses request should be converted to /v1/chat/completions for
+// the given channel and model combination, using the supplied policy.
+// Returns true when the policy is enabled, the channel matches, and the
+// model name matches one of the configured regex patterns.
 func ShouldResponsesUseChatCompletionsPolicy(policy model_setting.ResponsesToChatCompletionsPolicy, channelID int, channelType int, model string) bool {
 	if !policy.IsChannelEnabled(channelID, channelType) {
 		return false
@@ -28,6 +38,9 @@ func ShouldResponsesUseChatCompletionsPolicy(policy model_setting.ResponsesToCha
 	return matchAnyRegex(policy.ModelPatterns, model)
 }
 
+// ShouldResponsesUseChatCompletionsGlobal is a convenience wrapper
+// around ShouldResponsesUseChatCompletionsPolicy that reads the policy
+// from the global settings singleton.
 func ShouldResponsesUseChatCompletionsGlobal(channelID int, channelType int, model string) bool {
 	return ShouldResponsesUseChatCompletionsPolicy(
 		model_setting.GetGlobalSettings().ResponsesToChatCompletionsPolicy,

--- a/service/openaicompat/regex.go
+++ b/service/openaicompat/regex.go
@@ -7,6 +7,10 @@ import (
 
 var compiledRegexCache sync.Map // map[string]*regexp.Regexp
 
+// matchAnyRegex returns true when s matches at least one of the given
+// regex patterns.  Compiled regexes are cached in a sync.Map for
+// performance.  Invalid patterns are silently skipped to avoid breaking
+// runtime traffic.
 func matchAnyRegex(patterns []string, s string) bool {
 	if len(patterns) == 0 || s == "" {
 		return false

--- a/service/openaicompat/responses_request_to_chat.go
+++ b/service/openaicompat/responses_request_to_chat.go
@@ -1,6 +1,7 @@
 package openaicompat
 
 import (
+	"fmt"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -158,6 +159,7 @@ func responsesInputToMessages(input json.RawMessage) ([]dto.Message, error) {
 	for _, raw := range items {
 		var item map[string]any
 		if err := common.Unmarshal(raw, &item); err != nil {
+			common.SysLog(fmt.Sprintf("skipping malformed Responses input item: %v", err))
 			continue
 		}
 
@@ -357,6 +359,7 @@ func responsesToolsToChatTools(toolsRaw json.RawMessage) ([]dto.ToolCallRequest,
 	return chatTools, nil
 }
 
+// cond returns t if b is true, f otherwise.  A simple ternary helper.
 func cond(b bool, t, f string) string {
 	if b {
 		return t

--- a/setting/model_setting/global.go
+++ b/setting/model_setting/global.go
@@ -7,7 +7,13 @@ import (
 	"github.com/QuantumNous/new-api/setting/config"
 )
 
-type ChatCompletionsToResponsesPolicy struct {
+// ChannelRoutingPolicy defines a reusable policy structure for deciding
+// whether a particular channel/model combination should have its API
+// request format converted (e.g. Responses → Chat Completions or vice
+// versa).  Both ChatCompletionsToResponsesPolicy and
+// ResponsesToChatCompletionsPolicy embed this type so that field
+// definitions and the IsChannelEnabled logic are shared.
+type ChannelRoutingPolicy struct {
 	Enabled       bool     `json:"enabled"`
 	AllChannels   bool     `json:"all_channels"`
 	ChannelIDs    []int    `json:"channel_ids,omitempty"`
@@ -15,7 +21,9 @@ type ChatCompletionsToResponsesPolicy struct {
 	ModelPatterns []string `json:"model_patterns,omitempty"`
 }
 
-func (p ChatCompletionsToResponsesPolicy) IsChannelEnabled(channelID int, channelType int) bool {
+// IsChannelEnabled returns true when the policy is enabled and the given
+// channel matches by ID, type, or the AllChannels wildcard.
+func (p ChannelRoutingPolicy) IsChannelEnabled(channelID int, channelType int) bool {
 	if !p.Enabled {
 		return false
 	}
@@ -31,35 +39,20 @@ func (p ChatCompletionsToResponsesPolicy) IsChannelEnabled(channelID int, channe
 	}
 	return false
 }
+
+// ChatCompletionsToResponsesPolicy controls when incoming
+// /v1/chat/completions requests should be converted to /v1/responses
+// for upstream channels that only support the Responses API.
+type ChatCompletionsToResponsesPolicy = ChannelRoutingPolicy
 
 // ResponsesToChatCompletionsPolicy controls when incoming /v1/responses
-// requests should be converted to /v1/chat/completions for upstream channels
-// that do not support the Responses API natively.
-type ResponsesToChatCompletionsPolicy struct {
-	Enabled       bool     `json:"enabled"`
-	AllChannels   bool     `json:"all_channels"`
-	ChannelIDs    []int    `json:"channel_ids,omitempty"`
-	ChannelTypes  []int    `json:"channel_types,omitempty"`
-	ModelPatterns []string `json:"model_patterns,omitempty"`
-}
+// requests should be converted to /v1/chat/completions for upstream
+// channels that do not support the Responses API natively (e.g. NVIDIA
+// NIM, ZhipuAI).
+type ResponsesToChatCompletionsPolicy = ChannelRoutingPolicy
 
-func (p ResponsesToChatCompletionsPolicy) IsChannelEnabled(channelID int, channelType int) bool {
-	if !p.Enabled {
-		return false
-	}
-	if p.AllChannels {
-		return true
-	}
-
-	if channelID > 0 && len(p.ChannelIDs) > 0 && slices.Contains(p.ChannelIDs, channelID) {
-		return true
-	}
-	if channelType > 0 && len(p.ChannelTypes) > 0 && slices.Contains(p.ChannelTypes, channelType) {
-		return true
-	}
-	return false
-}
-
+// GlobalSettings holds the top-level runtime configuration loaded from
+// the database options table under the "global" key.
 type GlobalSettings struct {
 	PassThroughRequestEnabled        bool                             `json:"pass_through_request_enabled"`
 	ThinkingModelBlacklist           []string                         `json:"thinking_model_blacklist"`
@@ -92,6 +85,8 @@ func init() {
 	config.GlobalConfig.Register("global", &globalSettings)
 }
 
+// GetGlobalSettings returns a pointer to the current runtime
+// GlobalSettings instance.
 func GetGlobalSettings() *GlobalSettings {
 	return &globalSettings
 }


### PR DESCRIPTION
…ream compatibility

Allow channels that only support /v1/chat/completions to serve clients that speak the OpenAI Responses API (e.g. Codex CLI v0.106+).

## Background

OpenAI Codex CLI v0.106+ exclusively uses the Responses API (/v1/responses). Many upstream providers (NVIDIA NIM, ZhipuAI, etc.) only implement Chat Completions (/v1/chat/completions). This change bridges the gap by transparently converting between the two formats inside the relay layer.

## New files

- relay/responses_via_chat_completions.go Main handler: converts Responses request → Chat Completions, forwards to upstream, converts response back (streaming + non-streaming). Streaming emits the full Responses API SSE event sequence Codex needs. Tool call chunks tracked by index for correct ID/name reconstruction.

- service/openaicompat/responses_request_to_chat.go Converts Responses API request → Chat Completions request. Handles input array (message, function_call, function_call_output, input_text, input_image), merges consecutive function_calls into a single assistant message with tool_calls[].

- service/openaicompat/chat_response_to_responses.go Converts Chat Completions response → Responses API response. Non-streaming + streaming chunk converters + completed event builder.

## Modified files

- relay/responses_handler.go: hook in ResponsesHelper
- service/openaicompat/policy.go: ShouldResponsesUseChatCompletions*()
- setting/model_setting/global.go: ResponsesToChatCompletionsPolicy struct
- service/openai_chat_responses_compat.go: exported wrapper functions

## Configuration (System Settings)

```json
{
  "enabled": true,
  "all_channels": true,
  "model_patterns": [".*"]
}
```

## Tested with

- OpenAI Codex CLI v0.106.0 + NVIDIA NIM upstream (glm-5)
- Multi-turn conversations, streaming, tool call round-trips ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert Responses requests to Chat Completions for compatible channels (streaming & non-streaming), including tool call and usage mapping.
  * Global routing policies and settings to control conversions with regex-based model matching (cached).
* **Behavior**
  * New quota dispatch path that attributes consumption per model family and reuses reported usage.
* **Chores**
  * Added compatibility wrappers to simplify request/response translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->