### PR TITLE
Support iframe footers

### DIFF
--- a/web/src/components/layout/Footer.jsx
+++ b/web/src/components/layout/Footer.jsx
@@ -17,26 +17,76 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 
-import React, { useEffect, useState, useMemo, useContext } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Typography } from '@douyinfe/semi-ui';
 import { getFooterHTML, getLogo, getSystemName } from '../../helpers';
+import {
+  FOOTER_IFRAME_FALLBACK_HEIGHT,
+  getFooterRenderMode,
+  normalizeFooterValue,
+  shouldResetFooterIframeHeight,
+} from '../../helpers/footer';
 import { StatusContext } from '../../context/Status';
 
+/**
+ * 渲染站点页脚，按配置切换默认页脚、HTML 片段或 iframe 模式。
+ * @returns {JSX.Element} 页脚内容
+ */
 const FooterBar = () => {
   const { t } = useTranslation();
-  const [footer, setFooter] = useState(getFooterHTML());
+  const iframeRef = useRef(null);
+  const previousFooterRef = useRef({
+    renderMode: null,
+    footerValue: '',
+  });
+  const [iframeHeight, setIframeHeight] = useState(
+    FOOTER_IFRAME_FALLBACK_HEIGHT,
+  );
+  const [statusState] = useContext(StatusContext);
   const systemName = getSystemName();
   const logo = getLogo();
-  const [statusState] = useContext(StatusContext);
   const isDemoSiteMode = statusState?.status?.demo_site_enabled || false;
+  const footerValue = useMemo(
+    () =>
+      normalizeFooterValue(statusState?.status?.footer_html ?? getFooterHTML()),
+    [statusState?.status?.footer_html],
+  );
+  const footerRenderMode = useMemo(
+    () => getFooterRenderMode(footerValue),
+    [footerValue],
+  );
 
-  const loadFooter = () => {
-    let footer_html = localStorage.getItem('footer_html');
-    if (footer_html) {
-      setFooter(footer_html);
+  /**
+   * 在 iframe 加载完成后尝试同步其内容高度。
+   * @returns {void}
+   */
+  const handleFooterFrameLoad = useCallback(() => {
+    try {
+      const iframeDocument = iframeRef.current?.contentDocument;
+      if (!iframeDocument) {
+        return;
+      }
+
+      const nextHeight = Math.max(
+        iframeDocument.documentElement?.scrollHeight || 0,
+        iframeDocument.body?.scrollHeight || 0,
+      );
+
+      if (nextHeight > 0) {
+        setIframeHeight(nextHeight);
+      }
+    } catch {
+      // Cross-origin iframe documents cannot be measured, so keep the fallback height.
     }
-  };
+  }, []);
 
   const currentYear = new Date().getFullYear();
 
@@ -215,17 +265,43 @@ const FooterBar = () => {
   );
 
   useEffect(() => {
-    loadFooter();
-  }, []);
+    const previousFooter = previousFooterRef.current;
+    if (
+      shouldResetFooterIframeHeight(
+        previousFooter.renderMode,
+        previousFooter.footerValue,
+        footerRenderMode,
+        footerValue,
+      )
+    ) {
+      setIframeHeight(FOOTER_IFRAME_FALLBACK_HEIGHT);
+    }
+
+    previousFooterRef.current = {
+      renderMode: footerRenderMode,
+      footerValue,
+    };
+  }, [footerRenderMode, footerValue]);
 
   return (
     <div className='w-full'>
-      {footer ? (
-        <div className='relative'>
-          <div
-            className='custom-footer'
-            dangerouslySetInnerHTML={{ __html: footer }}
-          ></div>
+      {footerRenderMode !== 'default' ? (
+        <div className='relative pb-8'>
+          {footerRenderMode === 'iframe' ? (
+            <iframe
+              ref={iframeRef}
+              title={t('页脚')}
+              src={footerValue}
+              className='custom-footer-frame'
+              style={{ height: `${iframeHeight}px` }}
+              onLoad={handleFooterFrameLoad}
+            />
+          ) : (
+            <div
+              className='custom-footer'
+              dangerouslySetInnerHTML={{ __html: footerValue }}
+            ></div>
+          )}
           <div className='absolute bottom-2 right-4 text-xs !text-semi-color-text-2 opacity-70'>
             <span>{t('设计与开发由')} </span>
             <a

--- a/web/src/helpers/footer.js
+++ b/web/src/helpers/footer.js
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2025 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+
+/**
+ * iframe 页脚在无法测量内容高度时使用的默认回退高度。
+ */
+export const FOOTER_IFRAME_FALLBACK_HEIGHT = 240;
+
+/**
+ * 规范化页脚配置值，统一将非字符串输入视为空值。
+ * @param {unknown} footer - 原始页脚配置值
+ * @returns {string} 去除首尾空白后的页脚内容，或空字符串
+ */
+export function normalizeFooterValue(footer) {
+  return typeof footer === 'string' ? footer.trim() : '';
+}
+
+/**
+ * 根据页脚内容判断前端应使用的渲染模式。
+ * @param {unknown} footer - 原始页脚配置值
+ * @returns {'default' | 'iframe' | 'html'} 页脚渲染模式
+ */
+export function getFooterRenderMode(footer) {
+  const normalizedFooter = normalizeFooterValue(footer);
+
+  if (!normalizedFooter) {
+    return 'default';
+  }
+
+  try {
+    const parsedUrl = new URL(normalizedFooter);
+    if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
+      return 'iframe';
+    }
+  } catch {
+    // Fall through to HTML mode for malformed or non-URL footer content.
+  }
+
+  return 'html';
+}
+
+/**
+ * 判断本次渲染是否需要将 iframe 高度重置为回退值。
+ * @param {'default' | 'iframe' | 'html' | null | undefined} previousRenderMode - 上一次渲染模式
+ * @param {string | null | undefined} previousFooterValue - 上一次页脚值
+ * @param {'default' | 'iframe' | 'html'} nextRenderMode - 当前渲染模式
+ * @param {string} nextFooterValue - 当前页脚值
+ * @returns {boolean} 是否需要重置 iframe 高度
+ */
+export function shouldResetFooterIframeHeight(
+  previousRenderMode,
+  previousFooterValue,
+  nextRenderMode,
+  nextFooterValue,
+) {
+  return (
+    nextRenderMode === 'iframe' &&
+    (previousRenderMode !== nextRenderMode ||
+      previousFooterValue !== nextFooterValue)
+  );
+}

--- a/web/src/helpers/footer.test.mjs
+++ b/web/src/helpers/footer.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  FOOTER_IFRAME_FALLBACK_HEIGHT,
+  getFooterRenderMode,
+  shouldResetFooterIframeHeight,
+} from './footer.js';
+
+test('uses a stable fallback height for iframe footers', () => {
+  assert.equal(FOOTER_IFRAME_FALLBACK_HEIGHT, 240);
+});
+
+test('treats http and https footer values as iframe embeds', () => {
+  assert.equal(
+    getFooterRenderMode('https://veriai.chat/landing/footer.html'),
+    'iframe',
+  );
+  assert.equal(getFooterRenderMode('http://example.com/footer.html'), 'iframe');
+});
+
+test('does not treat malformed http-like strings as iframe embeds', () => {
+  assert.equal(getFooterRenderMode('https://exa mple.com/footer'), 'html');
+});
+
+test('treats HTML fragments as inline footer content', () => {
+  assert.equal(getFooterRenderMode('<div>Footer</div>'), 'html');
+});
+
+test('falls back to the built-in footer for blank values', () => {
+  assert.equal(getFooterRenderMode(''), 'default');
+  assert.equal(getFooterRenderMode('   '), 'default');
+  assert.equal(getFooterRenderMode(null), 'default');
+});
+
+test('resets iframe height when the footer source or mode changes', () => {
+  assert.equal(
+    shouldResetFooterIframeHeight(
+      'iframe',
+      'https://a.example/footer',
+      'iframe',
+      'https://b.example/footer',
+    ),
+    true,
+  );
+  assert.equal(
+    shouldResetFooterIframeHeight(
+      'html',
+      '<div>Footer</div>',
+      'iframe',
+      'https://b.example/footer',
+    ),
+    true,
+  );
+  assert.equal(
+    shouldResetFooterIframeHeight(
+      'iframe',
+      'https://a.example/footer',
+      'iframe',
+      'https://a.example/footer',
+    ),
+    false,
+  );
+});

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -25,8 +25,8 @@ body.sidebar-collapsed {
 }
 
 body {
-  font-family: Lato, 'Helvetica Neue', Arial, Helvetica, 'Microsoft YaHei',
-    sans-serif;
+  font-family:
+    Lato, 'Helvetica Neue', Arial, Helvetica, 'Microsoft YaHei', sans-serif;
   color: var(--semi-color-text-0);
   background-color: var(--semi-color-bg-0);
 }
@@ -42,8 +42,8 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family:
+    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
 
 /* ==================== 布局相关样式 ==================== */
@@ -360,7 +360,9 @@ code {
   line-height: 1;
   background-color: var(--semi-color-fill-0);
   color: var(--semi-color-text-2);
-  transition: background-color 0.15s ease, color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .sbg-badge-active {
@@ -468,6 +470,14 @@ html.dark .sbg-variant-green {
 /* 页脚样式 */
 .custom-footer {
   font-size: 1.1em;
+}
+
+.custom-footer-frame {
+  width: 100%;
+  min-height: 240px;
+  display: block;
+  border: none;
+  background: transparent;
 }
 
 /* 卡片内容容器通用样式 */
@@ -797,11 +807,8 @@ html:not(.dark) .blur-ball-teal {
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background: radial-gradient(
-      circle at -5% -10%,
-      var(--pb1) 0%,
-      transparent 60%
-    ),
+  background:
+    radial-gradient(circle at -5% -10%, var(--pb1) 0%, transparent 60%),
     radial-gradient(circle at 105% -10%, var(--pb2) 0%, transparent 55%),
     radial-gradient(circle at 5% 110%, var(--pb3) 0%, transparent 55%),
     radial-gradient(circle at 105% 110%, var(--pb4) 0%, transparent 50%);


### PR DESCRIPTION
## Summary
- add footer helpers and tests for default, HTML, and iframe footer modes
- render `http/https` footer values as iframes while keeping HTML fragments inline
- reset iframe height when the footer source or mode changes so cross-origin embeds fall back to the default height

## Test Plan
- node --test web/src/helpers/footer.test.mjs
- NODE_PATH=/Users/sh001/Documents/codes/ivan/veriaichat/lib/web/node_modules /Users/sh001/Documents/codes/ivan/veriaichat/lib/web/node_modules/.bin/eslint src/components/layout/Footer.jsx src/helpers/footer.js src/helpers/footer.test.mjs
- /Users/sh001/Documents/codes/ivan/veriaichat/lib/web/node_modules/.bin/prettier --check src/components/layout/Footer.jsx src/helpers/footer.js src/helpers/footer.test.mjs src/index.css

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Footer now supports embedding iframe content with dynamic height synchronization to fit content.
  * Improved footer rendering to elegantly handle different content types while maintaining optimal layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->