### PR TITLE
fix: completion ratio config prioritized over hard code

### DIFF
--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -442,12 +442,12 @@ func GetCompletionRatio(name string) float64 {
 			return ratio
 		}
 	}
+	if ratio, ok := completionRatioMap.Get(name); ok {
+		return ratio
+	}
 	hardCodedRatio, contain := getHardcodedCompletionModelRatio(name)
 	if contain {
 		return hardCodedRatio
-	}
-	if ratio, ok := completionRatioMap.Get(name); ok {
-		return ratio
 	}
 	return hardCodedRatio
 }


### PR DESCRIPTION
修复gpt-5.4倍率被硬编码为8的问题
支持手动设置倍率优于硬编码

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed completion ratio configuration precedence to properly prioritize user-configured settings over default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->