### PR TITLE
feat: support redeeming subscription plans with redemption codes

### DIFF
--- a/controller/group.go
+++ b/controller/group.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"sort"
 
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/service"
@@ -16,6 +17,7 @@ func GetGroups(c *gin.Context) {
 	for groupName := range ratio_setting.GetGroupRatioCopy() {
 		groupNames = append(groupNames, groupName)
 	}
+	sort.Strings(groupNames)
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",

--- a/controller/group_test.go
+++ b/controller/group_test.go
@@ -1,0 +1,50 @@
+package controller
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/setting/ratio_setting"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGroupsReturnsSortedGroupNames(t *testing.T) {
+	originalGroupRatioJSON := ratio_setting.GroupRatio2JSONString()
+	t.Cleanup(func() {
+		require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(originalGroupRatioJSON))
+	})
+
+	require.NoError(t, ratio_setting.UpdateGroupRatioByJSONString(`{
+		"vip": 1,
+		"group-z": 1,
+		"default": 1,
+		"group-b": 1,
+		"group-y": 1,
+		"group-a": 1,
+		"svip": 1
+	}`))
+
+	expected := []string{
+		"default",
+		"group-a",
+		"group-b",
+		"group-y",
+		"group-z",
+		"svip",
+		"vip",
+	}
+
+	for range 20 {
+		ctx, recorder := newAuthenticatedContext(t, http.MethodGet, "/api/group", nil, 1)
+
+		GetGroups(ctx)
+
+		response := decodeAPIResponse(t, recorder)
+		require.True(t, response.Success)
+
+		var groups []string
+		require.NoError(t, common.Unmarshal(response.Data, &groups))
+		require.Equal(t, expected, groups)
+	}
+}


### PR DESCRIPTION
## Summary
- add redemption code types so a code can either top up quota or activate a subscription plan
- reuse the existing `/api/user/topup` flow and admin redemption management UI instead of adding a separate subscription-code module
- update the console redemption form/list and user success messaging, and add model tests for both redemption paths

## Testing
- go test ./...
- cd web && bun run build
- cd web && bunx eslint src/constants/redemption.constants.js src/components/table/redemptions/RedemptionsColumnDefs.jsx src/components/table/redemptions/modals/EditRedemptionModal.jsx src/components/topup/index.jsx src/components/topup/RechargeCard.jsx

Closes #2845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redemption codes now support two types: quota and subscription; subscription codes can activate plans and show plan details.

* **Improvements**
  * Admin edit modal: choose type, pick subscription plan, name auto-fills from plan when appropriate.
  * Redeem flow and success UI display type-specific results (activated plan + expiry or redeemed quota).
  * List/table shows type and content; top-up UI text clarified.

* **Tests**
  * Added tests for quota and subscription redemption scenarios.

* **Documentation**
  * Added English and Chinese translations for redemption UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->