### PR TITLE
修复令牌搜索匹配语义与提示

### DIFF
--- a/docs/openapi/api.json
+++ b/docs/openapi/api.json
@@ -3430,10 +3430,37 @@
           {
             "name": "keyword",
             "in": "query",
-            "description": "",
+            "description": "名称关键词，默认模糊匹配",
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "token",
+            "in": "query",
+            "description": "令牌密钥，完整匹配（支持 sk- 前缀）",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "p",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "integer"
             }
           }
         ],

--- a/model/token.go
+++ b/model/token.go
@@ -133,13 +133,21 @@ func SearchUserTokens(userId int, keyword string, token string, offset int, limi
 		offset = 0
 	}
 
+	// 搜索语义：关键词默认模糊；密钥仅支持完整匹配（允许 sk- 前缀）。
+	keyword = strings.TrimSpace(keyword)
+	token = strings.TrimSpace(token)
 	if token != "" {
 		token = strings.TrimPrefix(token, "sk-")
 	}
 
+	// 密钥禁止模糊匹配，避免误用 LIKE 通配符。
+	if strings.Contains(token, "%") {
+		return nil, 0, errors.New("密钥仅支持完整匹配")
+	}
+
 	// 超量用户（令牌数超过上限）只允许精确搜索，禁止模糊搜索
 	maxTokens := operation_setting.GetMaxUserTokens()
-	hasFuzzy := strings.Contains(keyword, "%") || strings.Contains(token, "%")
+	hasFuzzy := strings.Contains(keyword, "%")
 	if hasFuzzy {
 		count, err := CountUserTokens(userId)
 		if err != nil {
@@ -159,14 +167,15 @@ func SearchUserTokens(userId int, keyword string, token string, offset int, limi
 		if err != nil {
 			return nil, 0, err
 		}
+		// 未显式指定通配符时，默认模糊匹配。
+		if !strings.Contains(keywordPattern, "%") {
+			keywordPattern = "%" + keywordPattern + "%"
+		}
 		baseQuery = baseQuery.Where("name LIKE ? ESCAPE '!'", keywordPattern)
 	}
 	if token != "" {
-		tokenPattern, err := sanitizeLikePattern(token)
-		if err != nil {
-			return nil, 0, err
-		}
-		baseQuery = baseQuery.Where(commonKeyCol+" LIKE ? ESCAPE '!'", tokenPattern)
+		// 密钥仅允许精确匹配（不走 LIKE）。
+		baseQuery = baseQuery.Where(commonKeyCol+" = ?", token)
 	}
 
 	// 先查匹配总数（用于分页，受 maxTokens 上限保护，避免全表 COUNT）

--- a/web/src/components/table/tokens/TokensFilters.jsx
+++ b/web/src/components/table/tokens/TokensFilters.jsx
@@ -60,7 +60,8 @@ const TokensFilters = ({
           <Form.Input
             field='searchKeyword'
             prefix={<IconSearch />}
-            placeholder={t('搜索关键字')}
+            placeholder={t('名称关键词（模糊）')}
+            // 提示关键词默认为模糊匹配，避免误解为精确搜索。
             showClear
             pure
             size='small'
@@ -71,7 +72,8 @@ const TokensFilters = ({
           <Form.Input
             field='searchToken'
             prefix={<IconSearch />}
-            placeholder={t('密钥')}
+            placeholder={t('密钥（完整匹配）')}
+            // 提示密钥仅支持完整匹配（可包含 sk- 前缀）。
             showClear
             pure
             size='small'


### PR DESCRIPTION
## 变更说明
- 令牌搜索：关键词默认模糊匹配，密钥仅支持完整匹配并支持 sk- 前缀（后端处理）。
- 前端令牌筛选输入框补充匹配语义提示注释。
- OpenAPI 文档补充 /api/token/search 的 keyword/token 描述。

## 影响范围
- 后端：[`model.SearchUserTokens()`](model/token.go:127)
- 前端：[`TokensFilters`](web/src/components/table/tokens/TokensFilters.jsx:24)
- 文档：[`/api/token/search`](docs/openapi/api.json:3421)

## 测试
- 未运行（当前环境无 Go 工具链）。

## 验证方式
1. 在令牌管理页输入关键词（不含 %）搜索，跨页应可命中。
2. 输入完整密钥（含或不含 sk- 前缀）搜索，应仅精确匹配。
3. 直接请求 /api/token/search，分页参数生效且结果一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pagination support to token search with new parameters for page and page size.

* **Improvements**
  * Token search now requires exact matching for precise results.
  * Keyword search now defaults to fuzzy matching for broader results.
  * Updated search input labels to clarify matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->