### PR TITLE
feat(openai): add responses reasoning input compatibility flag

### DIFF
--- a/common/init.go
+++ b/common/init.go
@@ -143,6 +143,8 @@ func initConstantEnv() {
 	constant.GenerateDefaultToken = GetEnvOrDefaultBool("GENERATE_DEFAULT_TOKEN", false)
 	// 是否启用错误日志
 	constant.ErrorLogEnabled = GetEnvOrDefaultBool("ERROR_LOG_ENABLED", false)
+	// 是否移除 Responses 请求中与账号/会话绑定的 reasoning 输入项
+	constant.RemoveResponsesReasoningInput = GetEnvOrDefaultBool("REMOVE_RESPONSES_REASONING_INPUT", false)
 	// 任务轮询时查询的最大数量
 	constant.TaskQueryLimit = GetEnvOrDefault("TASK_QUERY_LIMIT", 1000)
 	// 异步任务超时时间（分钟），超过此时间未完成的任务将被标记为失败并退款。0 表示禁用。

--- a/constant/env.go
+++ b/constant/env.go
@@ -15,6 +15,7 @@ var NotifyLimitCount int
 var NotificationLimitDurationMinute int
 var GenerateDefaultToken bool
 var ErrorLogEnabled bool
+var RemoveResponsesReasoningInput bool
 var TaskQueryLimit int
 var TaskTimeoutMinutes int
 

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -923,6 +923,42 @@ func (r *OpenAIResponsesRequest) SetModelName(modelName string) {
 	}
 }
 
+// RemoveReasoningFromInput strips reasoning-prefixed items from Responses input.
+func (r *OpenAIResponsesRequest) RemoveReasoningFromInput() error {
+	if len(r.Input) == 0 || common.GetJsonType(r.Input) != "array" {
+		return nil
+	}
+
+	var items []json.RawMessage
+	if err := common.Unmarshal(r.Input, &items); err != nil {
+		return fmt.Errorf("unmarshal responses input: %w", err)
+	}
+
+	filteredItems := make([]json.RawMessage, 0, len(items))
+	for _, raw := range items {
+		var item map[string]any
+		if err := common.Unmarshal(raw, &item); err != nil {
+			filteredItems = append(filteredItems, raw)
+			continue
+		}
+
+		typeValue, _ := item["type"].(string)
+		if strings.HasPrefix(typeValue, "reasoning") {
+			continue
+		}
+
+		filteredItems = append(filteredItems, raw)
+	}
+
+	filteredInput, err := common.Marshal(filteredItems)
+	if err != nil {
+		return fmt.Errorf("marshal filtered responses input: %w", err)
+	}
+
+	r.Input = filteredInput
+	return nil
+}
+
 func (r *OpenAIResponsesRequest) GetToolsMap() []map[string]any {
 	var toolsMap []map[string]any
 	if len(r.Tools) > 0 {

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -596,6 +596,11 @@ func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommo
 	if info != nil && request.Reasoning != nil && request.Reasoning.Effort != "" {
 		info.ReasoningEffort = request.Reasoning.Effort
 	}
+	if constant.RemoveResponsesReasoningInput {
+		if err := request.RemoveReasoningFromInput(); err != nil {
+			return nil, fmt.Errorf("remove reasoning input from responses request: %w", err)
+		}
+	}
 	return request, nil
 }
 


### PR DESCRIPTION
## Summary
- add a default-off `REMOVE_RESPONSES_REASONING_INPUT` flag for OpenAI Responses requests
- strip `reasoning*` items from `input` when the flag is enabled before forwarding upstream
- help partially compatible relays avoid account/session-bound errors such as `Item with id 'rs_...' not found`

## Why
Some OpenAI-compatible relays can serve `/v1/responses`, but do not fully support account/session-bound reasoning state across turns. In those cases, replaying reasoning items from prior responses may fail with errors like:
- `Item with id 'rs_...' not found`
- `invalid_encrypted_content`

This PR adds a small compatibility escape hatch without changing the default behavior.

## Behavior
- default remains unchanged
- when `REMOVE_RESPONSES_REASONING_INPUT=true`, `reasoning*` items are removed from the Responses `input` array before the request is sent upstream
- malformed input items are preserved as-is

## Trade-offs
This compatibility mode may reduce some Responses-native continuity/cost benefits because account-bound reasoning items are no longer replayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable option to remove reasoning data from responses via environment variable.
  * Integrated filtering mechanism with error handling for response processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->