### PR TITLE
fix: apply param override in audio relay flow

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -55,6 +55,7 @@ const (
 	ContextKeyLocalCountTokens ContextKey = "local_count_tokens"
 
 	ContextKeySystemPromptOverride ContextKey = "system_prompt_override"
+	ContextKeyAudioFormOverride    ContextKey = "audio_form_override"
 
 	// ContextKeyFileSourcesToCleanup stores file sources that need cleanup when request ends
 	ContextKeyFileSourcesToCleanup ContextKey = "file_sources_to_cleanup"

--- a/relay/audio_handler.go
+++ b/relay/audio_handler.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
 	"github.com/QuantumNous/new-api/relay/helper"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/types"
@@ -31,6 +34,11 @@ func AudioHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 	err = helper.ModelMappedHelper(c, info, request)
 	if err != nil {
 		return types.NewError(err, types.ErrorCodeChannelModelMappedError, types.ErrOptionWithSkipRetry())
+	}
+
+	err = applyAudioParamOverride(c, info, request)
+	if err != nil {
+		return newAPIErrorFromParamOverride(err)
 	}
 
 	adaptor := GetAdaptor(info.ApiType)
@@ -73,5 +81,79 @@ func AudioHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 		postConsumeQuota(c, info, usage.(*dto.Usage))
 	}
 
+	return nil
+}
+
+func applyAudioParamOverride(c *gin.Context, info *relaycommon.RelayInfo, request *dto.AudioRequest) error {
+	if info == nil || (len(info.ParamOverride) == 0 && (info.ChannelMeta == nil || len(info.ChannelMeta.ParamOverride) == 0)) {
+		return nil
+	}
+
+	if isMultipartAudioRequest(c, info) {
+		return applyMultipartAudioParamOverride(c, info, request)
+	}
+
+	jsonData, err := common.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
+	if err != nil {
+		return err
+	}
+
+	if err = common.Unmarshal(jsonData, request); err != nil {
+		return err
+	}
+	info.Request = request
+	return nil
+}
+
+func isMultipartAudioRequest(c *gin.Context, info *relaycommon.RelayInfo) bool {
+	if c == nil || c.Request == nil || info == nil {
+		return false
+	}
+	if info.RelayMode == relayconstant.RelayModeAudioSpeech {
+		return false
+	}
+	return strings.Contains(c.Request.Header.Get("Content-Type"), gin.MIMEMultipartPOSTForm)
+}
+
+func applyMultipartAudioParamOverride(c *gin.Context, info *relaycommon.RelayInfo, request *dto.AudioRequest) error {
+	form, err := common.ParseMultipartFormReusable(c)
+	if err != nil {
+		return err
+	}
+
+	formMap := make(map[string]any, len(form.Value))
+	for key, values := range form.Value {
+		if len(values) == 1 {
+			formMap[key] = values[0]
+			continue
+		}
+		formMap[key] = values
+	}
+
+	jsonData, err := common.Marshal(formMap)
+	if err != nil {
+		return err
+	}
+
+	jsonData, err = relaycommon.ApplyParamOverrideWithRelayInfo(jsonData, info)
+	if err != nil {
+		return err
+	}
+
+	effectiveForm := make(map[string]any)
+	if err = common.Unmarshal(jsonData, &effectiveForm); err != nil {
+		return err
+	}
+	common.SetContextKey(c, constant.ContextKeyAudioFormOverride, effectiveForm)
+
+	if err = common.Unmarshal(jsonData, request); err != nil {
+		return err
+	}
+	info.Request = request
 	return nil
 }

--- a/relay/audio_handler_test.go
+++ b/relay/audio_handler_test.go
@@ -1,0 +1,91 @@
+package relay
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyAudioParamOverrideForSpeech(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/speech", bytes.NewReader([]byte(`{"model":"tts-1"}`)))
+	c.Request.Header.Set("Content-Type", gin.MIMEJSON)
+
+	request := &dto.AudioRequest{
+		Model:          "tts-1",
+		Input:          "hello",
+		Voice:          "alloy",
+		ResponseFormat: "mp3",
+	}
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeAudioSpeech,
+		Request:   request,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ParamOverride: map[string]any{
+				"voice":           "nova",
+				"response_format": "pcm",
+			},
+		},
+	}
+
+	err := applyAudioParamOverride(c, info, request)
+	require.NoError(t, err)
+	require.Equal(t, "nova", request.Voice)
+	require.Equal(t, "pcm", request.ResponseFormat)
+	require.Same(t, request, info.Request)
+}
+
+func TestApplyAudioParamOverrideForMultipartStoresEffectiveForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	require.NoError(t, writer.WriteField("model", "whisper-1"))
+	require.NoError(t, writer.WriteField("response_format", "json"))
+	require.NoError(t, writer.WriteField("language", "en"))
+	fileWriter, err := writer.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("fake audio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", requestBody)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	audioRequest := &dto.AudioRequest{
+		Model:          "whisper-1",
+		ResponseFormat: "json",
+	}
+	info := &relaycommon.RelayInfo{
+		RelayMode: relayconstant.RelayModeAudioTranscription,
+		Request:   audioRequest,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ParamOverride: map[string]any{
+				"response_format": "verbose_json",
+				"temperature":     0.2,
+			},
+		},
+	}
+
+	err = applyAudioParamOverride(c, info, audioRequest)
+	require.NoError(t, err)
+	require.Equal(t, "verbose_json", audioRequest.ResponseFormat)
+
+	formOverride := common.GetContextKeyStringMap(c, constant.ContextKeyAudioFormOverride)
+	require.Equal(t, "verbose_json", formOverride["response_format"])
+	require.Equal(t, 0.2, formOverride["temperature"])
+	require.Equal(t, "en", formOverride["language"])
+}

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -380,19 +380,17 @@ func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInf
 		if err2 != nil {
 			return nil, fmt.Errorf("error parsing multipart form: %w", err2)
 		}
