### PR TITLE
feat: allow existing users to bind inviter via aff code

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -1064,7 +1064,10 @@ func BindInviterByAffCode(userId int, affCode string) error {
 	// Wrap bind + reward in a transaction so a partial failure doesn't leave
 	// the user bound without receiving their quota (or vice-versa).
 	// All DB writes go through tx to ensure atomicity.
-	return DB.Transaction(func(tx *gorm.DB) error {
+	// RecordLog is deferred until after successful commit to avoid orphan logs on rollback.
+	inviteeRewarded := false
+	inviterRewarded := false
+	err = DB.Transaction(func(tx *gorm.DB) error {
 		// Optimistic lock: only update when inviter_id is still 0, preventing race conditions.
 		result := tx.Model(&User{}).Where("id = ? AND inviter_id = 0", userId).
 			Update("inviter_id", inviterId)
@@ -1081,22 +1084,47 @@ func BindInviterByAffCode(userId int, affCode string) error {
 				Update("quota", gorm.Expr("quota + ?", common.QuotaForInvitee)).Error; err != nil {
 				return err
 			}
-			RecordLog(userId, LogTypeSystem, fmt.Sprintf("绑定邀请码赠送 %s", logger.LogQuota(common.QuotaForInvitee)))
+			inviteeRewarded = true
 		}
 
 		// Grant inviter reward via atomic SQL (uses tx, not DB).
 		// Avoids the read-modify-write race in inviteUser().
 		if common.QuotaForInviter > 0 {
-			if err := tx.Model(&User{}).Where("id = ?", inviterId).Updates(map[string]interface{}{
+			result := tx.Model(&User{}).Where("id = ?", inviterId).Updates(map[string]interface{}{
 				"aff_count":         gorm.Expr("aff_count + 1"),
 				"aff_quota":         gorm.Expr("aff_quota + ?", common.QuotaForInviter),
 				"aff_history_quota": gorm.Expr("aff_history_quota + ?", common.QuotaForInviter),
-			}).Error; err != nil {
-				return err
+			})
+			if result.Error != nil {
+				return result.Error
 			}
-			RecordLog(inviterId, LogTypeSystem, fmt.Sprintf("被邀请用户绑定赠送 %s", logger.LogQuota(common.QuotaForInviter)))
+			if result.RowsAffected != 1 {
+				return errors.New("邀请人不存在，绑定失败")
+			}
+			inviterRewarded = true
 		}
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// Write logs only after successful commit to avoid orphan entries on rollback.
+	if inviteeRewarded {
+		RecordLog(userId, LogTypeSystem, fmt.Sprintf("绑定邀请码赠送 %s", logger.LogQuota(common.QuotaForInvitee)))
+		// Refresh invitee quota cache so the user sees the updated balance immediately.
+		gopool.Go(func() {
+			if err := cacheIncrUserQuota(userId, int64(common.QuotaForInvitee)); err != nil {
+				common.SysLog("failed to refresh invitee quota cache after bind: " + err.Error())
+			}
+		})
+	}
+	if inviterRewarded {
+		RecordLog(inviterId, LogTypeSystem, fmt.Sprintf("被邀请用户绑定赠送 %s", logger.LogQuota(common.QuotaForInviter)))
+	}
+	// Invalidate cache for both parties so stale aff stats are cleared.
+	_ = invalidateUserCache(userId)
+	_ = invalidateUserCache(inviterId)
+	return nil
 }


### PR DESCRIPTION
## Summary

Currently, invitation codes can only be applied during registration via URL parameter `?aff=XXXX`. This PR adds the ability for existing users to bind an inviter after account creation, with an admin-controlled feature gate.

- **`model/user.go`**: Add `BindInviterByAffCode()` — admin gate check, self-bind guard, optimistic lock (`WHERE inviter_id = 0` prevents race conditions), quota rewards mirroring registration logic
- **`controller/user.go`**: Add `BindAffCode` handler
- **`router/api-router.go`**: Register `POST /api/user/bind_aff` under `selfRoute` (requires `UserAuth`)
- **`common/constants.go`**: Add `AllowExistingUserBindInviterEnabled` flag (default `false`)
- **`model/option.go`**: Wire new option into `InitOptionMap` and `updateOptionMap`
- **Frontend**: Bind-inviter card in `InvitationCard` (only shown when `inviter_id === 0`), admin toggle in Operation Settings, i18n keys for all 6 locales (zh-CN, zh-TW, en, fr, ja, ru, vi)

## Behaviour

| Condition | Result |
|-----------|--------|
| Admin toggle off | 管理员未开启此功能 |
| User already has inviter | 您已绑定过邀请人，无法重复绑定 |
| User binds own aff code | 不能绑定自己的邀请码 |
| Invalid aff code | 邀请码无效 |
| Valid, first-time bind | success: true, both parties receive quota rewards |

## Test plan

- [x] T1: Normal bind — `success: true`, `inviter_id` updated
- [x] T2: Duplicate bind — rejected with correct message
- [x] T3: Self-bind — rejected with correct message
- [x] T4: Invalid code — rejected with correct message
- [x] T5: Feature gate off — rejected with correct message
- [x] Existing registration flow unchanged (purely additive change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registered users can bind an existing referrer by entering an invitation code; both parties receive quota rewards on success.
  * New rate-limited API endpoint to submit invitation codes.

* **Settings**
  * Admin toggle to enable/disable allowing existing users to bind a referrer.

* **UI**
  * “Bind Inviter” input and action added to the referral/invitation card with loading and success/error handling.

* **Localization**
  * Added translations for the binding flow in multiple locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->