### PR TITLE
fix: use default model price for radio price model

### DIFF
--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -147,11 +147,10 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 	// 如果没有配置价格，检查模型倍率配置
 	if !success {
 
-		// 没有配置费用，返回错误
+		// 没有配置费用，也要使用默认费用,否则按费率计费模型无法使用
 		defaultPrice, ok := ratio_setting.GetDefaultModelPriceMap()[info.OriginModelName]
 		if !ok {
-			// 不再使用默认价格，而是返回错误
-			return types.PriceData{}, fmt.Errorf("模型 %s 价格未配置，请联系管理员设置", info.OriginModelName)
+			modelPrice = float64(common.PreConsumedQuota) / common.QuotaPerUnit
 		} else {
 			modelPrice = defaultPrice
 		}


### PR DESCRIPTION
没有配置费用，也要使用默认费用,否则按费率计费的视频模型无法使用
比如豆包视频和可灵视频
<img width="2552" height="1204" alt="image" src="https://github.com/user-attachments/assets/9ca8e69b-ca06-4db4-a7b6-17e9dd64f125" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing model pricing configurations. The system now gracefully falls back to a calculated default price instead of returning an error, ensuring continued operation when per-call pricing is not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->