+		formValues := buildAudioFormValues(c, formData.Value)
 
 		// 打印类似 curl 命令格式的信息
 		logger.LogDebug(c.Request.Context(), fmt.Sprintf("--form 'model=\"%s\"'", request.Model))
 
 		// 遍历表单字段并打印输出
-		for key, values := range formData.Value {
+		for key, values := range formValues {
 			if key == "model" {
 				continue
 			}
-			for _, value := range values {
-				writer.WriteField(key, value)
-				logger.LogDebug(c.Request.Context(), fmt.Sprintf("--form '%s=\"%s\"'", key, value))
-			}
+			writeMultipartFieldValues(c, writer, key, values)
 		}
 
 		// 从 formData 中获取文件
@@ -426,6 +424,45 @@ func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInf
 		logger.LogDebug(c.Request.Context(), fmt.Sprintf("--header 'Content-Type: %s'", writer.FormDataContentType()))
 		return &requestBody, nil
 	}
+}
+
+func buildAudioFormValues(c *gin.Context, original map[string][]string) map[string]any {
+	if override := common.GetContextKeyStringMap(c, constant.ContextKeyAudioFormOverride); len(override) > 0 {
+		return override
+	}
+
+	values := make(map[string]any, len(original))
+	for key, items := range original {
+		if len(items) == 1 {
+			values[key] = items[0]
+			continue
+		}
+		copied := make([]string, len(items))
+		copy(copied, items)
+		values[key] = copied
+	}
+	return values
+}
+
+func writeMultipartFieldValues(c *gin.Context, writer *multipart.Writer, key string, value any) {
+	switch typed := value.(type) {
+	case []string:
+		for _, item := range typed {
+			writeMultipartFieldValue(c, writer, key, item)
+		}
+	case []any:
+		for _, item := range typed {
+			writeMultipartFieldValue(c, writer, key, item)
+		}
+	default:
+		writeMultipartFieldValue(c, writer, key, typed)
+	}
+}
+
+func writeMultipartFieldValue(c *gin.Context, writer *multipart.Writer, key string, value any) {
+	stringValue := fmt.Sprintf("%v", value)
+	writer.WriteField(key, stringValue)
+	logger.LogDebug(c.Request.Context(), fmt.Sprintf("--form '%s=\"%s\"'", key, stringValue))
 }
 
 func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {

--- a/relay/channel/openai/adaptor_audio_override_test.go
+++ b/relay/channel/openai/adaptor_audio_override_test.go
@@ -1,0 +1,62 @@
+package openai
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertAudioRequestUsesOverriddenMultipartFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestBody := &bytes.Buffer{}
+	writer := multipart.NewWriter(requestBody)
+	require.NoError(t, writer.WriteField("model", "whisper-1"))
+	require.NoError(t, writer.WriteField("response_format", "json"))
+	require.NoError(t, writer.WriteField("language", "en"))
+	fileWriter, err := writer.CreateFormFile("file", "sample.wav")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("fake audio"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", requestBody)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	c.Set(string(constant.ContextKeyAudioFormOverride), map[string]any{
+		"model":           "whisper-1",
+		"response_format": "verbose_json",
+		"language":        "fr",
+		"temperature":     0.2,
+	})
+
+	adaptor := &Adaptor{}
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeAudioTranscription}
+	reader, err := adaptor.ConvertAudioRequest(c, info, dto.AudioRequest{Model: "whisper-1"})
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(reader)
+	require.NoError(t, err)
+
+	_, params, err := mime.ParseMediaType(c.Request.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	multipartReader := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+	form, err := multipartReader.ReadForm(1024 * 1024)
+	require.NoError(t, err)
+
+	require.Equal(t, "verbose_json", form.Value["response_format"][0])
+	require.Equal(t, "fr", form.Value["language"][0])
+	require.Equal(t, "0.2", form.Value["temperature"][0])
+	require.Len(t, form.File["file"], 1)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled audio request parameter overrides via channel metadata for speech synthesis and transcription requests. Supports customization of voice, response format, language, and temperature parameters.

* **Tests**
  * Added comprehensive unit tests validating audio parameter override processing and multipart form field handling with context-based overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->