### PR TITLE
fix: three user controller and notify-limit bugs (P1+P2)

### DIFF
--- a/common/limiter/lua/notify_limit.lua
+++ b/common/limiter/lua/notify_limit.lua
@@ -1,0 +1,20 @@
+-- 通知限速原子计数器
+-- KEYS[1]: 限速 key（含用户ID、通知类型、时间窗口）
+-- ARGV[1]: 最大允许次数
+-- ARGV[2]: 过期时间（秒）
+-- 返回: 1 = 允许, 0 = 超限
+
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+
+local current = redis.call('INCR', key)
+if current == 1 then
+    redis.call('EXPIRE', key, ttl)
+end
+
+if current <= limit then
+    return 1
+else
+    return 0
+end

--- a/controller/user.go
+++ b/controller/user.go
@@ -381,6 +381,13 @@ func GetSelf(c *gin.Context) {
 
 	// 获取用户设置并提取sidebar_modules
 	userSetting := user.GetSetting()
+	// Redact notification credentials before returning to client.
+	// WebhookSecret, GotifyToken, BarkUrl are write-only fields: the frontend
+	// only needs to know whether they are configured, not their actual values.
+	safeSettings := userSetting
+	safeSettings.WebhookSecret = ""
+	safeSettings.GotifyToken = ""
+	safeSettings.BarkUrl = ""
 
 	// 构建响应数据，包含用户信息和权限
 	responseData := map[string]interface{}{
@@ -405,7 +412,7 @@ func GetSelf(c *gin.Context) {
 		"aff_history_quota": user.AffHistoryQuota,
 		"inviter_id":        user.InviterId,
 		"linux_do_id":       user.LinuxDOId,
-		"setting":           user.Setting,
+		"setting":           safeSettings,
 		"stripe_customer":   user.StripeCustomer,
 		"sidebar_modules":   userSetting.SidebarModules, // 正确提取sidebar_modules字段
 		"permissions":       permissions,                // 新增权限字段
@@ -770,12 +777,13 @@ func DeleteUser(c *gin.Context) {
 	}
 	err = model.HardDeleteUserById(id)
 	if err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"success": true,
-			"message": "",
-		})
+		common.ApiError(c, err)
 		return
 	}
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"message": "",
+	})
 }
 
 func DeleteSelf(c *gin.Context) {

--- a/service/notify-limit.go
+++ b/service/notify-limit.go
@@ -1,14 +1,15 @@
 package service
 
 import (
+	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/bytedance/gopkg/util/gopool"
+	"github.com/go-redis/redis/v8"
 )
 
 // notifyLimitStore is used for in-memory rate limiting when Redis is disabled
@@ -54,36 +55,32 @@ func CheckNotificationLimit(userId int, notifyType string) (bool, error) {
 	return checkMemoryLimit(userId, notifyType)
 }
 
+// notifyLimitScript is an atomic Lua script that increments a counter and
+// checks it against the limit in a single round-trip, eliminating the
+// GET → check → INCR race condition present in the previous implementation.
+var notifyLimitScript = redis.NewScript(`
+local current = redis.call('INCR', KEYS[1])
+if current == 1 then
+    redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))
+end
+if current <= tonumber(ARGV[1]) then return 1 else return 0 end
+`)
+
 func checkRedisLimit(userId int, notifyType string) (bool, error) {
 	key := fmt.Sprintf("notify_limit:%d:%s:%s", userId, notifyType, time.Now().Format("2006010215"))
+	ttlSeconds := int(getDuration().Seconds())
 
-	// Get current count
-	count, err := common.RedisGet(key)
-	if err != nil && err.Error() != "redis: nil" {
-		return false, fmt.Errorf("failed to get notification count: %w", err)
-	}
-
-	// If key doesn't exist, initialize it
-	if count == "" {
-		err = common.RedisSet(key, "1", getDuration())
-		return true, err
-	}
-
-	currentCount, _ := strconv.Atoi(count)
-	limit := constant.NotifyLimitCount
-
-	// Check if limit is already reached
-	if currentCount >= limit {
-		return false, nil
-	}
-
-	// Only increment if under limit
-	err = common.RedisIncr(key, 1)
+	result, err := notifyLimitScript.Run(
+		context.Background(),
+		common.RDB,
+		[]string{key},
+		constant.NotifyLimitCount,
+		ttlSeconds,
+	).Int()
 	if err != nil {
-		return false, fmt.Errorf("failed to increment notification count: %w", err)
+		return false, fmt.Errorf("notify rate limit script error: %w", err)
 	}
-
-	return true, nil
+	return result == 1, nil
 }
 
 func checkMemoryLimit(userId int, notifyType string) (bool, error) {


### PR DESCRIPTION
## Summary

Three bugs fixed: one P1 functionality issue and two P2 quality issues.

---

### P1 — DeleteUser logic inversion

**File:** controller/user.go:DeleteUser
**Bug:** Error path returned success:true, success path had no response at all.

**Fix:** Swap responses - error returns ApiError, success returns JSON 200.

---

### P2 — GetSelf leaks notification credentials

**File:** controller/user.go:GetSelf
**Bug:** /api/user/self returned raw user.Setting including WebhookSecret, GotifyToken, BarkUrl in plaintext.

**Fix:** Redact write-only fields before returning. Frontend only needs to know if configured, not the actual values.

---

### P2 — notify rate limit Redis race condition

**File:** service/notify-limit.go
**Bug:** GET + check + INCR was non-atomic (3 round-trips). Under concurrency, actual send count could exceed limit.

**Fix:** Replace with atomic Lua script (INCR + EXPIRE in one EVAL).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * User credential fields are now redacted from user settings API responses.

* **Bug Fixes**
  * User deletion now properly returns API errors on failure instead of success responses.

* **Refactor**
  * Notification rate limiting implementation updated for atomic execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->