### PR TITLE
feat(codex): 在渠道列表展示 ChatGPT plan type

### DIFF
--- a/relay/channel/codex/oauth_key.go
+++ b/relay/channel/codex/oauth_key.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 )


### PR DESCRIPTION
Extract Codex OAuth plan_type from OpenAI JWTs during code exchange and token refresh, then persist it to both the OAuth key JSON and channel other_info for safe list rendering without exposing channel keys.

Also backfill the plan type for existing Codex channels when loading channel records, and render a Plus/Team/Pro/Free badge after the type tag in the channel management table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex plan type (Plus, Team, Pro, Free) is now derived, stored, and merged into channel metadata and preloaded for display across lists, search results, and single-channel views.
  * Plan type is returned in credential refresh and OAuth flows and re-synced during channel create/update operations.
  * Channel tables and detail views show a plan type label for easier identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->