### PR TITLE
feat: add support for new relay mode based on /v1/messages path

### DIFF
--- a/relay/constant/relay_mode.go
+++ b/relay/constant/relay_mode.go
@@ -56,7 +56,7 @@ const (
 
 func Path2RelayMode(path string) int {
 	relayMode := RelayModeUnknown
-	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") {
+	if strings.HasPrefix(path, "/v1/chat/completions") || strings.HasPrefix(path, "/pg/chat/completions") || strings.HasPrefix(path, "/v1/messages") {
 		relayMode = RelayModeChatCompletions
 	} else if strings.HasPrefix(path, "/v1/completions") {
 		relayMode = RelayModeCompletions


### PR DESCRIPTION
修复claude 调用 千帆v2 的 kimi 报错:
```
500 {"error":{"type":"do_request_failed","message":"get request url failed: unsupported relay mode: 0 (request id: 
     ....)"},"type":"error"} 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API compatibility by adding support for the `/v1/messages` endpoint path for chat completion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->