### PR TITLE
feat(claude): add whitelist-based header passthrough for Claude channels

### DIFF
--- a/dto/channel_settings.go
+++ b/dto/channel_settings.go
@@ -34,6 +34,11 @@ type ChannelOtherSettings struct {
 	DisableStore                          bool          `json:"disable_store,omitempty"`             // 是否禁用 store 透传（默认允许透传，禁用后可能导致 Codex 无法使用）
 	AllowIncludeObfuscation               bool          `json:"allow_include_obfuscation,omitempty"` // 是否允许 stream_options.include_obfuscation 透传（默认过滤以避免关闭流混淆保护）
 	AwsKeyType                            AwsKeyType    `json:"aws_key_type,omitempty"`
+
+	// Claude 白名单请求头透传（可选）
+	PassThroughClaudeHeaders bool     `json:"pass_through_claude_headers,omitempty"` // 是否启用白名单请求头透传
+	PassThroughClaudeUA      bool     `json:"pass_through_claude_ua,omitempty"`      // 是否透传 User-Agent
+	ClaudeAllowedHeaders     []string `json:"claude_allowed_headers,omitempty"`      // 额外允许透传的请求头名（小写），在默认白名单基础上追加
 	UpstreamModelUpdateCheckEnabled       bool          `json:"upstream_model_update_check_enabled,omitempty"`        // 是否检测上游模型更新
 	UpstreamModelUpdateAutoSyncEnabled    bool          `json:"upstream_model_update_auto_sync_enabled,omitempty"`    // 是否自动同步上游模型更新
 	UpstreamModelUpdateLastCheckTime      int64         `json:"upstream_model_update_last_check_time,omitempty"`      // 上次检测时间

--- a/relay/channel/claude/adaptor.go
+++ b/relay/channel/claude/adaptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
@@ -49,12 +50,17 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 }
 
 func CommonClaudeHeadersOperation(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) {
-	// common headers operation
-	anthropicBeta := c.Request.Header.Get("anthropic-beta")
-	if anthropicBeta != "" {
-		req.Set("anthropic-beta", anthropicBeta)
-	}
+	// 1) 写入模型默认头（可能包含默认 anthropic-beta 等）
 	model_setting.GetClaudeSettings().WriteHeaders(info.OriginModelName, req)
+
+	// 2) 合并并透传来访 anthropic-beta（保持去重与顺序）
+	incomingBeta := GetAnthropicBetaFromHeaders(c.Request.Header)
+	if incomingBeta != "" {
+		merged := MergeAnthropicBeta(req.Get("Anthropic-Beta"), incomingBeta)
+		if merged != "" {
+			req.Set("anthropic-beta", merged)
+		}
+	}
 }
 
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
@@ -66,6 +72,42 @@ func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *rel
 	}
 	req.Set("anthropic-version", anthropicVersion)
 	CommonClaudeHeadersOperation(c, req, info)
+
+	// 白名单请求头透传（可选）
+	if info.ChannelOtherSettings.PassThroughClaudeHeaders {
+		// 默认白名单
+		allowed := map[string]bool{
+			"anthropic-beta":               true,
+			"x-stainless-lang":             true,
+			"x-stainless-os":               true,
+			"x-stainless-package-version":  true,
+			"x-stainless-runtime":          true,
+			"x-stainless-runtime-version":  true,
+		}
+		if info.ChannelOtherSettings.PassThroughClaudeUA {
+			allowed["user-agent"] = true
+		}
+		// 附加白名单（小写）
+		for _, h := range info.ChannelOtherSettings.ClaudeAllowedHeaders {
+			allowed[strings.ToLower(h)] = true
+		}
+		// 拷贝白名单内的请求头（来访 -> 上游），不覆盖已设置的关键认证头
+		for name, values := range c.Request.Header {
+			ln := strings.ToLower(name)
+			if !allowed[ln] {
+				continue
+			}
+			// 跳过必须由网关控制的认证/版本头
+			if ln == "x-api-key" || ln == "authorization" || ln == "anthropic-version" {
+				continue
+			}
+			canon := http.CanonicalHeaderKey(name)
+			req.Del(canon)
+			for _, v := range values {
+				req.Add(canon, v)
+			}
+		}
+	}
 	return nil
 }
 

--- a/relay/channel/claude/header_helpers.go
+++ b/relay/channel/claude/header_helpers.go
@@ -1,0 +1,50 @@
+package claude
+
+import (
+	"net/http"
+	"strings"
+)
+
+// GetAnthropicBetaFromHeaders extracts and normalizes all anthropic-beta header values
+// into a single comma-separated string.
+func GetAnthropicBetaFromHeaders(headers http.Header) string {
+	vals := headers.Values("Anthropic-Beta")
+	if len(vals) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, v := range vals {
+		for _, t := range strings.Split(v, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				parts = append(parts, t)
+			}
+		}
+	}
+	return strings.Join(parts, ",")
+}
+
+// MergeAnthropicBeta merges two comma-separated anthropic-beta value strings,
+// deduplicating by lowercase key while preserving original casing and order.
+func MergeAnthropicBeta(defaultValues, incoming string) string {
+	seen := map[string]bool{}
+	out := make([]string, 0)
+	add := func(src string) {
+		for _, t := range strings.Split(src, ",") {
+			tt := strings.TrimSpace(t)
+			if tt == "" {
+				continue
+			}
+			key := strings.ToLower(tt)
+			if !seen[key] {
+				seen[key] = true
+				out = append(out, tt)
+			}
+		}
+	}
+	add(defaultValues)
+	if incoming != "" {
+		add(incoming)
+	}
+	return strings.Join(out, ",")
+}


### PR DESCRIPTION
Add configurable header passthrough for Claude channel type. When enabled via `pass_through_claude_headers`, whitelisted headers (anthropic-beta, x-stainless-*) are forwarded to the upstream Claude API while authentication headers (x-api-key, authorization, anthropic-version) remain protected.

- Add PassThroughClaudeHeaders, PassThroughClaudeUA, ClaudeAllowedHeaders fields to ChannelOtherSettings
- Add GetAnthropicBetaFromHeaders and MergeAnthropicBeta helper functions for proper anthropic-beta header merging with deduplication
- Update CommonClaudeHeadersOperation to merge incoming anthropic-beta with model defaults instead of overwriting
- Update SetupRequestHeader with whitelist passthrough logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New channel configuration settings allow fine-grained control over header passthrough behavior for Claude integration
  * Users can now specify custom allowed headers in channel configuration beyond the default whitelist
  * Enhanced handling of vendor-specific headers with improved deduplication and formatting preservation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->