### PR TITLE
fix(auth): fix Discord OAuth mobile login and add password login/register toggle

### DIFF
--- a/web/src/components/auth/RegisterForm.jsx
+++ b/web/src/components/auth/RegisterForm.jsx
@@ -542,7 +542,7 @@ const RegisterForm = () => {
                 )}
               </div>
 
-              {passwordLoginEnabled && (
+              {(passwordLoginEnabled || hasOAuthRegisterOptions) && (
                 <div className='mt-6 text-center text-sm'>
                   <Text>
                     {t('已有账户？')}{' '}
@@ -720,7 +720,7 @@ const RegisterForm = () => {
                 </>
               )}
 
-              {passwordLoginEnabled && (
+              {(passwordLoginEnabled || hasOAuthRegisterOptions) && (
                 <div className='mt-6 text-center text-sm'>
                   <Text>
                     {t('已有账户？')}{' '}


### PR DESCRIPTION
This PR introduces password login/registration control settings, fixes Discord OAuth on mobile devices, and adds
  optional Cloudflare Tunnel support to the Docker Compose configuration.

  本 PR 新增密碼登入/註冊的開關設定、修復手機上的 Discord OAuth 登入問題，並在 Docker Compose 中加入可選的 Cloudflare Tunnel 支援。

  ---
  Changes / 變更內容

  ✨ feat: Password Login / Register Toggle

  - Backend (controller/misc.go): Exposes password_login_enabled and password_register_enabled fields in the /api/status
   response, reading from common.PasswordLoginEnabled and common.PasswordRegisterEnabled.
  - Frontend (LoginForm.jsx, RegisterForm.jsx): Conditionally renders password login/register UI based on the above
  settings. When disabled, shows only OAuth options or a "login disabled" message.
  - 後端 (controller/misc.go)：在 /api/status 回應中新增 password_login_enabled 和 password_register_enabled 欄位。
  - 前端 (LoginForm.jsx, RegisterForm.jsx)：依據上述設定動態顯示或隱藏密碼登入/註冊區塊；停用時僅顯示 OAuth
  選項或「登入已停用」提示。

  🐛 fix: Discord OAuth Mobile Login

  - web/src/helpers/api.js: Changed window.open() to window.location.href for the Discord OAuth redirect. window.open()
  is frequently blocked by mobile popup blockers or opens in a separate tab, causing the OAuth state session to be lost
  and leaving the user appearing not logged in after authorization.
  - web/src/helpers/api.js：將 Discord OAuth 的跳轉從 window.open() 改為 window.location.href。window.open()
  在手機上常被彈出視窗封鎖，或在新分頁完成登入後，原分頁仍顯示未登入狀態。

  🔧 chore: Docker Compose & Environment

  - docker-compose.yml: Adds Cloudflare Tunnel service as a commented-out template with setup instructions. Default
  image restored to calciumion/new-api:latest. Placeholder credentials restored.
  - .env.example: Documents the TUNNEL_TOKEN environment variable required for Cloudflare Tunnel.
  - .gitignore: Adds .omc/ to ignore local OMC orchestration state files.
  - docker-compose.yml：將 Cloudflare Tunnel service 以註解方式附上說明，方便需要時啟用。image 恢復為上游預設值，預設憑證恢復為佔位符。
  - .env.example：新增 TUNNEL_TOKEN 說明，描述 Cloudflare Tunnel 的設定方式。
  - .gitignore：加入 .omc/，避免本地 OMC 狀態檔案被追蹤。

  ---
  Testing / 測試

  - Discord OAuth login works on mobile (same-tab redirect, no popup blocker)
  - When password_login_enabled = false, password login UI is hidden; OAuth options shown
  - When password_register_enabled = false, registration button is hidden
  - Docker Compose starts correctly with default config
  - 手機 Discord OAuth 登入正常（同分頁 redirect，不被彈出視窗封鎖）
  - password_login_enabled = false 時，密碼登入 UI 隱藏，僅顯示 OAuth
  - password_register_enabled = false 時，註冊按鈕隱藏
  - Docker Compose 以預設設定可正常啟動

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password login and registration can be enabled or disabled independently; the UI adapts to those toggles.

* **Improvements**
  * OAuth flows now open in the current tab instead of a popup.
  * Server status now reports password-login and password-register availability so the UI reflects configured toggles.

* **Chores**
  * Added Cloudflare Tunnel configuration templates to examples and compose, and added .omc/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->