### PR TITLE
feat: add task concurrency limit

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -145,6 +145,8 @@ func initConstantEnv() {
 	constant.ErrorLogEnabled = GetEnvOrDefaultBool("ERROR_LOG_ENABLED", false)
 	// 任务轮询时查询的最大数量
 	constant.TaskQueryLimit = GetEnvOrDefault("TASK_QUERY_LIMIT", 1000)
+	// 未完成异步任务并发上限（0 表示不限制）
+	constant.TaskMaxConcurrentTask = GetEnvOrDefault("TASK_MAX_CONCURRENT_TASK", 0)
 	// 异步任务超时时间（分钟），超过此时间未完成的任务将被标记为失败并退款。0 表示禁用。
 	constant.TaskTimeoutMinutes = GetEnvOrDefault("TASK_TIMEOUT_MINUTES", 1440)
 

--- a/constant/env.go
+++ b/constant/env.go
@@ -16,6 +16,7 @@ var NotificationLimitDurationMinute int
 var GenerateDefaultToken bool
 var ErrorLogEnabled bool
 var TaskQueryLimit int
+var TaskMaxConcurrentTask int
 var TaskTimeoutMinutes int
 
 // temporary variable for sora patch, will be removed in future

--- a/middleware/task_concurrency_limit.go
+++ b/middleware/task_concurrency_limit.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/gin-gonic/gin"
+)
+
+func TaskConcurrencyLimit() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		limit := constant.TaskMaxConcurrentTask
+		if limit <= 0 {
+			c.Next()
+			return
+		}
+		total, err := model.CountUnfinishedTasks()
+		if err != nil {
+			c.Next()
+			return
+		}
+		if int(total) >= limit {
+			c.JSON(http.StatusTooManyRequests, &dto.TaskError{
+				Code:       "task_concurrency_limit_exceeded",
+				Message:    "任务并发数已达上限，请稍后再试",
+				StatusCode: http.StatusTooManyRequests,
+			})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/model/task.go
+++ b/model/task.go
@@ -495,6 +495,20 @@ func TaskCountAllUserTask(userId int, queryParams SyncTaskQueryParams) int64 {
 	_ = query.Count(&total).Error
 	return total
 }
+
+func CountUnfinishedTasks() (int64, error) {
+	var total int64
+	query := DB.Model(&Task{}).
+		Where("progress != ?", "100%").
+		Where("status != ?", TaskStatusFailure).
+		Where("status != ?", TaskStatusSuccess)
+	if constant.TaskTimeoutMinutes > 0 {
+		cutoff := time.Now().Add(-time.Duration(constant.TaskTimeoutMinutes) * time.Minute).Unix()
+		query = query.Where("submit_time >= ?", cutoff)
+	}
+	err := query.Count(&total).Error
+	return total, err
+}
 func (t *Task) ToOpenAIVideo() *dto.OpenAIVideo {
 	openAIVideo := dto.NewOpenAIVideo()
 	openAIVideo.ID = t.TaskID

--- a/router/video-router.go
+++ b/router/video-router.go
@@ -27,7 +27,7 @@ func SetVideoRouter(router *gin.Engine) {
 	// openai compatible API video routes
 	// docs: https://platform.openai.com/docs/api-reference/videos/create
 	{
-		videoV1Router.POST("/videos", controller.RelayTask)
+		videoV1Router.POST("/videos", middleware.TaskConcurrencyLimit(), controller.RelayTask)
 		videoV1Router.GET("/videos/:task_id", controller.RelayTaskFetch)
 	}
 


### PR DESCRIPTION
增加异步任务并发限制
可通过环境变量`TASK_MAX_CONCURRENT_TASK`配置
默认不限制
<img width="2558" height="786" alt="image" src="https://github.com/user-attachments/assets/e4594317-8626-447a-b3a6-b9bda377c62f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a configurable task concurrency limit feature. The limit can be set via an environment variable (defaults to 0 for unlimited). When concurrent unfinished tasks reach the configured limit, subsequent requests receive a "Too Many Requests" response. This controls load on task processing endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->