### PR TITLE
fix: kling risk fail return openAIVideo error

### DIFF
--- a/relay/channel/task/kling/adaptor.go
+++ b/relay/channel/task/kling/adaptor.go
@@ -405,5 +405,12 @@ func (a *TaskAdaptor) ConvertToOpenAIVideo(originTask *model.Task) ([]byte, erro
 			Code:    fmt.Sprintf("%d", klingResp.Code),
 		}
 	}
+
+	// https://app.klingai.com/cn/dev/document-api/apiReference/model/textToVideo
+	if data := klingResp.Data; data.TaskStatus == "failed" {
+		openAIVideo.Error = &dto.OpenAIVideoError{
+			Message: data.TaskStatusMsg,
+		}
+	}
 	return common.Marshal(openAIVideo)
 }


### PR DESCRIPTION
可灵视频被风控时返回标准错误
<img width="2514" height="1002" alt="image" src="https://github.com/user-attachments/assets/5d53ed55-754d-4198-9b80-bd1f4e314ad7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failed Kling video generation tasks, ensuring error messages are properly captured and communicated to users when a task fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->