### PR TITLE
fix: apply channel header overrides to async video task requests

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -16,6 +16,7 @@ import (
 	"github.com/QuantumNous/new-api/middleware"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/relay"
+	relaychannel "github.com/QuantumNous/new-api/relay/channel"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
 	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
@@ -571,10 +572,17 @@ func RelayTask(c *gin.Context) {
 		service.LogTaskConsumption(c, relayInfo)
 
 		task := model.InitTask(result.Platform, relayInfo)
+		task.PrivateData.Key = relayInfo.ApiKey
 		task.PrivateData.UpstreamTaskID = result.UpstreamTaskID
 		task.PrivateData.BillingSource = relayInfo.BillingSource
 		task.PrivateData.SubscriptionId = relayInfo.SubscriptionId
 		task.PrivateData.TokenId = relayInfo.TokenId
+		resolvedHeaders, resolveErr := relaychannel.ResolveHeaderOverride(relayInfo, c)
+		if resolveErr != nil {
+			logger.LogWarn(c, fmt.Sprintf("Failed to snapshot resolved headers for task %s: %s", task.TaskID, resolveErr.Error()))
+		} else if len(resolvedHeaders) > 0 {
+			task.PrivateData.ResolvedHeaders = resolvedHeaders
+		}
 		task.PrivateData.BillingContext = &model.TaskBillingContext{
 			ModelPrice:      relayInfo.PriceData.ModelPrice,
 			GroupRatio:      relayInfo.PriceData.GroupRatioInfo.GroupRatio,

--- a/controller/video_proxy.go
+++ b/controller/video_proxy.go
@@ -108,17 +108,26 @@ func VideoProxy(c *gin.Context) {
 		}
 	case constant.ChannelTypeOpenAI, constant.ChannelTypeSora:
 		videoURL = fmt.Sprintf("%s/v1/videos/%s/content", baseURL, task.GetUpstreamTaskID())
-		req.Header.Set("Authorization", "Bearer "+channel.Key)
-		headerOverride, resolveErr := relaychannel.ResolveHeaderOverride(&relaycommon.RelayInfo{
-			ChannelMeta: &relaycommon.ChannelMeta{
-				ApiKey:          channel.Key,
-				HeadersOverride: channel.GetHeaderOverride(),
-			},
-		}, c)
-		if resolveErr != nil {
-			logger.LogError(c.Request.Context(), fmt.Sprintf("Failed to resolve header override for task %s: %s", taskID, resolveErr.Error()))
-			videoProxyError(c, http.StatusInternalServerError, "server_error", "Failed to create proxy request")
-			return
+		effectiveKey := channel.Key
+		if task.PrivateData.Key != "" {
+			effectiveKey = task.PrivateData.Key
+		}
+		req.Header.Set("Authorization", "Bearer "+effectiveKey)
+
+		headerOverride := task.PrivateData.ResolvedHeaders
+		if len(headerOverride) == 0 {
+			var resolveErr error
+			headerOverride, resolveErr = relaychannel.ResolveHeaderOverride(&relaycommon.RelayInfo{
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ApiKey:          effectiveKey,
+					HeadersOverride: channel.GetHeaderOverride(),
+				},
+			}, c)
+			if resolveErr != nil {
+				logger.LogError(c.Request.Context(), fmt.Sprintf("Failed to resolve header override for task %s: %s", taskID, resolveErr.Error()))
+				videoProxyError(c, http.StatusInternalServerError, "server_error", "Failed to create proxy request")
+				return
+			}
 		}
 		for key, value := range headerOverride {
 			req.Header.Set(key, value)

--- a/model/task.go
+++ b/model/task.go
@@ -97,9 +97,10 @@ func (m Properties) Value() (driver.Value, error) {
 }
 
 type TaskPrivateData struct {
-	Key            string `json:"key,omitempty"`
-	UpstreamTaskID string `json:"upstream_task_id,omitempty"` // 上游真实 task ID
-	ResultURL      string `json:"result_url,omitempty"`       // 任务成功后的结果 URL（视频地址等）
+	Key             string            `json:"key,omitempty"`
+	UpstreamTaskID  string            `json:"upstream_task_id,omitempty"` // 上游真实 task ID
+	ResultURL       string            `json:"result_url,omitempty"`       // 任务成功后的结果 URL（视频地址等）
+	ResolvedHeaders map[string]string `json:"resolved_headers,omitempty"` // 提交时已解析的请求头快照，供异步 follow-up 复用
 	// 计费上下文：用于异步退款/差额结算（轮询阶段读取）
 	BillingSource  string              `json:"billing_source,omitempty"`  // "wallet" 或 "subscription"
 	SubscriptionId int                 `json:"subscription_id,omitempty"` // 订阅 ID，用于订阅退款
@@ -150,7 +151,14 @@ func (p *TaskPrivateData) Scan(val interface{}) error {
 }
 
 func (p TaskPrivateData) Value() (driver.Value, error) {
-	if (p == TaskPrivateData{}) {
+	if p.Key == "" &&
+		p.UpstreamTaskID == "" &&
+		p.ResultURL == "" &&
+		len(p.ResolvedHeaders) == 0 &&
+		p.BillingSource == "" &&
+		p.SubscriptionId == 0 &&
+		p.TokenId == 0 &&
+		p.BillingContext == nil {
 		return nil, nil
 	}
 	return common.Marshal(p)

--- a/service/task_polling.go
+++ b/service/task_polling.go
@@ -359,10 +359,17 @@ func updateVideoSingleTask(ctx context.Context, adaptor TaskPollingAdaptor, ch *
 	if privateData.Key != "" {
 		key = privateData.Key
 	}
+	headerOverride := ch.GetHeaderOverride()
+	if len(privateData.ResolvedHeaders) > 0 {
+		headerOverride = make(map[string]any, len(privateData.ResolvedHeaders))
+		for k, v := range privateData.ResolvedHeaders {
+			headerOverride[k] = v
+		}
+	}
 	resp, err := adaptor.FetchTask(baseURL, key, map[string]any{
 		"task_id":         task.GetUpstreamTaskID(),
 		"action":          task.Action,
-		"header_override": ch.GetHeaderOverride(),
+		"header_override": headerOverride,
 	}, proxy)
 	if err != nil {
 		return fmt.Errorf("fetchTask failed for task %s: %w", taskId, err)


### PR DESCRIPTION
## Problem

Channel configuration already supports `HeaderOverride`, but async video task requests do not consistently apply these headers.

This causes Sora2 task submission, polling, and content download to behave differently from regular relay requests, especially when the upstream is behind Microsoft APIM or another gateway that requires additional request headers.

## Solution

This PR applies channel header overrides to the Sora2 async video task flow:

- apply `HeaderOverride` in the shared task submit request path
- apply `HeaderOverride` in Sora task polling requests
- apply `HeaderOverride` in Sora/OpenAI video content proxy requests

## Compatibility

- no behavior change when `HeaderOverride` is not configured
- existing default `Authorization: Bearer <key>` behavior is preserved
- header override remains the final override layer

## Scope

This PR is intentionally scoped to the Sora2 async video task flow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header override support expanded across video proxy and task API paths, allowing dynamic per-request header customization (including Host).
  * Resolved headers are now preserved with tasks for consistent async follow-ups.
* **Bug Fixes**
  * Header override precedence unified so explicit overrides take priority over defaults; failures during resolution surface as an error response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->