### PR TITLE
fix: use default model price for radio price model

### DIFF
--- a/relay/helper/price.go
+++ b/relay/helper/price.go
@@ -147,24 +147,22 @@ func ModelPriceHelperPerCall(c *gin.Context, info *relaycommon.RelayInfo) (types
 	// 如果没有配置价格，检查模型倍率配置
 	if !success {
 
-		// 没有配置费用，返回错误
+		// 没有配置费用，也要使用默认费用,否则按费率计费模型无法使用
 		defaultPrice, ok := ratio_setting.GetDefaultModelPriceMap()[info.OriginModelName]
-		if !ok {
-			// 不再使用默认价格，而是返回错误
-			return types.PriceData{}, fmt.Errorf("模型 %s 价格未配置，请联系管理员设置", info.OriginModelName)
-		} else {
+		if ok {
 			modelPrice = defaultPrice
-		}
-		// 没有配置倍率也不接受没配置,那就返回错误
-		_, ratioSuccess, matchName := ratio_setting.GetModelRatio(info.OriginModelName)
-		if !ratioSuccess {
+		} else {
+			// 没有配置倍率也不接受没配置,那就返回错误
+			_, ratioSuccess, matchName := ratio_setting.GetModelRatio(info.OriginModelName)
 			acceptUnsetRatio := false
 			if info.UserSetting.AcceptUnsetRatioModel {
 				acceptUnsetRatio = true
 			}
-			if !acceptUnsetRatio {
+			if !ratioSuccess && !acceptUnsetRatio {
 				return types.PriceData{}, fmt.Errorf("模型 %s 倍率或价格未配置，请联系管理员设置或开始自用模式；Model %s ratio or price not set, please set or start self-use mode", matchName, matchName)
 			}
+			// 未配置价格但配置了倍率，使用默认预扣价格
+			modelPrice = float64(common.PreConsumedQuota) / common.QuotaPerUnit
 		}
 
 	}


### PR DESCRIPTION
当前最新合并会导致未配置价格但配置了倍率的视频模型无法使用返回错误
<img width="2552" height="1204" alt="image" src="https://github.com/user-attachments/assets/80e5c08a-863c-42be-afd1-57e63cf13bc3" />

修复为只有价格和倍率都没有配置时才返回错误
价格没配置但倍率有配置时, 取配置的默认预扣值


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model pricing now gracefully falls back to default prices and model ratios when explicit pricing is unavailable, reducing configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->