### PR TITLE
feat: add Avian as a new channel provider

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -75,6 +75,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeReplicate
 	case constant.ChannelTypeCodex:
 		apiType = constant.APITypeCodex
+	case constant.ChannelTypeAvian:
+		apiType = constant.APITypeOpenAI
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -55,6 +55,7 @@ const (
 	ChannelTypeSora           = 55
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
+	ChannelTypeAvian          = 58
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -118,6 +119,7 @@ var ChannelBaseURLs = []string{
 	"https://api.openai.com",                    //55
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
+	"https://api.avian.io",                      //58
 }
 
 var ChannelTypeNames = map[int]string{
@@ -175,6 +177,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSora:           "Sora",
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "Codex",
+	ChannelTypeAvian:          "Avian",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -318,6 +318,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMoonshot:    true,
 	constant.ChannelTypeMiniMax:     true,
 	constant.ChannelTypeSiliconFlow: true,
+	constant.ChannelTypeAvian:      true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/web/src/constants/channel.constants.js
+++ b/web/src/constants/channel.constants.js
@@ -189,6 +189,11 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'Codex (OpenAI OAuth)',
   },
+  {
+    value: 58,
+    color: 'green',
+    label: 'Avian',
+  },
 ];
 
 // Channel types that support upstream model list fetching in UI.


### PR DESCRIPTION
## Summary
- Adds Avian (https://avian.io) as a new OpenAI-compatible channel type (ChannelTypeAvian = 58)
- Maps to OpenAI API adapter (fully OpenAI-compatible endpoint)
- Adds stream support
- Adds frontend channel option

## Changes
- `constant/channel.go` — new channel type, base URL, display name
- `common/api_type.go` — channel-to-API-type mapping
- `relay/common/relay_info.go` — stream support
- `web/src/constants/channel.constants.js` — frontend dropdown

## Test plan
- [ ] Verify Avian appears in channel type dropdown
- [ ] Create Avian channel with API key
- [ ] Test chat completion relay through Avian channel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Avian channel integration with OpenAI API compatibility
  * Avian channel now available in channel selection with streaming support enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->