### PR TITLE
fix: add VolcEngine(45) and Custom(8) to MODEL_FETCHABLE_CHANNEL_TYPES

### DIFF
--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -124,11 +124,6 @@ const PARAM_OVERRIDE_OPERATIONS_TEMPLATE = {
   ],
 };
 
-// 支持并且已适配通过接口获取模型列表的渠道类型
-const MODEL_FETCHABLE_TYPES = new Set([
-  1, 4, 8, 14, 34, 17, 26, 27, 24, 45, 47, 25, 20, 23, 31, 40, 42, 48, 43,
-]);
-
 function type2secretPrompt(type) {
   // inputs.type === 15 ? '按照如下格式输入：APIKey|SecretKey' : (inputs.type === 18 ? '按照如下格式输入：APPID|APISecret|APIKey' : '请输入渠道对应的鉴权密钥')
   switch (type) {

--- a/web/src/constants/channel.constants.js
+++ b/web/src/constants/channel.constants.js
@@ -193,7 +193,7 @@ export const CHANNEL_OPTIONS = [
 
 // Channel types that support upstream model list fetching in UI.
 export const MODEL_FETCHABLE_CHANNEL_TYPES = new Set([
-  1, 4, 8, 14, 34, 17, 26, 27, 24, 45, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  1, 4, 14, 34, 17, 26, 27, 24, 45, 47, 25, 20, 23, 31, 40, 42, 48, 43,
 ]);
 
 export const MODEL_TABLE_PAGE_SIZE = 10;


### PR DESCRIPTION
## 问题

前端 `MODEL_FETCHABLE_CHANNEL_TYPES` 白名单未包含**字节火山方舟(45)**和**自定义渠道(8)**，导致这两类渠道在配置面板上没有"获取模型列表"按钮。

## 修改

- 在 `web/src/constants/channel.constants.js` 中添加 45 (VolcEngine) 和 8 (Custom)
- 同步更新 `web/src/components/table/channels/modals/EditChannelModal.jsx` 中的本地白名单

## 验证

后端代码 `controller/channel_upstream_update.go` 已支持这两类渠道：

```go
case constant.ChannelTypeVolcEngine:
    url = fmt.Sprintf(\"%s/v1/models\", baseURL)
default:
    url = fmt.Sprintf(\"%s/v1/models\", baseURL)
```

## 相关 Issue

Fixes #3216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Added upstream model list support for one additional channel type.

* **Chores**
  * Cleaned up an internal duplicate definition related to channel model handling (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->