### PR TITLE
fix: add explicit docker-compose networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - redis
       - postgres
 #      - mysql  # Uncomment if using MySQL
+    networks:
+      - new-api-network
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O - http://localhost:3000/api/status | grep -o '\"success\":\\s*true' || exit 1"]
       interval: 30s
@@ -53,6 +55,8 @@ services:
     image: redis:latest
     container_name: redis
     restart: always
+    networks:
+      - new-api-network
 
   postgres:
     image: postgres:15
@@ -64,6 +68,8 @@ services:
       POSTGRES_DB: new-api
     volumes:
       - pg_data:/var/lib/postgresql/data
+    networks:
+      - new-api-network
 #    ports:
 #      - "5432:5432"  # Uncomment if you need to access PostgreSQL from outside Docker
 
@@ -76,9 +82,15 @@ services:
 #      MYSQL_DATABASE: new-api
 #    volumes:
 #      - mysql_data:/var/lib/mysql
+#    networks:
+#      - new-api-network
 #    ports:
 #      - "3306:3306"  # Uncomment if you need to access MySQL from outside Docker
 
 volumes:
   pg_data:
 #  mysql_data:
+
+networks:
+  new-api-network:
+    driver: bridge


### PR DESCRIPTION
This PR adds an explicit bridge network named new-api-network in docker-compose.yml.
It attaches new-api, redis, and postgres to the same network to make inter-service connectivity explicit and predictable.
It also keeps the commented MySQL section aligned by adding the same network lines for the optional service.
No application logic is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose configuration to establish a dedicated service network, enabling improved communication and isolation between application services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->