### PR TITLE
feat: 优化 OpenAI 请求转换与参数适配逻辑 兼容OpenRouter渠道的 OpenAI格式多模态模型参数（例如Gemini画图模型）和 Gemini转OpenRouter渠道多模态数据传入和传出逻辑

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -85,8 +85,9 @@ type GeneralOpenAIRequest struct {
 	// claude
 	WebSearchOptions *WebSearchOptions `json:"web_search_options,omitempty"`
 	// OpenRouter Params
-	Usage     json.RawMessage `json:"usage,omitempty"`
-	Reasoning json.RawMessage `json:"reasoning,omitempty"`
+	Usage       json.RawMessage `json:"usage,omitempty"`
+	Reasoning   json.RawMessage `json:"reasoning,omitempty"`
+	ImageConfig json.RawMessage `json:"image_config,omitempty"` // OpenRouter image generation config (aspect_ratio, image_size)
 	// Ali Qwen Params
 	VlHighResolutionImages json.RawMessage `json:"vl_high_resolution_images,omitempty"`
 	EnableThinking         json.RawMessage `json:"enable_thinking,omitempty"`
@@ -311,8 +312,21 @@ type Message struct {
 	Reasoning        string          `json:"reasoning,omitempty"`
 	ToolCalls        json.RawMessage `json:"tool_calls,omitempty"`
 	ToolCallId       string          `json:"tool_call_id,omitempty"`
+	// OpenRouter image generation response: images array with base64 data URLs
+	Images           json.RawMessage `json:"images,omitempty"`
 	parsedContent    []MediaContent
 	//parsedStringContent *string
+}
+
+// OpenRouterImage represents an image object in OpenRouter's response images array
+type OpenRouterImage struct {
+	Type     string                `json:"type"`
+	ImageUrl *OpenRouterImageUrl   `json:"image_url,omitempty"`
+}
+
+// OpenRouterImageUrl represents the image URL object in OpenRouter's response
+type OpenRouterImageUrl struct {
+	Url string `json:"url"`
 }
 
 type MediaContent struct {

--- a/service/convert.go
+++ b/service/convert.go
@@ -763,7 +763,50 @@ func GeminiToOpenAIRequest(geminiRequest *dto.GeminiChatRequest, info *relaycomm
 		openaiRequest.Messages = append([]dto.Message{systemMessage}, openaiRequest.Messages...)
 	}
 
+	// 转换 responseModalities → modalities（OpenRouter 格式）
+	// Gemini 使用 "IMAGE"/"TEXT"，OpenRouter 使用 "image"/"text"
+	if len(geminiRequest.GenerationConfig.ResponseModalities) > 0 {
+		modalities := make([]string, len(geminiRequest.GenerationConfig.ResponseModalities))
+		for i, m := range geminiRequest.GenerationConfig.ResponseModalities {
+			modalities[i] = strings.ToLower(m)
+		}
+		modalitiesJSON, err := common.Marshal(modalities)
+		if err == nil {
+			openaiRequest.Modalities = modalitiesJSON
+		}
+	}
+
+	// 转换 imageConfig → image_config（OpenRouter 格式）
+	// Gemini 使用 camelCase (aspectRatio, imageSize)，OpenRouter 使用 snake_case (aspect_ratio, image_size)
+	if len(geminiRequest.GenerationConfig.ImageConfig) > 0 {
+		var imageConfig map[string]interface{}
+		if err := common.Unmarshal(geminiRequest.GenerationConfig.ImageConfig, &imageConfig); err == nil {
+			converted := convertGeminiImageConfigToOpenRouter(imageConfig)
+			if convertedJSON, err := common.Marshal(converted); err == nil {
+				openaiRequest.ImageConfig = convertedJSON
+			}
+		}
+	}
+
 	return openaiRequest, nil
+}
+
+// convertGeminiImageConfigToOpenRouter converts Gemini camelCase imageConfig keys to OpenRouter snake_case
+func convertGeminiImageConfigToOpenRouter(config map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+	camelToSnake := map[string]string{
+		"aspectRatio": "aspect_ratio",
+		"imageSize":   "image_size",
+	}
+	for key, value := range config {
+		if snakeKey, ok := camelToSnake[key]; ok {
+			result[snakeKey] = value
+		} else {
+			// already snake_case or unknown key, pass through
+			result[key] = value
+		}
+	}
+	return result
 }
 
 func convertGeminiRoleToOpenAI(geminiRole string) string {
@@ -851,13 +894,54 @@ func ResponseOpenAI2Gemini(openAIResponse *dto.OpenAITextResponse, info *relayco
 				content.Parts = append(content.Parts, part)
 			}
 		} else {
-			// 处理文本内容
-			textContent := choice.Message.StringContent()
-			if textContent != "" {
-				part := dto.GeminiPart{
-					Text: textContent,
+			// 先尝试处理 OpenRouter 的 images 数组（图片生成响应）
+			hasImageFromImages := false
+			if len(choice.Message.Images) > 0 {
+				var images []dto.OpenRouterImage
+				if err := common.Unmarshal(choice.Message.Images, &images); err == nil {
+					for _, img := range images {
+						if img.Type == "image_url" && img.ImageUrl != nil {
+							inlineData := parseBase64DataURL(img.ImageUrl.Url)
+							if inlineData != nil {
+								content.Parts = append(content.Parts, dto.GeminiPart{
+									InlineData: inlineData,
+								})
+								hasImageFromImages = true
+							}
+						}
+					}
 				}
-				content.Parts = append(content.Parts, part)
+			}
+
+			// 处理 message content（可能包含 image_url 类型的多模态内容）
+			parsedContent := choice.Message.ParseContent()
+			for _, mc := range parsedContent {
+				switch mc.Type {
+				case "text":
+					if mc.Text != "" {
+						content.Parts = append(content.Parts, dto.GeminiPart{Text: mc.Text})
+					}
+				case "image_url":
+					imageMedia := mc.GetImageMedia()
+					if imageMedia != nil {
+						inlineData := parseBase64DataURL(imageMedia.Url)
+						if inlineData != nil {
+							content.Parts = append(content.Parts, dto.GeminiPart{
+								InlineData: inlineData,
+							})
+						}
+					}
+				}
+			}
+
+			// 如果没有从多模态内容中提取到，且没有从 images 中提取到，尝试简单文本
+			if len(content.Parts) == 0 && !hasImageFromImages {
+				textContent := choice.Message.StringContent()
+				if textContent != "" {
+					content.Parts = append(content.Parts, dto.GeminiPart{
+						Text: textContent,
+					})
+				}
 			}
 		}
 
@@ -866,6 +950,29 @@ func ResponseOpenAI2Gemini(openAIResponse *dto.OpenAITextResponse, info *relayco
 	}
 
 	return geminiResponse
+}
+
+// parseBase64DataURL parses a data URL (e.g. "data:image/png;base64,iVBOR...") into GeminiInlineData
+func parseBase64DataURL(url string) *dto.GeminiInlineData {
+	if !strings.HasPrefix(url, "data:") {
+		return nil
+	}
+	// Format: data:<mimeType>;base64,<data>
+	rest := strings.TrimPrefix(url, "data:")
+	parts := strings.SplitN(rest, ",", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	// parts[0] is like "image/png;base64"
+	metaParts := strings.Split(parts[0], ";")
+	mimeType := metaParts[0]
+	if mimeType == "" {
+		mimeType = "image/png" // fallback
+	}
+	return &dto.GeminiInlineData{
+		MimeType: mimeType,
+		Data:     parts[1],
+	}
 }
 
 // StreamResponseOpenAI2Gemini 将 OpenAI 流式响应转换为 Gemini 格式


### PR DESCRIPTION
兼容OpenRouter渠道的 OpenAI格式多模态模型参数（例如Gemini画图模型）和 Gemini转OpenRouter渠道多模态数据传入和传出逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for OpenRouter image configurations and image payloads in requests.
  - Enhanced multimodal interoperability between Gemini and OpenRouter/OpenAI, including automatic modality and image-config conversions.
  - Responses can now include images alongside text, with support for data URL parsing to inline image data.
  - Streaming responses now deliver multimodal content (text and images) consistently.
  - Graceful fallback to text-only content when no multimodal data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->