### PR TITLE
Fix/aws non empty text

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -404,12 +404,15 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 	return &claudeRequest, nil
 }
 
-func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCompletionsStreamResponse {
+func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse, claudeInfo *ClaudeResponseInfo) *dto.ChatCompletionsStreamResponse {
 	var response dto.ChatCompletionsStreamResponse
 	response.Object = "chat.completion.chunk"
 	response.Model = claudeResponse.Model
 	response.Choices = make([]dto.ChatCompletionsStreamResponseChoice, 0)
 	tools := make([]dto.ToolCallResponse, 0)
+	if claudeInfo != nil && claudeInfo.ToolCallStreamStates == nil {
+		claudeInfo.ToolCallStreamStates = make(map[int]*ToolCallStreamState)
+	}
 	fcIdx := 0
 	if claudeResponse.Index != nil {
 		fcIdx = *claudeResponse.Index - 1
@@ -433,6 +436,13 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 				choice.Delta.SetContentString(*claudeResponse.ContentBlock.Text)
 			}
 			if claudeResponse.ContentBlock.Type == "tool_use" {
+				if claudeInfo != nil {
+					claudeInfo.ToolCallStreamStates[fcIdx] = &ToolCallStreamState{
+						ID:   claudeResponse.ContentBlock.Id,
+						Name: claudeResponse.ContentBlock.Name,
+					}
+					return nil
+				}
 				tools = append(tools, dto.ToolCallResponse{
 					Index: common.GetPointer(fcIdx),
 					ID:    claudeResponse.ContentBlock.Id,
@@ -451,19 +461,28 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 			choice.Delta.Content = claudeResponse.Delta.Text
 			switch claudeResponse.Delta.Type {
 			case "input_json_delta":
-				arguments := "{}"
-				if claudeResponse.Delta.PartialJson != nil {
-					if partial := strings.TrimSpace(*claudeResponse.Delta.PartialJson); partial != "" {
-						arguments = partial
-					}
+				if claudeResponse.Delta.PartialJson == nil {
+					return nil
 				}
-				tools = append(tools, dto.ToolCallResponse{
+				arguments := *claudeResponse.Delta.PartialJson
+				if strings.TrimSpace(arguments) == "" {
+					return nil
+				}
+				toolCall := dto.ToolCallResponse{
 					Type:  "function",
 					Index: common.GetPointer(fcIdx),
 					Function: dto.FunctionResponse{
 						Arguments: arguments,
 					},
-				})
+				}
+				if claudeInfo != nil {
+					if state, ok := claudeInfo.ToolCallStreamStates[fcIdx]; ok {
+						state.Emitted = true
+						toolCall.ID = state.ID
+						toolCall.Function.Name = state.Name
+					}
+				}
+				tools = append(tools, toolCall)
 			case "signature_delta":
 				// 加密的不处理
 				signatureContent := "\n"
@@ -472,6 +491,27 @@ func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCo
 				choice.Delta.ReasoningContent = claudeResponse.Delta.Thinking
 			}
 		}
+	} else if claudeResponse.Type == "content_block_stop" {
+		if claudeInfo == nil {
+			return nil
+		}
+		state, ok := claudeInfo.ToolCallStreamStates[fcIdx]
+		if !ok {
+			return nil
+		}
+		delete(claudeInfo.ToolCallStreamStates, fcIdx)
+		if state.Emitted {
+			return nil
+		}
+		tools = append(tools, dto.ToolCallResponse{
+			ID:    state.ID,
+			Type:  "function",
+			Index: common.GetPointer(fcIdx),
+			Function: dto.FunctionResponse{
+				Name:      state.Name,
+				Arguments: "{}",
+			},
+		})
 	} else if claudeResponse.Type == "message_delta" {
 		if claudeResponse.Delta != nil && claudeResponse.Delta.StopReason != nil {
 			finishReason := stopReasonClaude2OpenAI(*claudeResponse.Delta.StopReason)
@@ -556,12 +596,19 @@ func ResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.OpenAITextRe
 }
 
 type ClaudeResponseInfo struct {
-	ResponseId   string
-	Created      int64
-	Model        string
-	ResponseText strings.Builder
-	Usage        *dto.Usage
-	Done         bool
+	ResponseId           string
+	Created              int64
+	Model                string
+	ResponseText         strings.Builder
+	Usage                *dto.Usage
+	Done                 bool
+	ToolCallStreamStates map[int]*ToolCallStreamState
+}
+
+type ToolCallStreamState struct {
+	ID      string
+	Name    string
+	Emitted bool
 }
 
 func buildMessageDeltaPatchUsage(claudeResponse *dto.ClaudeResponse, claudeInfo *ClaudeResponseInfo) *dto.ClaudeUsage {
@@ -694,7 +741,7 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 
 		// 判断是否完整
 		claudeInfo.Done = true
-	} else if claudeResponse.Type == "content_block_start" {
+	} else if claudeResponse.Type == "content_block_start" || claudeResponse.Type == "content_block_stop" {
 	} else {
 		return false
 	}
@@ -739,7 +786,10 @@ func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		}
 		helper.ClaudeChunkData(c, claudeResponse, data)
 	} else if info.RelayFormat == types.RelayFormatOpenAI {
-		response := StreamResponseClaude2OpenAI(&claudeResponse)
+		response := StreamResponseClaude2OpenAI(&claudeResponse, claudeInfo)
+		if response == nil {
+			return nil
+		}
 
 		if !FormatClaudeResponseInfo(&claudeResponse, response, claudeInfo) {
 			return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of function/tool calls in Claude streaming to avoid duplicate or spurious emissions.
  * Empty JSON deltas are ignored in the streaming flow unless explicit stream context indicates a real tool invocation.
  * Better lifecycle and cleanup of tool-call state to ensure correct emission timing and final finalization.

* **Tests**
  * Updated and added tests verifying ignored empty deltas, correct no-argument tool emission at stream end, and ID/name preservation for argumented tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->