### PR TITLE
fix: pricing model drawer crash due to missing translation function

### DIFF
--- a/web/src/components/table/model-pricing/modal/components/ModelPricingTable.jsx
+++ b/web/src/components/table/model-pricing/modal/components/ModelPricingTable.jsx
@@ -20,6 +20,7 @@ For commercial licensing, please contact support@quantumnous.com
 import React from 'react';
 import { Card, Avatar, Typography, Table, Tag } from '@douyinfe/semi-ui';
 import { IconCoinMoneyStroked } from '@douyinfe/semi-icons';
+import { useTranslation } from 'react-i18next';
 import { calculateModelPrice, getModelPriceItems } from '../../../../../helpers';
 
 const { Text } = Typography;
@@ -34,8 +35,8 @@ const ModelPricingTable = ({
   showRatio,
   usableGroup,
   autoGroups = [],
-  t,
 }) => {
+  const { t } = useTranslation();
   const modelEnableGroups = Array.isArray(modelData?.enable_groups)
     ? modelData.enable_groups
     : [];


### PR DESCRIPTION
## Summary
- `ModelPricingTable` expected `t` (translation function) as a prop, but `ModelDetailSideSheet` never passed it
- Clicking any model on the pricing page caused `TypeError: u is not a function` and rendered a blank page
- Replaced the `t` prop with `useTranslation()` hook, consistent with all other pricing modal components

## Test plan
- [ ] Open `/pricing` page
- [ ] Click on any model card to open the detail drawer
- [ ] Verify the drawer opens without errors and displays group pricing correctly
- [ ] Verify translations work correctly in the pricing table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal localization handling in the model pricing table component by streamlining how translation resources are accessed within the component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->