### PR TITLE
fix: infer missing schema type in normalizeGeminiSchemaTypeAndNullable

### DIFF
--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -852,10 +852,10 @@ func cleanFunctionParametersShallow(params interface{}) interface{} {
 }
 
 // inferTypeFromEnumValues detects the best Gemini schema type for an enum field
-// whose "type" is absent. Per the Vertex AI Schema spec, enum values are
-// represented as strings even when the logical type is INTEGER or BOOLEAN, so
-// we inspect the string content rather than the Go type of each element.
-// Priority: BOOLEAN > INTEGER > NUMBER > STRING (most specific first).
+// whose "type" is absent. Only native JSON types (bool, float64) are used for
+// inference; quoted string members are always treated as STRING literals,
+// because in JSON Schema enum: ["01", "true"] means string values, not numbers.
+// Priority: BOOLEAN > INTEGER > NUMBER > STRING.
 func inferTypeFromEnumValues(rawEnum interface{}) string {
 	enumSlice, ok := rawEnum.([]interface{})
 	if !ok || len(enumSlice) == 0 {
@@ -867,37 +867,20 @@ func inferTypeFromEnumValues(rawEnum interface{}) string {
 	allNumber := true
 
 	for _, v := range enumSlice {
-		s := ""
 		switch val := v.(type) {
 		case string:
-			s = val
+			// Quoted enum members are string literals even if they look numeric.
+			return "STRING"
 		case bool:
-			// Native JSON boolean — no further numeric check needed.
 			allInteger = false
 			allNumber = false
-			continue
 		case float64:
-			// Native JSON number.
 			allBool = false
 			if val != float64(int64(val)) {
 				allInteger = false
 			}
-			continue
 		default:
-			// Unknown type; cannot determine a precise scalar type.
 			return "STRING"
-		}
-
-		// String-encoded value checks (Vertex AI encodes enum values as strings).
-		lower := strings.ToLower(strings.TrimSpace(s))
-		if lower != "true" && lower != "false" {
-			allBool = false
-		}
-		if _, err := strconv.ParseInt(s, 10, 64); err != nil {
-			allInteger = false
-		}
-		if _, err := strconv.ParseFloat(s, 64); err != nil {
-			allNumber = false
 		}
 	}
 


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

**关联 Issue：#3022**

#### 问题

Gemini / Vertex AI 要求 tool schema 中每个节点都必须显式声明 `type` 字段，但 OpenAI 协议允许嵌套对象省略该字段。`normalizeGeminiSchemaTypeAndNullable` 在检测到 `type` 缺失时直接 `return`，导致后端报错：

```
relay error: `edit` functionDeclaration `parameters.edits.lines` schema didn't specify the schema type field.
```

#### 修复

当 `type` 缺失时，根据同级字段推断类型，再继续执行正常逻辑：

| 条件 | 推断类型 |
|------|----------|
| 存在 `properties` | `OBJECT` |
| 存在 `items` | `ARRAY` |
| 存在 `enum` | `STRING` |
| 其他 | `OBJECT`（安全默认值）|

#### 影响范围

仅修改 `relay/channel/gemini/relay-gemini.go` 中的单个函数，不影响其他渠道。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini schema handling when type is missing: infers OBJECT if properties present, ARRAY if items present, derives type from enum values, and defaults to OBJECT otherwise.
  * Enum-based inference now prioritizes BOOLEAN, then INTEGER, then NUMBER, falling back to STRING for quoted or non-numeric members.
  * Added inline documentation clarifying the new inference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->