### PR TITLE
修复Turnstile Site Key在后台不显示的问题

### DIFF
--- a/controller/option.go
+++ b/controller/option.go
@@ -68,7 +68,7 @@ func GetOptions(c *gin.Context) {
 		value := common.Interface2String(v)
 		if strings.HasSuffix(k, "Token") ||
 			strings.HasSuffix(k, "Secret") ||
-			strings.HasSuffix(k, "Key") ||
+			(strings.HasSuffix(k, "Key") && k != "TurnstileSiteKey") ||
 			strings.HasSuffix(k, "secret") ||
 			strings.HasSuffix(k, "api_key") {
 			continue


### PR DESCRIPTION
Turnstile Secret Key才需要屏蔽
Turnstile Site Key由于字段带key被误伤了
修复前:
<img width="1580" height="290" alt="image" src="https://github.com/user-attachments/assets/7674b66a-6632-49c1-a03e-f0a6f51f023c" />
修复后:
<img width="1564" height="308" alt="image" src="https://github.com/user-attachments/assets/2f0b8fa7-95b0-4799-9441-a84962d9cd55" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the exclusion logic for API options to ensure specific options are now properly included in responses, fixing an overly broad filtering condition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->