### PR TITLE
fix: fetch model add header passthrough rule key check

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
+	relaychannel "github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/gemini"
 	"github.com/QuantumNous/new-api/relay/channel/ollama"
 	"github.com/QuantumNous/new-api/service"
@@ -183,6 +184,9 @@ func buildFetchModelsHeaders(channel *model.Channel, key string) (http.Header, e
 
 	headerOverride := channel.GetHeaderOverride()
 	for k, v := range headerOverride {
+		if relaychannel.IsHeaderPassthroughRuleKey(k) {
+			continue
+		}
 		str, ok := v.(string)
 		if !ok {
 			return nil, fmt.Errorf("invalid header override for key %s", k)

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -100,6 +100,9 @@ func getHeaderPassthroughRegex(pattern string) (*regexp.Regexp, error) {
 	return compiled, nil
 }
 
+func IsHeaderPassthroughRuleKey(key string) bool {
+	return isHeaderPassthroughRuleKey(key)
+}
 func isHeaderPassthroughRuleKey(key string) bool {
 	key = strings.TrimSpace(key)
 	if key == "" {


### PR DESCRIPTION
修复当渠道配置请求头透传模板时, 获取模型列表失败的问题
<img width="1154" height="330" alt="image" src="https://github.com/user-attachments/assets/f7236e87-14a8-46d9-bd7e-043dd839ac25" />
<img width="660" height="148" alt="image" src="https://github.com/user-attachments/assets/c3d8fa86-de6f-4e28-8faa-42c58e45bcf6" />
修复后
<img width="2492" height="1162" alt="image" src="https://github.com/user-attachments/assets/5e8f11f0-22ea-4299-ae1e-1886980b883b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved header handling logic in channel relay operations by introducing a new public interface for header pass-through rule validation, enabling more modular header processing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->