### PR TITLE
refactor: optimize billing flow for OpenAI-to-Anthropic conversion

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -559,10 +559,14 @@ func cacheCreationTokensForOpenAIUsage(usage *dto.Usage) int {
 	if usage == nil {
 		return 0
 	}
-	if usage.ClaudeCacheCreation5mTokens > 0 || usage.ClaudeCacheCreation1hTokens > 0 {
-		return usage.ClaudeCacheCreation5mTokens + usage.ClaudeCacheCreation1hTokens
+	splitCacheCreationTokens := usage.ClaudeCacheCreation5mTokens + usage.ClaudeCacheCreation1hTokens
+	if splitCacheCreationTokens == 0 {
+		return usage.PromptTokensDetails.CachedCreationTokens
 	}
-	return usage.PromptTokensDetails.CachedCreationTokens
+	if usage.PromptTokensDetails.CachedCreationTokens > splitCacheCreationTokens {
+		return usage.PromptTokensDetails.CachedCreationTokens
+	}
+	return splitCacheCreationTokens
 }
 
 func buildOpenAIStyleUsageFromClaudeUsage(usage *dto.Usage) dto.Usage {

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -189,19 +189,69 @@ func TestBuildOpenAIStyleUsageFromClaudeUsage(t *testing.T) {
 
 	openAIUsage := buildOpenAIStyleUsageFromClaudeUsage(usage)
 
-	if openAIUsage.PromptTokens != 160 {
-		t.Fatalf("PromptTokens = %d, want 160", openAIUsage.PromptTokens)
+	if openAIUsage.PromptTokens != 180 {
+		t.Fatalf("PromptTokens = %d, want 180", openAIUsage.PromptTokens)
 	}
-	if openAIUsage.InputTokens != 160 {
-		t.Fatalf("InputTokens = %d, want 160", openAIUsage.InputTokens)
+	if openAIUsage.InputTokens != 180 {
+		t.Fatalf("InputTokens = %d, want 180", openAIUsage.InputTokens)
 	}
-	if openAIUsage.TotalTokens != 180 {
-		t.Fatalf("TotalTokens = %d, want 180", openAIUsage.TotalTokens)
+	if openAIUsage.TotalTokens != 200 {
+		t.Fatalf("TotalTokens = %d, want 200", openAIUsage.TotalTokens)
 	}
 	if openAIUsage.UsageSemantic != "openai" {
 		t.Fatalf("UsageSemantic = %s, want openai", openAIUsage.UsageSemantic)
 	}
 	if openAIUsage.UsageSource != "anthropic" {
 		t.Fatalf("UsageSource = %s, want anthropic", openAIUsage.UsageSource)
+	}
+}
+
+func TestBuildOpenAIStyleUsageFromClaudeUsagePreservesCacheCreationRemainder(t *testing.T) {
+	tests := []struct {
+		name                    string
+		cachedCreationTokens    int
+		cacheCreationTokens5m   int
+		cacheCreationTokens1h   int
+		expectedTotalInputToken int
+	}{
+		{
+			name:                    "prefers aggregate when it includes remainder",
+			cachedCreationTokens:    50,
+			cacheCreationTokens5m:   10,
+			cacheCreationTokens1h:   20,
+			expectedTotalInputToken: 180,
+		},
+		{
+			name:                    "falls back to split tokens when aggregate missing",
+			cachedCreationTokens:    0,
+			cacheCreationTokens5m:   10,
+			cacheCreationTokens1h:   20,
+			expectedTotalInputToken: 160,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := &dto.Usage{
+				PromptTokens:     100,
+				CompletionTokens: 20,
+				PromptTokensDetails: dto.InputTokenDetails{
+					CachedTokens:         30,
+					CachedCreationTokens: tt.cachedCreationTokens,
+				},
+				ClaudeCacheCreation5mTokens: tt.cacheCreationTokens5m,
+				ClaudeCacheCreation1hTokens: tt.cacheCreationTokens1h,
+				UsageSemantic:               "anthropic",
+			}
+
+			openAIUsage := buildOpenAIStyleUsageFromClaudeUsage(usage)
+
+			if openAIUsage.PromptTokens != tt.expectedTotalInputToken {
+				t.Fatalf("PromptTokens = %d, want %d", openAIUsage.PromptTokens, tt.expectedTotalInputToken)
+			}
+			if openAIUsage.InputTokens != tt.expectedTotalInputToken {
+				t.Fatalf("InputTokens = %d, want %d", openAIUsage.InputTokens, tt.expectedTotalInputToken)
+			}
+		})
 	}
 }

--- a/service/text_quota.go
+++ b/service/text_quota.go
@@ -55,7 +55,11 @@ type textQuotaSummary struct {
 
 func cacheWriteTokensTotal(summary textQuotaSummary) int {
 	if summary.CacheCreationTokens5m > 0 || summary.CacheCreationTokens1h > 0 {
-		return summary.CacheCreationTokens5m + summary.CacheCreationTokens1h
+		splitCacheWriteTokens := summary.CacheCreationTokens5m + summary.CacheCreationTokens1h
+		if summary.CacheCreationTokens > splitCacheWriteTokens {
+			return summary.CacheCreationTokens
+		}
+		return splitCacheWriteTokens
 	}
 	return summary.CacheCreationTokens
 }

--- a/service/text_quota_test.go
+++ b/service/text_quota_test.go
@@ -153,12 +153,20 @@ func TestCacheWriteTokensTotal(t *testing.T) {
 			CacheCreationTokens5m: 10,
 			CacheCreationTokens1h: 20,
 		}
-		require.Equal(t, 30, cacheWriteTokensTotal(summary))
+		require.Equal(t, 50, cacheWriteTokensTotal(summary))
 	})
 
 	t.Run("legacy cache creation", func(t *testing.T) {
 		summary := textQuotaSummary{CacheCreationTokens: 50}
 		require.Equal(t, 50, cacheWriteTokensTotal(summary))
+	})
+
+	t.Run("split cache creation without aggregate remainder", func(t *testing.T) {
+		summary := textQuotaSummary{
+			CacheCreationTokens5m: 10,
+			CacheCreationTokens1h: 20,
+		}
+		require.Equal(t, 30, cacheWriteTokensTotal(summary))
 	})
 }
 

--- a/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
@@ -310,15 +310,21 @@ function getPromptCacheSummary(other) {
   }
 
   const cacheReadTokens = toTokenNumber(other.cache_tokens);
+  const normalizedCacheWriteTokens = toTokenNumber(other.cache_write_tokens);
   const cacheCreationTokens = toTokenNumber(other.cache_creation_tokens);
   const cacheCreationTokens5m = toTokenNumber(other.cache_creation_tokens_5m);
   const cacheCreationTokens1h = toTokenNumber(other.cache_creation_tokens_1h);
 
   const hasSplitCacheCreation =
     cacheCreationTokens5m > 0 || cacheCreationTokens1h > 0;
-  const cacheWriteTokens = hasSplitCacheCreation
-    ? cacheCreationTokens5m + cacheCreationTokens1h
-    : cacheCreationTokens;
+  const cacheWriteTokens = normalizedCacheWriteTokens > 0
+    ? normalizedCacheWriteTokens
+    : hasSplitCacheCreation
+      ? Math.max(
+          cacheCreationTokens,
+          cacheCreationTokens5m + cacheCreationTokens1h,
+        )
+      : cacheCreationTokens;
 
   if (cacheReadTokens <= 0 && cacheWriteTokens <= 0) {
     return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI and logs show split cache-creation metrics (5m/1h tokens & ratios) and updated input-token display.
  * Usage records include explicit semantic/source metadata for Anthropic vs OpenAI flows.
  * Centralized text-based quota posting and unified text-quota calculation/summary.

* **Bug Fixes**
  * Improved cache token accounting and pricing accuracy across UI and backend quota paths.
  * Removed fragmented Claude-specific quota path in favor of unified text quota.

* **Tests**
  * Added tests for usage marshal/unmarshal, Claude↔OpenAI usage conversion, and text quota calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->