### PR TITLE
fix: make channel weights configured correctly

### DIFF
--- a/model/ability.go
+++ b/model/ability.go
@@ -64,7 +64,7 @@ func getPriority(group string, model string, retry int) (int, error) {
 	err := DB.Model(&Ability{}).
 		Select("DISTINCT(priority)").
 		Where(commonGroupCol+" = ? and model = ? and enabled = ?", group, model, true).
-		Order("priority DESC").              // 按优先级降序排序
+		Order("priority DESC"). // 按优先级降序排序
 		Pluck("priority", &priorities).Error // Pluck用于将查询的结果直接扫描到一个切片中
 
 	if err != nil {
@@ -123,15 +123,19 @@ func GetChannel(group string, model string, retry int) (*Channel, error) {
 	if len(abilities) > 0 {
 		// Randomly choose one
 		weightSum := uint(0)
+		zeroWeight := uint(0)
+		if lo.EveryBy(abilities, func(ability Ability) bool { return ability.Weight == 0 }) {
+			zeroWeight = 10
+		}
 		for _, ability_ := range abilities {
-			weightSum += ability_.Weight + 10
+			weightSum += ability_.Weight + zeroWeight
 		}
 		// Randomly choose one
 		weight := common.GetRandomInt(int(weightSum))
 		for _, ability_ := range abilities {
-			weight -= int(ability_.Weight) + 10
+			weight -= int(ability_.Weight + zeroWeight)
 			//log.Printf("weight: %d, ability weight: %d", weight, *ability_.Weight)
-			if weight <= 0 {
+			if weight < 0 {
 				channel.Id = ability_.ChannelId
 				break
 			}


### PR DESCRIPTION
当渠道设置>0的权重时, +10常量会导致权重被稀释
例如配置为1:10的渠道, 实际权重会变成11:20
只有所有渠道全部为0的, 才适合增加常量支持平均分配

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced weighted random selection logic to properly handle scenarios where all abilities have zero weights, ensuring more balanced and predictable selection outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->