### PR TITLE
feat(aws): Bedrock 智能模型解析与推理模式自适应

### DIFF
--- a/relay/channel/aws/adaptor.go
+++ b/relay/channel/aws/adaptor.go
@@ -90,7 +90,12 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if info.ChannelOtherSettings.AwsKeyType == dto.AwsKeyTypeApiKey {
-		awsModelId := getAwsModelID(info.UpstreamModelName)
+		awsModelId, skipInferenceResolve := getAwsModelID(info.UpstreamModelName)
+		if !skipInferenceResolve {
+			if awsModelsRequireInferenceProfile[awsModelId] {
+				awsModelId = "global." + awsModelId
+			}
+		}
 		a.ClientMode = ClientModeApiKey
 		awsSecret := strings.Split(info.ApiKey, "|")
 		if len(awsSecret) != 2 {

--- a/relay/channel/aws/constants.go
+++ b/relay/channel/aws/constants.go
@@ -2,6 +2,22 @@ package aws
 
 import "strings"
 
+// bedrockProviderPrefixes are known Bedrock provider prefixes for Layer 1 detection.
+var bedrockProviderPrefixes = []string{
+	"anthropic.", "amazon.", "meta.", "mistral.", "cohere.", "ai21.", "stability.", "deepseek.", "minimax.",
+}
+
+// bedrockRegionPrefixes are known Bedrock cross-region inference prefixes for Layer 1 detection.
+var bedrockRegionPrefixes = []string{
+	"global.", "us.", "eu.", "ap.", "apac.", "jp.",
+}
+
+// modelProviderPatterns maps short-name prefixes to Bedrock provider prefixes for Layer 3.
+var modelProviderPatterns = map[string]string{
+	"claude-": "anthropic.",
+	"nova-":   "amazon.",
+}
+
 var awsModelIDMap = map[string]string{
 	"claude-3-sonnet-20240229":   "anthropic.claude-3-sonnet-20240229-v1:0",
 	"claude-3-opus-20240229":     "anthropic.claude-3-opus-20240229-v1:0",
@@ -20,6 +36,8 @@ var awsModelIDMap = map[string]string{
 	"claude-opus-4-6":            "anthropic.claude-opus-4-6-v1",
 	// Nova models
 	"nova-micro-v1:0":   "amazon.nova-micro-v1:0",
+	// Nova 2 models
+	"nova-2-lite-v1:0": "amazon.nova-2-lite-v1:0",
 	"nova-lite-v1:0":    "amazon.nova-lite-v1:0",
 	"nova-pro-v1:0":     "amazon.nova-pro-v1:0",
 	"nova-premier-v1:0": "amazon.nova-premier-v1:0",
@@ -29,116 +47,26 @@ var awsModelIDMap = map[string]string{
 	"nova-sonic-v1:0":   "amazon.nova-sonic-v1:0",
 }
 
-var awsModelCanCrossRegionMap = map[string]map[string]bool{
-	"anthropic.claude-3-sonnet-20240229-v1:0": {
-		"us": true,
-		"eu": true,
-		"ap": true,
-	},
-	"anthropic.claude-3-opus-20240229-v1:0": {
-		"us": true,
-	},
-	"anthropic.claude-3-haiku-20240307-v1:0": {
-		"us": true,
-		"eu": true,
-		"ap": true,
-	},
-	"anthropic.claude-3-5-sonnet-20240620-v1:0": {
-		"us": true,
-		"eu": true,
-		"ap": true,
-	},
-	"anthropic.claude-3-5-sonnet-20241022-v2:0": {
-		"us": true,
-		"ap": true,
-	},
-	"anthropic.claude-3-5-haiku-20241022-v1:0": {
-		"us": true,
-	},
-	"anthropic.claude-3-7-sonnet-20250219-v1:0": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-sonnet-4-20250514-v1:0": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-opus-4-20250514-v1:0": {
-		"us": true,
-	},
-	"anthropic.claude-opus-4-1-20250805-v1:0": {
-		"us": true,
-	},
-	"anthropic.claude-sonnet-4-5-20250929-v1:0": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-sonnet-4-6": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-opus-4-5-20251101-v1:0": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-opus-4-6-v1": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	"anthropic.claude-haiku-4-5-20251001-v1:0": {
-		"us": true,
-		"ap": true,
-		"eu": true,
-	},
-	// Nova models - all support three major regions
-	"amazon.nova-micro-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-	"amazon.nova-lite-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-	"amazon.nova-pro-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-	"amazon.nova-premier-v1:0": {
-		"us": true,
-	},
-	"amazon.nova-canvas-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-	"amazon.nova-reel-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-	"amazon.nova-reel-v1:1": {
-		"us": true,
-	},
-	"amazon.nova-sonic-v1:0": {
-		"us":   true,
-		"eu":   true,
-		"apac": true,
-	},
-}
-
-var awsRegionCrossModelPrefixMap = map[string]string{
-	"us": "us",
-	"eu": "eu",
-	"ap": "apac",
+// awsModelsRequireInferenceProfile lists models whose base model ID does NOT
+// support on-demand invocation. These models MUST be called with an inference
+// profile prefix (global./us./eu./jp.). Models not in this map default to
+// on-demand (base model ID).
+var awsModelsRequireInferenceProfile = map[string]bool{
+	// Claude 3.7
+	"anthropic.claude-3-7-sonnet-20250219-v1:0": true,
+	// Claude 4.x
+	"anthropic.claude-sonnet-4-20250514-v1:0":   true,
+	"anthropic.claude-opus-4-20250514-v1:0":     true,
+	"anthropic.claude-opus-4-1-20250805-v1:0":   true,
+	"anthropic.claude-sonnet-4-5-20250929-v1:0": true,
+	"anthropic.claude-opus-4-5-20251101-v1:0":   true,
+	"anthropic.claude-haiku-4-5-20251001-v1:0":  true,
+	"anthropic.claude-opus-4-6-v1":              true,
+	"anthropic.claude-sonnet-4-6":               true,
+	// Nova 2
+	"amazon.nova-2-lite-v1:0": true,
+	// DeepSeek
+	"deepseek.r1-v1:0": true,
 }
 
 var ChannelName = "aws"

--- a/relay/channel/aws/relay-aws.go
+++ b/relay/channel/aws/relay-aws.go
@@ -96,12 +96,13 @@ func doAwsClientRequest(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor,
 	a.AwsClient = awsCli
 
 	// 获取对应的AWS模型ID
-	awsModelId := getAwsModelID(info.UpstreamModelName)
-
-	awsRegionPrefix := getAwsRegionPrefix(awsCli.Options().Region)
-	canCrossRegion := awsModelCanCrossRegion(awsModelId, awsRegionPrefix)
-	if canCrossRegion {
-		awsModelId = awsModelCrossRegion(awsModelId, awsRegionPrefix)
+	awsModelId, skipInferenceResolve := getAwsModelID(info.UpstreamModelName)
+	// Layer 1 (full IDs): user specified exact model ID, use as-is.
+	// Layer 2/3 (short names): check if model requires inference profile.
+	if !skipInferenceResolve {
+		if awsModelsRequireInferenceProfile[awsModelId] {
+			awsModelId = "global." + awsModelId
+		}
 	}
 
 	// init empty request.header
@@ -192,33 +193,33 @@ func buildAwsRequestBody(c *gin.Context, info *relaycommon.RelayInfo, awsClaudeR
 	return common.Marshal(awsClaudeReq)
 }
 
-func getAwsRegionPrefix(awsRegionId string) string {
-	parts := strings.Split(awsRegionId, "-")
-	regionPrefix := ""
-	if len(parts) > 0 {
-		regionPrefix = parts[0]
+func getAwsModelID(requestModel string) (modelID string, skipInferenceResolve bool) {
+	// Layer 1: Full Bedrock ID detection — passthrough
+	for _, rp := range bedrockRegionPrefixes {
+		if strings.HasPrefix(requestModel, rp) {
+			return requestModel, true
+		}
 	}
-	return regionPrefix
-}
-
-func awsModelCanCrossRegion(awsModelId, awsRegionPrefix string) bool {
-	regionSet, exists := awsModelCanCrossRegionMap[awsModelId]
-	return exists && regionSet[awsRegionPrefix]
-}
-
-func awsModelCrossRegion(awsModelId, awsRegionPrefix string) string {
-	modelPrefix, find := awsRegionCrossModelPrefixMap[awsRegionPrefix]
-	if !find {
-		return awsModelId
+	for _, pp := range bedrockProviderPrefixes {
+		if strings.HasPrefix(requestModel, pp) {
+			return requestModel, true // user explicitly passed full provider ID, skip cross-region
+		}
 	}
-	return modelPrefix + "." + awsModelId
-}
 
-func getAwsModelID(requestModel string) string {
-	if awsModelIDName, ok := awsModelIDMap[requestModel]; ok {
-		return awsModelIDName
+	// Layer 2: Exact map lookup (backwards compatible)
+	if mapped, ok := awsModelIDMap[requestModel]; ok {
+		return mapped, false
 	}
-	return requestModel
+
+	// Layer 3: Pattern matching — auto-prepend provider prefix
+	for pattern, prefix := range modelProviderPatterns {
+		if strings.HasPrefix(requestModel, pattern) {
+			return prefix + requestModel, false
+		}
+	}
+
+	// Fallback: passthrough as-is
+	return requestModel, false
 }
 
 func awsHandler(c *gin.Context, info *relaycommon.RelayInfo, a *Adaptor) (*types.NewAPIError, *dto.Usage) {

--- a/relay/channel/aws/relay_aws_test.go
+++ b/relay/channel/aws/relay_aws_test.go
@@ -53,3 +53,94 @@ func TestDoAwsClientRequest_AppliesRuntimeHeaderOverrideToAnthropicBeta(t *testi
 	require.True(t, ok)
 	require.Equal(t, []any{"computer-use-2025-01-24"}, values)
 }
+
+func TestGetAwsModelID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		input            string
+		wantModelID      string
+		wantHasRegionPfx bool
+	}{
+		// Layer 1: region-prefixed full IDs → passthrough, hasRegionPrefix=true
+		{"global prefix passthrough", "global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-opus-4-6-v1", true},
+		{"us prefix passthrough", "us.anthropic.claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6", true},
+		{"eu prefix passthrough", "eu.anthropic.claude-opus-4-6-v1", "eu.anthropic.claude-opus-4-6-v1", true},
+		{"jp prefix passthrough", "jp.anthropic.claude-sonnet-4-6", "jp.anthropic.claude-sonnet-4-6", true},
+		{"apac prefix passthrough", "apac.amazon.nova-micro-v1:0", "apac.amazon.nova-micro-v1:0", true},
+
+		// Layer 1: provider-prefixed full IDs → passthrough, skip cross-region (true)
+		{"anthropic provider passthrough", "anthropic.claude-opus-4-6-v1", "anthropic.claude-opus-4-6-v1", true},
+		{"amazon provider passthrough", "amazon.nova-micro-v1:0", "amazon.nova-micro-v1:0", true},
+		{"meta provider passthrough", "meta.llama3-70b-instruct-v1:0", "meta.llama3-70b-instruct-v1:0", true},
+
+		// Layer 2: exact map lookup (existing behavior)
+		{"exact map claude-opus-4-6", "claude-opus-4-6", "anthropic.claude-opus-4-6-v1", false},
+		{"exact map nova-micro", "nova-micro-v1:0", "amazon.nova-micro-v1:0", false},
+		{"exact map claude-3-sonnet", "claude-3-sonnet-20240229", "anthropic.claude-3-sonnet-20240229-v1:0", false},
+		{"exact map claude-haiku-4-5", "claude-haiku-4-5-20251001", "anthropic.claude-haiku-4-5-20251001-v1:0", false},
+
+		// Layer 3: pattern matching (new models auto-resolve)
+		{"pattern claude future model", "claude-future-model-2026", "anthropic.claude-future-model-2026", false},
+		{"pattern nova future model", "nova-ultra-v2:0", "amazon.nova-ultra-v2:0", false},
+
+		// Fallback: unknown model passthrough
+		{"unknown model passthrough", "some-unknown-model", "some-unknown-model", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modelID, hasRegionPfx := getAwsModelID(tt.input)
+			require.Equal(t, tt.wantModelID, modelID)
+			require.Equal(t, tt.wantHasRegionPfx, hasRegionPfx)
+		})
+	}
+}
+
+func TestEndToEndModelResolution(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       string
+		wantFinalID string
+	}{
+		// Short names: inference-profile-required models -> global. prefix
+		{"short claude-opus-4-6", "claude-opus-4-6", "global.anthropic.claude-opus-4-6-v1"},
+		{"short claude-sonnet-4-6", "claude-sonnet-4-6", "global.anthropic.claude-sonnet-4-6"},
+		{"short claude-haiku-4-5", "claude-haiku-4-5-20251001", "global.anthropic.claude-haiku-4-5-20251001-v1:0"},
+		{"short claude-opus-4-5", "claude-opus-4-5-20251101", "global.anthropic.claude-opus-4-5-20251101-v1:0"},
+		// Short names: on-demand models -> NO prefix (base ID)
+		{"short nova-micro", "nova-micro-v1:0", "amazon.nova-micro-v1:0"},
+		{"short nova-lite", "nova-lite-v1:0", "amazon.nova-lite-v1:0"},
+		{"short claude-3-haiku", "claude-3-haiku-20240307", "anthropic.claude-3-haiku-20240307-v1:0"},
+		// Short names: inference-profile-required Nova 2
+		{"short nova-2-lite", "nova-2-lite-v1:0", "global.amazon.nova-2-lite-v1:0"},
+		// Layer 3 pattern match: unknown model -> on-demand (safe default)
+		{"pattern future claude", "claude-future-2026", "anthropic.claude-future-2026"},
+		{"pattern future nova", "nova-ultra-v2:0", "amazon.nova-ultra-v2:0"},
+		// Full provider ID -> passthrough (no prefix)
+		{"full anthropic ID", "anthropic.claude-opus-4-6-v1", "anthropic.claude-opus-4-6-v1"},
+		{"full amazon ID", "amazon.nova-micro-v1:0", "amazon.nova-micro-v1:0"},
+		// Region-prefixed -> passthrough
+		{"global prefix", "global.anthropic.claude-opus-4-6-v1", "global.anthropic.claude-opus-4-6-v1"},
+		{"us prefix", "us.anthropic.claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6"},
+		{"eu prefix", "eu.anthropic.claude-opus-4-6-v1", "eu.anthropic.claude-opus-4-6-v1"},
+		{"jp prefix", "jp.anthropic.claude-sonnet-4-6", "jp.anthropic.claude-sonnet-4-6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the full resolution flow from doAwsClientRequest
+			modelID, skipInferenceResolve := getAwsModelID(tt.input)
+			if !skipInferenceResolve {
+				if awsModelsRequireInferenceProfile[modelID] {
+					modelID = "global." + modelID
+				}
+			}
+			require.Equal(t, tt.wantFinalID, modelID)
+		})
+	}
+}
+


### PR DESCRIPTION
## 概述

当前 new-api 的 AWS Bedrock 渠道存在以下限制：

1. 不支持 `global.`（全局推理）和 `jp.`（东京区域）等推理配置前缀
2. 模型映射表硬编码，每个新模型都需要修改代码
3. 完整的 Bedrock 模型 ID（如 `global.anthropic.claude-opus-4-6-v1`）可能被错误处理
4. 东京区域 `ap-northeast-1` 的前缀提取不正确
5. **新旧模型调用模式不同**：Claude 4.5+ 和 Nova 2 必须通过推理配置调用，而 Claude 3.x 和 Nova v1 只支持 on-demand 直连

本 PR 通过三层智能解析 + 模型级推理模式自适应，一次性解决以上所有问题。

## 变更内容

### 1. 三层智能模型 ID 解析

重写 `getAwsModelID()`，实现分层解析：

```
Layer 1: 完整 Bedrock ID 检测 → 直接透传
  - 区域前缀（global./us./eu./jp.）→ 跳过后续处理
  - Provider 前缀（anthropic./amazon.）→ 跳过后续处理

Layer 2: 精确映射（向后兼容）
  - 现有 awsModelIDMap 查找，行为完全不变

Layer 3: 模式匹配（自动构建）
  - claude-* → 自动加 anthropic. 前缀
  - nova-*   → 自动加 amazon. 前缀
  - 新模型无需修改代码即可支持
```

### 2. 模型级推理模式自适应

通过实际 API 测试验证，不同模型的调用模式完全不同：

| 模型 | Base ID (on-demand) | 推理配置 (global./us.) |
|------|:---:|:---:|
| Claude 3 Haiku | ✅ | ❌ |
| Claude 4.5 Haiku | ❌ | ✅ |
| Claude 4.6 Opus/Sonnet | ❌ | ✅ |
| Nova Micro/Lite/Pro (v1) | ✅ | ❌ |
| Nova 2 Lite | ❌ | ✅ |
| MiniMax M2/M2.1 | ✅ | ❌ |
| DeepSeek R1 | ❌ | ✅ (us.) |
| DeepSeek V3.2 | ✅ | ❌ |

新增 `awsModelsRequireInferenceProfile` 映射表，短名称解析后自动选择正确的调用模式：
- 需要推理配置的模型自动加 `global.` 前缀
- 不在映射表中的模型默认使用 on-demand（base ID）

### 3. 用户体验

修改后，用户可以灵活使用以下任何方式调用模型：

| 输入方式 | 示例 | 行为 |
|---------|------|------|
| **短名称**（推荐） | `claude-opus-4-6` | 自动解析 + 自动选择正确调用模式 |
| **完整 Provider ID** | `anthropic.claude-opus-4-6-v1` | 直接透传，用户自行控制 |
| **区域推理配置** | `us.anthropic.claude-opus-4-6-v1` | 直接透传 |
| **全局推理配置** | `global.anthropic.claude-opus-4-6-v1` | 直接透传 |
| **未知新模型** | `claude-future-model-2026` | 自动加 `anthropic.` 前缀 |

## 变更文件

| 文件 | 改动 |
|------|------|
| `relay/channel/aws/constants.go` | 新增前缀列表、模式匹配映射、推理模式映射表 |
| `relay/channel/aws/relay-aws.go` | 重写 `getAwsModelID()`（三层解析）；更新 `doAwsClientRequest()` 推理模式逻辑 |
| `relay/channel/aws/adaptor.go` | 适配新函数签名，API Key 模式同步支持推理配置 |
| `relay/channel/aws/relay_aws_test.go` | 新增 33 个测试用例覆盖全部场景 |

## 向后兼容性

| 场景 | 修改前 | 修改后 |
|------|-------|-------|
| `claude-opus-4-6` | 映射 + 区域前缀 | `global.anthropic.claude-opus-4-6-v1`（正确） |
| `nova-micro-v1:0` | 映射 → `amazon.nova-micro-v1:0` | 行为完全不变（on-demand） |
| `anthropic.claude-opus-4-6-v1` | 可能被加错误前缀 | 透传，不做修改（修复） |
| `global.anthropic.claude-opus-4-6-v1` | 可能被加错误前缀 | 透传，跳过推理解析（修复） |

## 测试

### 单元测试
- 3 个测试函数，33 个子测试，覆盖三层解析全部路径 + 端到端解析流程

### 集成测试（真实 Bedrock API 验证）
使用 AWS SDK (Go + boto3) 验证：Claude 4.6 Opus/Sonnet、Claude 4.5 Haiku、Claude 3 Haiku、Nova Micro/Lite/Pro、Nova 2 Lite、MiniMax M2/M2.1、DeepSeek R1/V3.2 — 12/12 全部通过

### 新增模型流程

| 新模型类型 | 需要做的 |
|-----------|---------|
| 需要推理配置 | `awsModelsRequireInferenceProfile` 加一行 |
| 支持 on-demand | 无需改代码（默认行为） |
| 新增短名称映射 | `awsModelIDMap` 加一行（可选） |

## 不包含的改动

- 无数据库 schema 变更
- 无前端 UI 变更
- 无其他渠道代码变更
- 无新依赖引入
- 无 adaptor 接口变更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced AWS model ID resolution with improved Bedrock compatibility and automatic inference profile support for applicable models.

* **Tests**
  * Added comprehensive tests for AWS model ID resolution and end-to-end model handling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->