### PR TITLE
fix: avoid early 200 commit on responses stream errors

### DIFF
--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -105,6 +105,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		usage       = &dto.Usage{}
 		outputText  strings.Builder
 		usageText   strings.Builder
+		streamed    bool
 		sentStart   bool
 		sentStop    bool
 		sawToolCall bool
@@ -133,6 +134,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 				streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
 				return false
 			}
+			streamed = streamed || c.Writer.Written()
 			return true
 		}
 
@@ -145,6 +147,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			streamErr = types.NewOpenAIError(err, types.ErrorCodeBadResponse, http.StatusInternalServerError)
 			return false
 		}
+		streamed = streamed || c.Writer.Written()
 		return true
 	}
 
@@ -485,13 +488,22 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 			}
 
 		case "response.error", "response.failed":
+			streamHasStarted := streamed || c.Writer.Written()
+			var eventErr *types.NewAPIError
 			if streamResp.Response != nil {
 				if oaiErr := streamResp.Response.GetOpenAIError(); oaiErr != nil && oaiErr.Type != "" {
-					streamErr = types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
-					return false
+					eventErr = types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
 				}
 			}
-			streamErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResp.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+			if eventErr == nil {
+				eventErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResp.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+			}
+			if !streamHasStarted {
+				streamErr = eventErr
+				return false
+			}
+			// Stream already committed; keep existing behavior by surfacing the stream error and stopping.
+			streamErr = eventErr
 			return false
 
 		default:

--- a/relay/channel/openai/relay_responses.go
+++ b/relay/channel/openai/relay_responses.go
@@ -78,13 +78,29 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 
 	var usage = &dto.Usage{}
 	var responseTextBuilder strings.Builder
+	var streamErr *types.NewAPIError
+	streamStarted := false
 
 	helper.StreamScannerHandler(c, resp, info, func(data string) bool {
 
 		// 检查当前数据是否包含 completed 状态和 usage 信息
 		var streamResponse dto.ResponsesStreamResponse
 		if err := common.UnmarshalJsonStr(data, &streamResponse); err == nil {
+			if streamResponse.Type == "response.error" || streamResponse.Type == "response.failed" {
+				if !streamStarted && !c.Writer.Written() {
+					if streamResponse.Response != nil {
+						if oaiErr := streamResponse.Response.GetOpenAIError(); oaiErr != nil && oaiErr.Type != "" {
+							streamErr = types.WithOpenAIError(*oaiErr, http.StatusInternalServerError)
+							return false
+						}
+					}
+					streamErr = types.NewOpenAIError(fmt.Errorf("responses stream error: %s", streamResponse.Type), types.ErrorCodeBadResponse, http.StatusInternalServerError)
+					return false
+				}
+			}
+
 			sendResponsesStreamData(c, streamResponse, data)
+			streamStarted = streamStarted || c.Writer.Written()
 			switch streamResponse.Type {
 			case "response.completed":
 				if streamResponse.Response != nil {
@@ -129,6 +145,10 @@ func OaiResponsesStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 		}
 		return true
 	})
+
+	if streamErr != nil {
+		return nil, streamErr
+	}
 
 	if usage.CompletionTokens == 0 {
 		// 计算输出文本的 token 数量

--- a/relay/channel/openai/responses_stream_error_test.go
+++ b/relay/channel/openai/responses_stream_error_test.go
@@ -1,0 +1,72 @@
+package openai
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func newResponsesStreamTestContext(t *testing.T, body string) (*gin.Context, *httptest.ResponseRecorder, *relaycommon.RelayInfo, *http.Response) {
+	t.Helper()
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() {
+		constant.StreamingTimeout = oldTimeout
+	})
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-4o-mini",
+		},
+	}
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	return c, recorder, info, resp
+}
+
+func TestOaiResponsesStreamHandler_ReturnsErrorBeforeFirstWrite(t *testing.T) {
+	t.Parallel()
+
+	body := "data: {\"type\":\"response.error\",\"response\":{\"error\":{\"message\":\"bad request\",\"type\":\"invalid_request_error\",\"code\":\"invalid_request_error\"}}}\n" +
+		"data: [DONE]\n"
+	c, recorder, info, resp := newResponsesStreamTestContext(t, body)
+
+	usage, streamErr := OaiResponsesStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, streamErr)
+	require.Equal(t, http.StatusInternalServerError, streamErr.StatusCode)
+	require.Zero(t, recorder.Body.Len())
+}
+
+func TestOaiResponsesToChatStreamHandler_ReturnsErrorBeforeFirstWrite(t *testing.T) {
+	t.Parallel()
+
+	body := "data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstream failed\",\"type\":\"server_error\",\"code\":\"server_error\"}}}\n" +
+		"data: [DONE]\n"
+	c, recorder, info, resp := newResponsesStreamTestContext(t, body)
+
+	usage, streamErr := OaiResponsesToChatStreamHandler(c, info, resp)
+	require.Nil(t, usage)
+	require.NotNil(t, streamErr)
+	require.Equal(t, http.StatusInternalServerError, streamErr.StatusCode)
+	require.Zero(t, recorder.Body.Len())
+}


### PR DESCRIPTION
## Summary

This keeps the fix intentionally narrow and localized to the OpenAI Responses streaming handlers.

When an upstream Responses stream emits `response.error` / `response.failed` **before New API has written any downstream event**, this patch now returns a structured API error instead of prematurely committing the downstream `200 OK` SSE response.

Once the downstream stream has already started, the existing stream behavior is preserved.

## What changed

- added a pre-first-write guard in `relay/channel/openai/relay_responses.go`
- added the analogous guard in `relay/channel/openai/chat_via_responses.go`
- added focused regression tests for both handlers

## Why this helps

Clients can now distinguish the important **"transport opened, but business failed before first token"** case using a normal non-200 API error, which makes retry logic much more reliable without redesigning the generic streaming pipeline.

## Tests

- `GOCACHE=/tmp/gocache-newapi go test ./relay/channel/openai -count=1`

Refs #3142


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OpenAI streaming responses. Errors occurring before streaming begins are now immediately returned, while errors during active streaming are handled gracefully without disrupting the response flow.

* **Tests**
  * Added tests to verify proper error handling in streaming response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->