### PR TITLE
fix: strip internal 'group' field from passthrough request body

### DIFF
--- a/relay/compatible_handler.go
+++ b/relay/compatible_handler.go
@@ -2,7 +2,6 @@ package relay
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -116,10 +115,10 @@ func TextHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types
 		// channel/group selection and must not be sent to external APIs — doing
 		// so causes 400 errors on backends like Gemini that reject unknown fields.
 		if rawBytes, readErr := storage.Bytes(); readErr == nil {
-			var bodyMap map[string]json.RawMessage
-			if jsonErr := json.Unmarshal(rawBytes, &bodyMap); jsonErr == nil {
+			var bodyMap map[string]any
+			if jsonErr := common.Unmarshal(rawBytes, &bodyMap); jsonErr == nil {
 				delete(bodyMap, "group")
-				if cleaned, marshalErr := json.Marshal(bodyMap); marshalErr == nil {
+				if cleaned, marshalErr := common.Marshal(bodyMap); marshalErr == nil {
 					requestBody = bytes.NewReader(cleaned)
 				}
 			}


### PR DESCRIPTION
### PR 类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 其他

### PR 是否包含破坏性更新？

- [ ] 是
- [x] 否

### PR 描述

**关联 Issue：#2099**

#### 问题

Playground 在开启「透传请求体」模式时，会将 UI 内部使用的 `group` 字段原样转发给上游 API。该字段仅用于 Distributor 中间件做渠道路由选择，对外部 API 毫无意义。Gemini 等后端会因收到未知的顶层字段而返回 400 错误。

#### 根因

`relay/compatible_handler.go` 在 passthrough 模式下直接将原始请求体 (`storage`) 转发给上游，而 Playground 前端构建的 payload 中包含 `group` 字段（见 `web/src/helpers/api.js` `buildApiPayload`）。Distributor 中间件消费 `group` 后，该字段仍残留在 body 中随透传一并发出。

#### 修复

在 passthrough 路径下，将请求体解析为 JSON map，删除 `group` 等 new-api 内部字段后再转发，同时保留所有其他字段。非 passthrough 路径不受影响（已经过 `ConvertOpenAIRequest` 结构体解析，`group` 本就不在 `GeneralOpenAIRequest` 中）。

#### 影响范围

- 仅修改 `relay/compatible_handler.go` 一个文件
- 不影响正常（非透传）请求路径
- 向后兼容，不含破坏性更新

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests sent in passthrough mode now have internal routing metadata removed before forwarding, preventing backend errors due to unknown fields.
  * Falls back to previous forwarding behavior if the request cannot be cleaned, ensuring stable delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->