### PR TITLE
fix: WeChatBind session hijack vulnerability (P0)

### DIFF
--- a/controller/wechat.go
+++ b/controller/wechat.go
@@ -129,6 +129,15 @@ func WeChatBind(c *gin.Context) {
 		})
 		return
 	}
+	// Verify user is authenticated before binding
+	id := c.GetInt("id")
+	if id == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"success": false,
+			"message": "未登录",
+		})
+		return
+	}
 	code := c.Query("code")
 	wechatId, err := getWeChatIdByCode(code)
 	if err != nil {
@@ -145,10 +154,8 @@ func WeChatBind(c *gin.Context) {
 		})
 		return
 	}
-	session := sessions.Default(c)
-	id := session.Get("id")
 	user := model.User{
-		Id: id.(int),
+		Id: id,
 	}
 	err = user.FillUserById()
 	if err != nil {

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -39,7 +39,7 @@ func SetApiRouter(router *gin.Engine) {
 		apiRouter.GET("/oauth/email/bind", middleware.CriticalRateLimit(), controller.EmailBind)
 		// Non-standard OAuth (WeChat, Telegram) - keep original routes
 		apiRouter.GET("/oauth/wechat", middleware.CriticalRateLimit(), controller.WeChatAuth)
-		apiRouter.GET("/oauth/wechat/bind", middleware.CriticalRateLimit(), controller.WeChatBind)
+		apiRouter.GET("/oauth/wechat/bind", middleware.UserAuth(), middleware.CriticalRateLimit(), controller.WeChatBind)
 		apiRouter.GET("/oauth/telegram/login", middleware.CriticalRateLimit(), controller.TelegramLogin)
 		apiRouter.GET("/oauth/telegram/bind", middleware.CriticalRateLimit(), controller.TelegramBind)
 		// Standard OAuth providers (GitHub, Discord, OIDC, LinuxDO) - unified route


### PR DESCRIPTION
## Summary

**P0 — WeChatBind allows session hijacking**

**Files:** controller/wechat.go:WeChatBind, router/api-router.go

**Bug:** Function read user ID from session without verifying the session belongs to the current request. Attacker could:
1. Login with their own account (get valid session)
2. Initiate WeChat OAuth for victim's WeChat account
3. Use their session + victim's WeChat code to bind victim's WeChat to attacker's account
4. Now attacker can login as victim via WeChat

**Fix:**
1. Add UserAuth() middleware to route to ensure authenticated request
2. Use c.GetInt("id") from validated context instead of raw session.Get("id")
3. Add explicit authentication check at function start

This prevents attackers from binding arbitrary WeChat accounts to their accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WeChat account binding endpoint now enforces authentication. Unauthenticated users will receive a 401 error response.
  * Updated authentication flow to retrieve user credentials from the context instead of session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->