### PR TITLE
修复localstorage playground messages 切换用户聊天记录相同问题

### DIFF
--- a/web/src/components/playground/ConfigManager.jsx
+++ b/web/src/components/playground/ConfigManager.jsx
@@ -25,6 +25,7 @@ import {
   exportConfig,
   importConfig,
   clearConfig,
+  saveConfig,
   hasStoredConfig,
   getConfigTimestamp,
 } from './configStorage';
@@ -41,16 +42,7 @@ const ConfigManager = ({
 
   const handleExport = () => {
     try {
-      // 在导出前先保存当前配置，确保导出的是最新内容
-      const configWithTimestamp = {
-        ...currentConfig,
-        timestamp: new Date().toISOString(),
-      };
-      localStorage.setItem(
-        'playground_config',
-        JSON.stringify(configWithTimestamp),
-      );
-
+      saveConfig(currentConfig);
       exportConfig(currentConfig, messages);
       Toast.success({
         content: t('配置已导出到下载文件夹'),

--- a/web/src/components/playground/configStorage.js
+++ b/web/src/components/playground/configStorage.js
@@ -22,7 +22,44 @@ import {
   DEFAULT_CONFIG,
 } from '../../constants/playground.constants';
 
-const MESSAGES_STORAGE_KEY = 'playground_messages';
+function getCurrentUserId() {
+  try {
+    const raw = localStorage.getItem('user');
+    if (raw) {
+      const user = JSON.parse(raw);
+      if (user && user.id) return user.id;
+    }
+  } catch {}
+  return null;
+}
+
+function getUserStorageKey(baseKey) {
+  const userId = getCurrentUserId();
+  return userId ? `${baseKey}_${userId}` : baseKey;
+}
+
+/**
+ * Migrate data from the old global key to the current user-scoped key.
+ * Only runs once per user per key — the old key is removed after migration.
+ */
+function migrateGlobalKey(baseKey) {
+  try {
+    const userId = getCurrentUserId();
+    if (!userId) return;
+    const userKey = `${baseKey}_${userId}`;
+    if (localStorage.getItem(userKey)) return;
+    const globalData = localStorage.getItem(baseKey);
+    if (globalData) {
+      localStorage.setItem(userKey, globalData);
+      localStorage.removeItem(baseKey);
+    }
+  } catch {}
+}
+
+export function runStorageMigration() {
+  migrateGlobalKey(STORAGE_KEYS.CONFIG);
+  migrateGlobalKey(STORAGE_KEYS.MESSAGES);
+}
 
 /**
  * 保存配置到 localStorage
@@ -34,7 +71,10 @@ export const saveConfig = (config) => {
       ...config,
       timestamp: new Date().toISOString(),
     };
-    localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(configToSave));
+    localStorage.setItem(
+      getUserStorageKey(STORAGE_KEYS.CONFIG),
+      JSON.stringify(configToSave),
+    );
   } catch (error) {
     console.error('保存配置失败:', error);
   }
@@ -50,7 +90,10 @@ export const saveMessages = (messages) => {
       messages,
       timestamp: new Date().toISOString(),
     };
-    localStorage.setItem(STORAGE_KEYS.MESSAGES, JSON.stringify(messagesToSave));
+    localStorage.setItem(
+      getUserStorageKey(STORAGE_KEYS.MESSAGES),
+      JSON.stringify(messagesToSave),
+    );
   } catch (error) {
     console.error('保存消息失败:', error);
   }
@@ -62,7 +105,9 @@ export const saveMessages = (messages) => {
  */
 export const loadConfig = () => {
   try {
-    const savedConfig = localStorage.getItem(STORAGE_KEYS.CONFIG);
+    const savedConfig = localStorage.getItem(
+      getUserStorageKey(STORAGE_KEYS.CONFIG),
+    );
     if (savedConfig) {
       const parsedConfig = JSON.parse(savedConfig);
 
@@ -98,7 +143,9 @@ export const loadConfig = () => {
  */
 export const loadMessages = () => {
   try {
-    const savedMessages = localStorage.getItem(STORAGE_KEYS.MESSAGES);
+    const savedMessages = localStorage.getItem(
+      getUserStorageKey(STORAGE_KEYS.MESSAGES),
+    );
     if (savedMessages) {
       const parsedMessages = JSON.parse(savedMessages);
       return parsedMessages.messages || null;
@@ -115,8 +162,8 @@ export const loadMessages = () => {
  */
 export const clearConfig = () => {
   try {
-    localStorage.removeItem(STORAGE_KEYS.CONFIG);
-    localStorage.removeItem(STORAGE_KEYS.MESSAGES); // 同时清除消息
+    localStorage.removeItem(getUserStorageKey(STORAGE_KEYS.CONFIG));
+    localStorage.removeItem(getUserStorageKey(STORAGE_KEYS.MESSAGES));
   } catch (error) {
     console.error('清除配置失败:', error);
   }
@@ -127,7 +174,7 @@ export const clearConfig = () => {
  */
 export const clearMessages = () => {
   try {
-    localStorage.removeItem(STORAGE_KEYS.MESSAGES);
+    localStorage.removeItem(getUserStorageKey(STORAGE_KEYS.MESSAGES));
   } catch (error) {
     console.error('清除消息失败:', error);
   }
@@ -139,7 +186,9 @@ export const clearMessages = () => {
  */
 export const hasStoredConfig = () => {
   try {
-    return localStorage.getItem(STORAGE_KEYS.CONFIG) !== null;
+    return (
+      localStorage.getItem(getUserStorageKey(STORAGE_KEYS.CONFIG)) !== null
+    );
   } catch (error) {
     console.error('检查配置失败:', error);
     return false;
@@ -152,7 +201,9 @@ export const hasStoredConfig = () => {
  */
 export const getConfigTimestamp = () => {
   try {
-    const savedConfig = localStorage.getItem(STORAGE_KEYS.CONFIG);
+    const savedConfig = localStorage.getItem(
+      getUserStorageKey(STORAGE_KEYS.CONFIG),
+    );
     if (savedConfig) {
       const parsedConfig = JSON.parse(savedConfig);
       return parsedConfig.timestamp || null;

--- a/web/src/hooks/playground/usePlaygroundState.js
+++ b/web/src/hooks/playground/usePlaygroundState.js
@@ -31,6 +31,8 @@ import {
   saveConfig,
   loadMessages,
   saveMessages,
+  clearMessages,
+  runStorageMigration,
 } from '../../components/playground/configStorage';
 import { processIncompleteThinkTags } from '../../helpers';
 
@@ -38,7 +40,10 @@ export const usePlaygroundState = () => {
   const { t } = useTranslation();
 
   // 使用惰性初始化，确保只在组件首次挂载时加载配置和消息
-  const [savedConfig] = useState(() => loadConfig());
+  const [savedConfig] = useState(() => {
+    runStorageMigration();
+    return loadConfig();
+  });
   const [initialMessages] = useState(() => {
     const loaded = loadMessages();
     // 检查是否是旧的中文默认消息，如果是则清除
@@ -54,8 +59,7 @@ export const usePlaygroundState = () => {
         loaded[1].content === '你好！很高兴见到你。有什么我可以帮助你的吗？';
 
       if (hasOldChinese) {
-        // 清除旧的默认消息
-        localStorage.removeItem('playground_messages');
+        clearMessages();
         return null;
       }
     }


### PR DESCRIPTION
本地浏览器localStorage存储playground messages未区分用户

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced data storage system with automatic migration of existing configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->