### PR TITLE
Round remaining balance

### DIFF
--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -537,7 +537,12 @@ export const getChannelsColumns = ({
                   </Tag>
                 </Tooltip>
                 <Tooltip
-                  content={t('剩余额度$') + record.balance + t('，点击更新')}
+                  content={
+                    t('剩余额度') +
+                    ': ' +
+                    renderQuotaWithAmount(record.balance) +
+                    t('，点击更新')
+                  }
                 >
                   <Tag
                     color='white'

--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -1066,8 +1066,14 @@ export function renderQuotaWithAmount(amount) {
   if (quotaDisplayType === 'TOKENS') {
     return renderNumber(renderUnitWithQuota(amount));
   }
+
+  const numericAmount = Number(amount);
+  const formattedAmount = Number.isFinite(numericAmount)
+    ? numericAmount.toFixed(2)
+    : amount;
+
   if (quotaDisplayType === 'CNY') {
-    return '¥' + amount;
+    return '¥' + formattedAmount;
   } else if (quotaDisplayType === 'CUSTOM') {
     const statusStr = localStorage.getItem('status');
     let symbol = '¤';
@@ -1077,9 +1083,9 @@ export function renderQuotaWithAmount(amount) {
         symbol = s?.custom_currency_symbol || symbol;
       }
     } catch (e) {}
-    return symbol + amount;
+    return symbol + formattedAmount;
   }
-  return '$' + amount;
+  return '$' + formattedAmount;
 }
 
 /**


### PR DESCRIPTION
closes #3230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Currency quota amounts now show consistent two-decimal formatting for non-token currencies, with invalid values left unchanged.
  * Balance tags display the reformatted amounts for clearer precision.
  * Balance tooltips updated for clearer localization and consistent presentation; token-based balances remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->