### PR TITLE
fix @douyinfe/semi.css and SiLinkedin not found bug

### DIFF
--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -89,7 +89,6 @@ import {
   SiGitlab,
   SiGoogle,
   SiKeycloak,
-  SiLinkedin,
   SiNextcloud,
   SiNotion,
   SiOkta,
@@ -101,7 +100,7 @@ import {
   SiWechat,
   SiX,
 } from 'react-icons/si';
-
+import { FaLinkedin } from 'react-icons/fa';
 // 获取侧边栏Lucide图标组件
 export function getLucideIcon(key, selected = false) {
   const size = 16;
@@ -504,7 +503,7 @@ const oauthProviderIconMap = {
   google: SiGoogle,
   discord: SiDiscord,
   facebook: SiFacebook,
-  linkedin: SiLinkedin,
+  linkedin: FaLinkedin,
   x: SiX,
   twitter: SiX,
   slack: SiSlack,

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -29,6 +29,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+        '@douyinfe/semi-ui': path.resolve(__dirname, 'node_modules/@douyinfe/semi-ui'),
     },
   },
   plugins: [


### PR DESCRIPTION
fix @douyinfe/semi.css and SiLinkedin not found bug
修复 import '@douyinfe/semi-ui/dist/css/semi.css'; 导入bug
修复 SiLinkedin图表导入bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated LinkedIn icon source to use an alternative icon library while maintaining the same visual appearance.

* **Chores**
  * Added module alias resolution for improved build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->