### PR TITLE
修复操练场max_token设置后请求失败的问题

### DIFF
--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -125,11 +125,14 @@ export const buildApiPayload = (
   const parameterMappings = {
     temperature: 'temperature',
     top_p: 'top_p',
-    max_tokens: 'max_tokens',
     frequency_penalty: 'frequency_penalty',
     presence_penalty: 'presence_penalty',
     seed: 'seed',
   };
+
+  if (parameterEnabled.max_tokens && inputs.max_tokens > 0) {
+    payload.max_tokens = parseInt(inputs.max_tokens, 10);
+  }
 
   Object.entries(parameterMappings).forEach(([key, param]) => {
     const enabled = parameterEnabled[key];


### PR DESCRIPTION
应该是中间一次重构丢失了将max_token转换为int的逻辑
<img width="2106" height="1588" alt="image" src="https://github.com/user-attachments/assets/192ede9c-5cd5-4e88-a9ff-553f84a4caff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token limit parameter handling in API requests to ensure proper conditional inclusion based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->