### PR TITLE
feat: 统一分页组件，使用 InputNumber 替代固定下拉选择器

### DIFF
--- a/web/src/components/settings/ChannelSelectorModal.jsx
+++ b/web/src/components/settings/ChannelSelectorModal.jsx
@@ -43,6 +43,17 @@ const MODELS_DEV_PRESET_NAME = 'models.dev 价格预设';
 const OFFICIAL_RATIO_PRESET_BASE_URL = 'https://basellm.github.io';
 const MODELS_DEV_PRESET_BASE_URL = 'https://models.dev';
 
+/**
+ * Modal for selecting and configuring upstream channels with endpoint settings.
+ * Exposes `resetPagination` method via ref (useImperativeHandle).
+ * @param {object} props
+ * @param {boolean} props.visible - Whether the modal is visible
+ * @param {Function} props.onCancel - Close callback
+ * @param {Function} props.onOk - Confirm callback
+ * @param {Array} props.allChannels - Available channels to select from
+ * @param {React.Ref} ref - Forwarded ref
+ * @returns {JSX.Element}
+ */
 const ChannelSelectorModal = forwardRef(
   (
     {

--- a/web/src/components/table/channels/ChannelsTable.jsx
+++ b/web/src/components/table/channels/ChannelsTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getChannelsColumns } from './ChannelsColumnDefs';
 
+/**
+ * Channels management table component with pagination, column visibility, and compact mode support.
+ * @param {object} channelsData - Props including channels, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const ChannelsTable = (channelsData) => {
   const {
     channels,

--- a/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
+++ b/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
@@ -51,6 +51,15 @@ import {
 
 const { Text } = Typography;
 
+/**
+ * Modal for managing API keys in multi-key channels with enable/disable/delete operations.
+ * @param {object} props
+ * @param {boolean} props.visible - Whether the modal is visible
+ * @param {Function} props.onCancel - Close callback
+ * @param {object} props.channel - Channel data containing keys to manage
+ * @param {Function} props.onRefresh - Callback to refresh channel data after changes
+ * @returns {JSX.Element}
+ */
 const MultiKeyManageModal = ({ visible, onCancel, channel, onRefresh }) => {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);

--- a/web/src/components/table/mj-logs/MjLogsTable.jsx
+++ b/web/src/components/table/mj-logs/MjLogsTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getMjLogsColumns } from './MjLogsColumnDefs';
 
+/**
+ * Midjourney task logs table component with image preview support.
+ * @param {object} mjLogsData - Props including logs, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const MjLogsTable = (mjLogsData) => {
   const {
     logs,

--- a/web/src/components/table/model-deployments/DeploymentsTable.jsx
+++ b/web/src/components/table/model-deployments/DeploymentsTable.jsx
@@ -33,6 +33,11 @@ import ViewDetailsModal from './modals/ViewDetailsModal';
 import UpdateConfigModal from './modals/UpdateConfigModal';
 import ConfirmationDialog from './modals/ConfirmationDialog';
 
+/**
+ * Model deployments management table with lifecycle operations and configuration modals.
+ * @param {object} deploymentsData - Props including deployments, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const DeploymentsTable = (deploymentsData) => {
   const {
     deployments,

--- a/web/src/components/table/model-pricing/view/card/PricingCardView.jsx
+++ b/web/src/components/table/model-pricing/view/card/PricingCardView.jsx
@@ -54,6 +54,17 @@ const CARD_STYLES = {
   default: 'border-gray-200 hover:border-gray-300',
 };
 
+/**
+ * Card-based grid layout for displaying model pricing with icons, tags, and pagination.
+ * @param {object} props
+ * @param {Array} props.filteredModels - Filtered model data to display
+ * @param {boolean} props.loading - Loading state
+ * @param {number} props.currentPage - Current page number
+ * @param {number} props.pageSize - Items per page
+ * @param {Function} props.onPageChange - Page change callback
+ * @param {Function} props.onPageSizeChange - Page size change callback
+ * @returns {JSX.Element}
+ */
 const PricingCardView = ({
   filteredModels,
   loading,

--- a/web/src/components/table/model-pricing/view/table/PricingTable.jsx
+++ b/web/src/components/table/model-pricing/view/table/PricingTable.jsx
@@ -25,6 +25,17 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getPricingTableColumns } from './PricingTableColumns';
 
+/**
+ * Table-based view for displaying model pricing with row selection and search filtering.
+ * @param {object} props
+ * @param {Array} props.filteredModels - Filtered model data to display
+ * @param {boolean} props.loading - Loading state
+ * @param {number} props.currentPage - Current page number
+ * @param {number} props.pageSize - Items per page
+ * @param {Function} props.onPageChange - Page change callback
+ * @param {Function} props.onPageSizeChange - Page size change callback
+ * @returns {JSX.Element}
+ */
 const PricingTable = ({
   filteredModels,
   loading,

--- a/web/src/components/table/models/ModelsTable.jsx
+++ b/web/src/components/table/models/ModelsTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getModelsColumns } from './ModelsColumnDefs';
 
+/**
+ * Models management table component with vendor mapping and batch selection support.
+ * @param {object} modelsData - Props including models, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const ModelsTable = (modelsData) => {
   const {
     models,

--- a/web/src/components/table/redemptions/RedemptionsTable.jsx
+++ b/web/src/components/table/redemptions/RedemptionsTable.jsx
@@ -27,6 +27,11 @@ import {
 import { getRedemptionsColumns, isExpired } from './RedemptionsColumnDefs';
 import DeleteRedemptionModal from './modals/DeleteRedemptionModal';
 
+/**
+ * Redemption codes management table with status tracking and batch operations.
+ * @param {object} redemptionsData - Props including redemptions, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const RedemptionsTable = (redemptionsData) => {
   const {
     redemptions,

--- a/web/src/components/table/task-logs/TaskLogsTable.jsx
+++ b/web/src/components/table/task-logs/TaskLogsTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getTaskLogsColumns } from './TaskLogsColumnDefs';
 
+/**
+ * Task logs table component with media preview support for video and audio content.
+ * @param {object} taskLogsData - Props including logs, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const TaskLogsTable = (taskLogsData) => {
   const {
     logs,

--- a/web/src/components/table/tokens/TokensTable.jsx
+++ b/web/src/components/table/tokens/TokensTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getTokensColumns } from './TokensColumnDefs';
 
+/**
+ * API tokens management table component with pagination, visibility toggle, and copy functionality.
+ * @param {object} tokensData - Props including tokens, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const TokensTable = (tokensData) => {
   const {
     tokens,

--- a/web/src/components/table/usage-logs/UsageLogsTable.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsTable.jsx
@@ -26,6 +26,11 @@ import {
 } from '@douyinfe/semi-illustrations';
 import { getLogsColumns } from './UsageLogsColumnDefs';
 
+/**
+ * Usage logs table component with expandable row details and billing display modes.
+ * @param {object} logsData - Props including logs, loading, pagination, and display settings
+ * @returns {JSX.Element}
+ */
 const LogsTable = (logsData) => {
   const {
     logs,

--- a/web/src/components/table/users/UsersTable.jsx
+++ b/web/src/components/table/users/UsersTable.jsx
@@ -33,6 +33,11 @@ import ResetPasskeyModal from './modals/ResetPasskeyModal';
 import ResetTwoFAModal from './modals/ResetTwoFAModal';
 import UserSubscriptionsModal from './modals/UserSubscriptionsModal';
 
+/**
+ * Users management table component with role management modals and pagination.
+ * @param {object} usersData - Props including users, loading, pagination, and action callbacks
+ * @returns {JSX.Element}
+ */
 const UsersTable = (usersData) => {
   const {
     users,

--- a/web/src/components/table/users/modals/UserSubscriptionsModal.jsx
+++ b/web/src/components/table/users/modals/UserSubscriptionsModal.jsx
@@ -73,6 +73,16 @@ function renderStatusTag(sub, t) {
   );
 }
 
+/**
+ * SideSheet for viewing and managing user subscription plans.
+ * @param {object} props
+ * @param {boolean} props.visible - Whether the side sheet is visible
+ * @param {Function} props.onCancel - Close callback
+ * @param {object} props.user - User object whose subscriptions to manage
+ * @param {Function} props.t - i18n translation function
+ * @param {Function} props.onSuccess - Callback after successful subscription operation
+ * @returns {JSX.Element}
+ */
 const UserSubscriptionsModal = ({ visible, onCancel, user, t, onSuccess }) => {
   const isMobile = useIsMobile();
   const [loading, setLoading] = useState(false);

--- a/web/src/components/topup/modals/TopupHistoryModal.jsx
+++ b/web/src/components/topup/modals/TopupHistoryModal.jsx
@@ -56,6 +56,14 @@ const PAYMENT_METHOD_MAP = {
   wxpay: '微信',
 };
 
+/**
+ * Modal for displaying the user's top-up/recharge transaction history with search and filtering.
+ * @param {object} props
+ * @param {boolean} props.visible - Whether the modal is visible
+ * @param {Function} props.onCancel - Close callback
+ * @param {Function} props.t - i18n translation function
+ * @returns {JSX.Element}
+ */
 const TopupHistoryModal = ({ visible, onCancel, t }) => {
   const [loading, setLoading] = useState(false);
   const [topups, setTopups] = useState([]);

--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -28,10 +28,20 @@ import {
 import { TABLE_COMPACT_MODES_KEY } from '../constants';
 import { MOBILE_BREAKPOINT } from '../hooks/common/useIsMobile';
 
+/**
+ * Toast content component that renders raw HTML.
+ * @param {object} props
+ * @param {string} props.htmlContent - HTML string to render
+ * @returns {JSX.Element}
+ */
 const HTMLToastContent = ({ htmlContent }) => {
   return <div dangerouslySetInnerHTML={{ __html: htmlContent }} />;
 };
 export default HTMLToastContent;
+/**
+ * Checks whether the current user has admin privileges (role >= 10).
+ * @returns {boolean}
+ */
 export function isAdmin() {
   let user = localStorage.getItem('user');
   if (!user) return false;
@@ -39,6 +49,10 @@ export function isAdmin() {
   return user.role >= 10;
 }
 
+/**
+ * Checks whether the current user has root privileges (role >= 100).
+ * @returns {boolean}
+ */
 export function isRoot() {
   let user = localStorage.getItem('user');
   if (!user) return false;
@@ -46,18 +60,30 @@ export function isRoot() {
   return user.role >= 100;
 }
 
+/**
+ * Retrieves the system name from localStorage, defaults to 'New API'.
+ * @returns {string}
+ */
 export function getSystemName() {
   let system_name = localStorage.getItem('system_name');
   if (!system_name) return 'New API';
   return system_name;
 }
 
+/**
+ * Retrieves the logo URL from localStorage, defaults to '/logo.png'.
+ * @returns {string}
+ */
 export function getLogo() {
   let logo = localStorage.getItem('logo');
   if (!logo) return '/logo.png';
   return logo;
 }
 
+/**
+ * Retrieves the current user's ID from localStorage.
+ * @returns {number} User ID, or -1 if not found
+ */
 export function getUserIdFromLocalStorage() {
   let user = localStorage.getItem('user');
   if (!user) return -1;
@@ -65,10 +91,19 @@ export function getUserIdFromLocalStorage() {
   return user.id;
 }
 
+/**
+ * Retrieves the footer HTML content from localStorage.
+ * @returns {string|null}
+ */
 export function getFooterHTML() {
   return localStorage.getItem('footer_html');
 }
 
+/**
+ * Copies the given text to the clipboard, with a textarea fallback for older browsers.
+ * @param {string} text - Text to copy
+ * @returns {Promise<boolean>} Whether the copy succeeded
+ */
 export async function copy(text) {
   let okay = true;
   try {
@@ -119,6 +154,10 @@ if (isMobileScreen) {
   // showNoticeOptions.transition = 'flip';
 }
 
+/**
+ * Displays an error toast. Handles Axios errors with status-specific messages.
+ * @param {Error|string} error - Error object or message string
+ */
 export function showError(error) {
   console.error(error);
   if (error.message) {
@@ -150,18 +189,35 @@ export function showError(error) {
   }
 }
 
+/**
+ * Displays a warning toast.
+ * @param {string} message
+ */
 export function showWarning(message) {
   Toast.warning(message);
 }
 
+/**
+ * Displays a success toast.
+ * @param {string} message
+ */
 export function showSuccess(message) {
   Toast.success(message);
 }
 
+/**
+ * Displays an info toast.
+ * @param {string} message
+ */
 export function showInfo(message) {
   Toast.info(message);
 }
 
+/**
+ * Displays a persistent info toast, optionally rendering HTML content.
+ * @param {string} message - Text or HTML content
+ * @param {boolean} [isHTML=false] - Whether to render as HTML
+ */
 export function showNotice(message, isHTML = false) {
   if (isHTML) {
     toast(<HTMLToastContent htmlContent={message} />, showNoticeOptions);
@@ -170,10 +226,19 @@ export function showNotice(message, isHTML = false) {
   }
 }
 
+/**
+ * Opens the given URL in a new browser tab/window.
+ * @param {string} url
+ */
 export function openPage(url) {
   window.open(url);
 }
 
+/**
+ * Removes the trailing slash from a URL string.
+ * @param {string} url
+ * @returns {string}
+ */
 export function removeTrailingSlash(url) {
   if (!url) return '';
   if (url.endsWith('/')) {
@@ -183,12 +248,21 @@ export function removeTrailingSlash(url) {
   }
 }
 
+/**
+ * Returns the Unix timestamp (seconds) for the start of today (00:00:00).
+ * @returns {number}
+ */
 export function getTodayStartTimestamp() {
   var now = new Date();
   now.setHours(0, 0, 0, 0);
   return Math.floor(now.getTime() / 1000);
 }
 
+/**
+ * Formats a Unix timestamp (seconds) to "YYYY-MM-DD HH:mm:ss".
+ * @param {number} timestamp - Unix timestamp in seconds
+ * @returns {string}
+ */
 export function timestamp2string(timestamp) {
   let date = new Date(timestamp * 1000);
   let year = date.getFullYear().toString();
@@ -217,6 +291,13 @@ export function timestamp2string(timestamp) {
   );
 }
 
+/**
+ * Formats a Unix timestamp with configurable granularity (hour, day, or week range).
+ * @param {number} timestamp - Unix timestamp in seconds
+ * @param {string} [dataExportDefaultTime='hour'] - Granularity: 'hour', 'day', or 'week'
+ * @param {boolean} [showYear=false] - Whether to include the year
+ * @returns {string}
+ */
 export function timestamp2string1(
   timestamp,
   dataExportDefaultTime = 'hour',
@@ -260,7 +341,11 @@ export function timestamp2string1(
   return str;
 }
 
-// 检查时间戳数组是否跨年
+/**
+ * Checks whether a set of Unix timestamps span across multiple calendar years.
+ * @param {number[]} timestamps - Array of Unix timestamps in seconds
+ * @returns {boolean}
+ */
 export function isDataCrossYear(timestamps) {
   if (!timestamps || timestamps.length === 0) return false;
   const years = new Set(
@@ -269,6 +354,11 @@ export function isDataCrossYear(timestamps) {
   return years.size > 1;
 }
 
+/**
+ * Downloads the given text content as a file.
+ * @param {string} text - File content
+ * @param {string} filename - Download filename
+ */
 export function downloadTextAsFile(text, filename) {
   let blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
   let url = URL.createObjectURL(blob);
@@ -278,6 +368,11 @@ export function downloadTextAsFile(text, filename) {
   a.click();
 }
 
+/**
+ * Validates whether a string is valid JSON.
+ * @param {string} str
+ * @returns {boolean}
+ */
 export const verifyJSON = (str) => {
   try {
     JSON.parse(str);
@@ -287,6 +382,11 @@ export const verifyJSON = (str) => {
   return true;
 };
 
+/**
+ * Validates a JSON string, returning a resolved or rejected Promise.
+ * @param {string} value
+ * @returns {Promise<void>}
+ */
 export function verifyJSONPromise(value) {
   try {
     JSON.parse(value);
@@ -296,11 +396,20 @@ export function verifyJSONPromise(value) {
   }
 }
 
+/**
+ * Checks if a one-time prompt with the given ID should be displayed.
+ * @param {string} id - Prompt identifier
+ * @returns {boolean}
+ */
 export function shouldShowPrompt(id) {
   let prompt = localStorage.getItem(`prompt-${id}`);
   return !prompt;
 }
 
+/**
+ * Marks a one-time prompt as shown so it won't display again.
+ * @param {string} id - Prompt identifier
+ */
 export function setPromptShown(id) {
   localStorage.setItem(`prompt-${id}`, 'true');
 }
@@ -332,11 +441,18 @@ export function compareObjects(oldObject, newObject) {
 
 // playground message
 
-// 生成唯一ID
+/**
+ * Generates a unique auto-incrementing message ID string.
+ * @returns {string}
+ */
 let messageId = 4;
 export const generateMessageId = () => `${messageId++}`;
 
-// 提取消息中的文本内容
+/**
+ * Extracts the text content from a message object.
+ * @param {object} message - Message with string or array content
+ * @returns {string}
+ */
 export const getTextContent = (message) => {
   if (!message || !message.content) return '';
 
@@ -347,7 +463,12 @@ export const getTextContent = (message) => {
   return typeof message.content === 'string' ? message.content : '';
 };
 
-// 处理 think 标签
+/**
+ * Extracts and separates `<think>` tag content from the main content string.
+ * @param {string} content - Raw content possibly containing <think> tags
+ * @param {string} [reasoningContent=''] - Existing reasoning content to append to
+ * @returns {{content: string, reasoningContent: string}}
+ */
 export const processThinkTags = (content, reasoningContent = '') => {
   if (!content || !content.includes('<think>')) {
     return { content, reasoningContent };
@@ -382,7 +503,12 @@ export const processThinkTags = (content, reasoningContent = '') => {
   };
 };
 
-// 处理未完成的 think 标签
+/**
+ * Processes content with potentially unclosed `<think>` tags during streaming.
+ * @param {string} content - Raw streaming content
+ * @param {string} [reasoningContent=''] - Existing reasoning content
+ * @returns {{content: string, reasoningContent: string}}
+ */
 export const processIncompleteThinkTags = (content, reasoningContent = '') => {
   if (!content) return { content: '', reasoningContent };
 
@@ -409,7 +535,13 @@ export const processIncompleteThinkTags = (content, reasoningContent = '') => {
   return processThinkTags(content, reasoningContent);
 };
 
-// 构建消息内容（包含图片）
+/**
+ * Builds message content, optionally including image URLs as multimodal content parts.
+ * @param {string} textContent - Text content of the message
+ * @param {string[]} [imageUrls=[]] - Array of image URLs
+ * @param {boolean} [imageEnabled=false] - Whether image mode is active
+ * @returns {string|Array<object>}
+ */
 export const buildMessageContent = (
   textContent,
   imageUrls = [],
@@ -434,7 +566,13 @@ export const buildMessageContent = (
   return textContent || '';
 };
 
-// 创建新消息
+/**
+ * Creates a new message object with auto-generated ID and timestamp.
+ * @param {string} role - Message role (e.g. 'user', 'assistant', 'system')
+ * @param {string|Array} content - Message content
+ * @param {object} [options={}] - Additional message properties
+ * @returns {object}
+ */
 export const createMessage = (role, content, options = {}) => ({
   role,
   content,
@@ -443,7 +581,10 @@ export const createMessage = (role, content, options = {}) => ({
   ...options,
 });
 
-// 创建加载中的助手消息
+/**
+ * Creates a loading placeholder assistant message for streaming responses.
+ * @returns {object}
+ */
 export const createLoadingAssistantMessage = () =>
   createMessage(MESSAGE_ROLES.ASSISTANT, '', {
     reasoningContent: '',
@@ -453,7 +594,11 @@ export const createLoadingAssistantMessage = () =>
     status: 'loading',
   });
 
-// 检查消息是否包含图片
+/**
+ * Checks whether a message contains image_url content parts.
+ * @param {object} message
+ * @returns {boolean}
+ */
 export const hasImageContent = (message) => {
   return (
     message &&
@@ -462,7 +607,11 @@ export const hasImageContent = (message) => {
   );
 };
 
-// 格式化消息用于API请求
+/**
+ * Formats a message object into the shape expected by the chat API.
+ * @param {object} message
+ * @returns {{role: string, content: string|Array}|null}
+ */
 export const formatMessageForAPI = (message) => {
   if (!message) return null;
 
@@ -472,12 +621,20 @@ export const formatMessageForAPI = (message) => {
   };
 };
 
-// 验证消息是否有效
+/**
+ * Checks whether a message object has a valid role and content.
+ * @param {object} message
+ * @returns {boolean}
+ */
 export const isValidMessage = (message) => {
   return message && message.role && (message.content || message.content === '');
 };
 
-// 获取最后一条用户消息
+/**
+ * Returns the last message with role 'user' from the messages array.
+ * @param {object[]} messages
+ * @returns {object|null}
+ */
 export const getLastUserMessage = (messages) => {
   if (!Array.isArray(messages)) return null;
 
@@ -489,7 +646,11 @@ export const getLastUserMessage = (messages) => {
   return null;
 };
 
-// 获取最后一条助手消息
+/**
+ * Returns the last message with role 'assistant' from the messages array.
+ * @param {object[]} messages
+ * @returns {object|null}
+ */
 export const getLastAssistantMessage = (messages) => {
   if (!Array.isArray(messages)) return null;
 
@@ -501,7 +662,11 @@ export const getLastAssistantMessage = (messages) => {
   return null;
 };
 
-// 计算相对时间（几天前、几小时前等）
+/**
+ * Returns a human-readable relative time string (e.g. "3 hours ago") for the given date.
+ * @param {string|Date} publishDate
+ * @returns {string}
+ */
 export const getRelativeTime = (publishDate) => {
   if (!publishDate) return '';
 
@@ -546,7 +711,11 @@ export const getRelativeTime = (publishDate) => {
   }
 };
 
-// 格式化日期字符串
+/**
+ * Formats a Date object to "YYYY-MM-DD" string.
+ * @param {Date} date
+ * @returns {string}
+ */
 export const formatDateString = (date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -554,7 +723,11 @@ export const formatDateString = (date) => {
   return `${year}-${month}-${day}`;
 };
 
-// 格式化日期时间字符串（包含时间）
+/**
+ * Formats a Date object to "YYYY-MM-DD HH:mm" string.
+ * @param {Date} date
+ * @returns {string}
+ */
 export const formatDateTimeString = (date) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -581,11 +754,21 @@ function writeTableCompactModes(modes) {
   }
 }
 
+/**
+ * Gets the compact mode setting for a specific table from localStorage.
+ * @param {string} [tableKey='global'] - Table identifier
+ * @returns {boolean}
+ */
 export function getTableCompactMode(tableKey = 'global') {
   const modes = readTableCompactModes();
   return !!modes[tableKey];
 }
 
+/**
+ * Persists the compact mode setting for a specific table to localStorage.
+ * @param {boolean} compact
+ * @param {string} [tableKey='global'] - Table identifier
+ */
 export function setTableCompactMode(compact, tableKey = 'global') {
   const modes = readTableCompactModes();
   modes[tableKey] = compact;
@@ -594,8 +777,12 @@ export function setTableCompactMode(compact, tableKey = 'global') {
 
 // -------------------------------
 // Select 组件统一过滤逻辑
-// 使用方式： <Select filter={selectFilter} ... />
-// 统一的 Select 搜索过滤逻辑 -- 支持同时匹配 option.value 与 option.label
+/**
+ * Unified Select component filter function that matches against both option value and label.
+ * @param {string} input - Search keyword
+ * @param {object} option - Select option with value and label
+ * @returns {boolean}
+ */
 export const selectFilter = (input, option) => {
   if (!input) return true;
 
@@ -607,7 +794,19 @@ export const selectFilter = (input, option) => {
 };
 
 // -------------------------------
-// 模型定价计算工具函数
+/**
+ * Calculates display prices for a model based on its billing type, group ratio, and currency.
+ * @param {object} params
+ * @param {object} params.record - Model record with pricing fields
+ * @param {string} params.selectedGroup - Selected user group
+ * @param {object} params.groupRatio - Map of group names to ratio multipliers
+ * @param {string} params.tokenUnit - Token unit ('K' or 'M')
+ * @param {Function} params.displayPrice - Function to convert USD price to display value
+ * @param {string} params.currency - Currency code ('USD', 'CNY', 'CUSTOM')
+ * @param {string} [params.quotaDisplayType='USD'] - Display type
+ * @param {number} [params.precision=4] - Decimal precision
+ * @returns {object} Computed price data
+ */
 export const calculateModelPrice = ({
   record,
   selectedGroup,
@@ -761,6 +960,13 @@ export const calculateModelPrice = ({
   };
 };
 
+/**
+ * Converts computed price data into an array of label/value items for display.
+ * @param {object} priceData - Price data from calculateModelPrice
+ * @param {Function} t - i18n translation function
+ * @param {string} [quotaDisplayType='USD'] - Display type
+ * @returns {Array<{key: string, label: string, value: string, suffix: string}>}
+ */
 export const getModelPriceItems = (
   priceData,
   t,
@@ -874,7 +1080,13 @@ export const getModelPriceItems = (
   ].filter((item) => item.value !== null && item.value !== undefined && item.value !== '');
 };
 
-// 格式化价格信息（用于卡片视图）
+/**
+ * Renders price data as inline JSX spans for card views.
+ * @param {object} priceData - Price data from calculateModelPrice
+ * @param {Function} t - i18n translation function
+ * @param {string} [quotaDisplayType='USD'] - Display type
+ * @returns {JSX.Element}
+ */
 export const formatPriceInfo = (priceData, t, quotaDisplayType = 'USD') => {
   const items = getModelPriceItems(priceData, t, quotaDisplayType);
   return (
@@ -890,8 +1102,18 @@ export const formatPriceInfo = (priceData, t, quotaDisplayType = 'USD') => {
 };
 
 // -------------------------------
-// CardPro 分页配置函数
-// 用于创建 CardPro 的 paginationArea 配置
+/**
+ * Creates a pagination area element for CardPro components with page navigation and page size input.
+ * @param {object} params
+ * @param {number} params.currentPage - Current page number
+ * @param {number} params.pageSize - Items per page
+ * @param {number} params.total - Total item count
+ * @param {Function} params.onPageChange - Page change callback
+ * @param {Function} params.onPageSizeChange - Page size change callback
+ * @param {boolean} [params.isMobile=false] - Whether in mobile viewport
+ * @param {Function} [params.t] - i18n translation function
+ * @returns {JSX.Element|null}
+ */
 export const createCardProPagination = ({
   currentPage,
   pageSize,
@@ -969,7 +1191,10 @@ const DEFAULT_PRICING_FILTERS = {
   currentPage: 1,
 };
 
-// 重置模型定价筛选条件
+/**
+ * Resets all model pricing filter states to their default values.
+ * @param {object} params - Object containing setter functions for each filter
+ */
 export const resetPricingFilters = ({
   handleChange,
   setShowWithRecharge,

--- a/web/src/pages/Setting/Dashboard/SettingsAPIInfo.jsx
+++ b/web/src/pages/Setting/Dashboard/SettingsAPIInfo.jsx
@@ -42,6 +42,13 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
+/**
+ * Admin settings panel for managing API information endpoint entries with CRUD operations.
+ * @param {object} props
+ * @param {object} props.options - Current dashboard settings options
+ * @param {Function} props.refresh - Callback to refresh settings data
+ * @returns {JSX.Element}
+ */
 const SettingsAPIInfo = ({ options, refresh }) => {
   const { t } = useTranslation();
 

--- a/web/src/pages/Setting/Dashboard/SettingsAnnouncements.jsx
+++ b/web/src/pages/Setting/Dashboard/SettingsAnnouncements.jsx
@@ -49,6 +49,13 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
+/**
+ * Admin settings panel for managing system announcements with rich content (markdown/HTML) support.
+ * @param {object} props
+ * @param {object} props.options - Current dashboard settings options
+ * @param {Function} props.refresh - Callback to refresh settings data
+ * @returns {JSX.Element}
+ */
 const SettingsAnnouncements = ({ options, refresh }) => {
   const { t } = useTranslation();
 

--- a/web/src/pages/Setting/Dashboard/SettingsFAQ.jsx
+++ b/web/src/pages/Setting/Dashboard/SettingsFAQ.jsx
@@ -41,6 +41,13 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
+/**
+ * Admin settings panel for managing FAQ question-and-answer entries.
+ * @param {object} props
+ * @param {object} props.options - Current dashboard settings options
+ * @param {Function} props.refresh - Callback to refresh settings data
+ * @returns {JSX.Element}
+ */
 const SettingsFAQ = ({ options, refresh }) => {
   const { t } = useTranslation();
 

--- a/web/src/pages/Setting/Dashboard/SettingsUptimeKuma.jsx
+++ b/web/src/pages/Setting/Dashboard/SettingsUptimeKuma.jsx
@@ -40,6 +40,13 @@ import { useTranslation } from 'react-i18next';
 
 const { Text } = Typography;
 
+/**
+ * Admin settings panel for managing Uptime Kuma monitoring status page categories.
+ * @param {object} props
+ * @param {object} props.options - Current dashboard settings options
+ * @param {Function} props.refresh - Callback to refresh settings data
+ * @returns {JSX.Element}
+ */
 const SettingsUptimeKuma = ({ options, refresh }) => {
   const { t } = useTranslation();
 

--- a/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
+++ b/web/src/pages/Setting/Ratio/UpstreamRatioSync.jsx
@@ -64,6 +64,16 @@ const MODELS_DEV_PRESET_NAME = 'models.dev 价格预设';
 const MODELS_DEV_PRESET_BASE_URL = 'https://models.dev';
 const MODELS_DEV_PRESET_ENDPOINT = 'https://models.dev/api.json';
 
+/**
+ * Modal for confirming and resolving pricing ratio conflicts during upstream sync.
+ * @param {object} props
+ * @param {Function} props.t - i18n translation function
+ * @param {boolean} props.visible - Whether the modal is visible
+ * @param {Array} props.items - Conflict items to display
+ * @param {Function} props.onOk - Confirm callback
+ * @param {Function} props.onCancel - Cancel callback
+ * @returns {JSX.Element}
+ */
 function ConflictConfirmModal({ t, visible, items, onOk, onCancel }) {
   const isMobile = useIsMobile();
   const columns = [
@@ -99,6 +109,11 @@ function ConflictConfirmModal({ t, visible, items, onOk, onCancel }) {
   );
 }
 
+/**
+ * Panel for synchronizing model pricing ratios from upstream channels or external presets.
+ * @param {object} props - Component props passed from parent
+ * @returns {JSX.Element}
+ */
 export default function UpstreamRatioSync(props) {
   const { t } = useTranslation();
   const [modalVisible, setModalVisible] = useState(false);

--- a/web/src/pages/Setting/Ratio/components/ModelPricingEditor.jsx
+++ b/web/src/pages/Setting/Ratio/components/ModelPricingEditor.jsx
@@ -54,6 +54,14 @@ import { useIsMobile } from '../../../../hooks/common/useIsMobile';
 const { Text } = Typography;
 const EMPTY_CANDIDATE_MODEL_NAMES = [];
 
+/**
+ * Controlled numeric input component for price values with validation and optional suffix.
+ * @param {object} props
+ * @param {string} props.label - Input label text
+ * @param {string} props.value - Current input value
+ * @param {string} props.placeholder - Placeholder text
+ * @returns {JSX.Element}
+ */
 const PriceInput = ({
   label,
   value,
@@ -85,6 +93,15 @@ const PriceInput = ({
   </div>
 );
 
+/**
+ * Comprehensive editor for configuring model pricing with per-token and per-request billing modes.
+ * Supports batch operations, conflict detection, and preview of calculated ratios.
+ * @param {object} props
+ * @param {object} props.options - Current ratio settings
+ * @param {Function} props.refresh - Callback to refresh settings data
+ * @param {string[]} [props.candidateModelNames] - Suggested model names for autocomplete
+ * @returns {JSX.Element}
+ */
 export default function ModelPricingEditor({
   options,
   refresh,

--- a/web/src/pages/Setting/Ratio/hooks/useModelPricingEditorState.js
+++ b/web/src/pages/Setting/Ratio/hooks/useModelPricingEditorState.js
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { API, showError, showSuccess } from '../../../../helpers';
 
+/** @constant {number} Default number of items per page */
 export const DEFAULT_PAGE_SIZE = 10;
+/** @constant {number[]} Available page size options */
 export const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+/** @constant {string} Price unit suffix label */
 export const PRICE_SUFFIX = '$/1M tokens';
 const EMPTY_CANDIDATE_MODEL_NAMES = [];
 
@@ -33,6 +36,11 @@ const EMPTY_MODEL = {
 
 const NUMERIC_INPUT_REGEX = /^(\d+(\.\d*)?|\.\d*)?$/;
 
+/**
+ * Checks whether a value is non-empty (not '', null, undefined, or false).
+ * @param {*} value
+ * @returns {boolean}
+ */
 export const hasValue = (value) =>
   value !== '' && value !== null && value !== undefined && value !== false;
 
@@ -174,9 +182,20 @@ const buildModelState = (name, sourceMaps) => {
   };
 };
 
+/**
+ * Checks whether a model has neither fixed price nor input price set.
+ * @param {object} model - Model pricing data
+ * @returns {boolean}
+ */
 export const isBasePricingUnset = (model) =>
   !hasValue(model.fixedPrice) && !hasValue(model.inputPrice);
 
+/**
+ * Returns an array of warning messages for a model's pricing configuration.
+ * @param {object} model - Model pricing data
+ * @param {Function} t - i18n translation function
+ * @returns {string[]}
+ */
 export const getModelWarnings = (model, t) => {
   if (!model) {
     return [];
@@ -227,6 +246,12 @@ export const getModelWarnings = (model, t) => {
   return warnings;
 };
 
+/**
+ * Builds a short summary text describing a model's current pricing configuration.
+ * @param {object} model - Model pricing data
+ * @param {Function} t - i18n translation function
+ * @returns {string}
+ */
 export const buildSummaryText = (model, t) => {
   if (model.billingMode === 'per-request' && hasValue(model.fixedPrice)) {
     return `${t('按次')} $${model.fixedPrice} / ${t('次')}`;
@@ -249,6 +274,11 @@ export const buildSummaryText = (model, t) => {
   return t('未设置价格');
 };
 
+/**
+ * Determines which optional price fields should be shown based on the model's current values.
+ * @param {object} model - Model pricing data
+ * @returns {object} Map of field names to boolean visibility flags
+ */
 export const buildOptionalFieldToggles = (model) => ({
   completionPrice: model.completionRatioLocked || hasValue(model.completionPrice),
   cachePrice: hasValue(model.cachePrice),
@@ -363,6 +393,12 @@ const serializeModel = (model, t) => {
   return result;
 };
 
+/**
+ * Builds preview table rows showing the computed ratios for a model's pricing configuration.
+ * @param {object} model - Model pricing data
+ * @param {Function} t - i18n translation function
+ * @returns {Array<{key: string, label: string, value: string}>}
+ */
 export const buildPreviewRows = (model, t) => {
   if (!model) return [];
 
@@ -490,6 +526,17 @@ export const buildPreviewRows = (model, t) => {
   ];
 };
 
+/**
+ * Custom hook that manages complete state for the model pricing editor.
+ * Handles model loading, price calculations, CRUD operations, pagination, and batch updates.
+ * @param {object} params
+ * @param {object} params.options - Current ratio settings from the server
+ * @param {Function} params.refresh - Callback to refresh settings data
+ * @param {Function} params.t - i18n translation function
+ * @param {string[]} [params.candidateModelNames] - Suggested model names for autocomplete
+ * @param {string} [params.filterMode='all'] - Filter mode for model list
+ * @returns {object} State values, computed data, and handler functions
+ */
 export function useModelPricingEditorState({
   options,
   refresh,


### PR DESCRIPTION
## 概要

  将系统中所有分页的页码大小选择器从固定选项的下拉菜单（`showSizeChanger` 下拉）替换为 `InputNumber`
  输入框，允许用户自由输入任意每页条数。

  ## 改动内容

  - **`createCardProPagination`（utils.jsx）**：移除 `pageSizeOpts`/`showSizeChanger` 参数，在
  Pagination 后追加 InputNumber 控件，一次性覆盖 9 个 CardPro 表格页面（channels、tokens、users、usage
  -logs、mj-logs、task-logs、models、redemptions、model-deployments）
  - **`CardTable.jsx`**：移动端分页同步添加 InputNumber
  - **独立 Table
  分页页面**：PricingTable、PricingCardView、ChannelSelectorModal、TopupHistoryModal、MultiKeyManageMo
  dal、SettingsFAQ、SettingsAPIInfo、SettingsAnnouncements、SettingsUptimeKuma、UpstreamRatioSync
  均统一替换
  - **ModelPricingEditor**：已有 InputNumber，无需改动
  - **i18n**：为 `每页条数` 添加 en/fr/ja/ru/vi 翻译
  - **vite.config.js**：修复开发代理环境变量读取（`loadEnv` 替代未定义的 `env`）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Select all current search results" option; new bulk-selection controls in pricing editor and related tables

* **UI Improvements**
  * Per-table per-page numeric input controls; replaced page-size dropdowns and improved pagination layout for mobile/tablet

* **Configuration**
  * Added development env template and updated .gitignore

* **Localization**
  * Added translations for en, fr, ja, ru, vi, zh-CN, zh-TW (including "Per page")

* **Documentation**
  * Added API docs for subscription and payment endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->