### PR TITLE
fix(billing): correct cache token double-counting in Claude relay to non-Claude providers

### DIFF
--- a/service/quota.go
+++ b/service/quota.go
@@ -261,7 +261,6 @@ func PostClaudeConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, 
 	cacheCreationTokens1h := usage.ClaudeCacheCreation1hTokens
 
 	if relayInfo.ChannelType == constant.ChannelTypeOpenRouter {
-		promptTokens -= cacheTokens
 		isUsingCustomSettings := relayInfo.PriceData.UsePrice || hasCustomModelRatio(modelName, relayInfo.PriceData.ModelRatio)
 		if cacheCreationTokens == 0 && relayInfo.PriceData.CacheCreationRatio != 1 && usage.Cost != 0 && !isUsingCustomSettings {
 			maybeCacheCreationTokens := CalcOpenRouterCacheCreateTokens(*usage, relayInfo.PriceData)
@@ -269,6 +268,14 @@ func PostClaudeConsumeQuota(ctx *gin.Context, relayInfo *relaycommon.RelayInfo, 
 				cacheCreationTokens = maybeCacheCreationTokens
 			}
 		}
+	}
+
+	// Anthropic API's input_tokens already excludes cached tokens, no subtraction needed.
+	// Other providers (Gemini, OpenAI, OpenRouter, etc.) include cached tokens in prompt_tokens,
+	// so we must subtract them to avoid double-counting.
+	isClaudeUsageSemantic := relayInfo.GetFinalRequestRelayFormat() == types.RelayFormatClaude
+	if !isClaudeUsageSemantic {
+		promptTokens -= cacheTokens
 		promptTokens -= cacheCreationTokens
 	}
 


### PR DESCRIPTION
## Problem

When a Claude-format request (`/v1/messages`) is relayed to a non-Claude provider (e.g. Gemini, OpenAI), `PostClaudeConsumeQuota` incorrectly assumes Claude usage semantics for the returned usage data.

**Claude API** returns `input_tokens` that already **excludes** cached tokens — so no subtraction is needed.

**Gemini / OpenAI / etc.** return `prompt_tokens` that **includes** cached tokens — so `cacheTokens` must be subtracted from `promptTokens` before adding `cacheTokens * cacheRatio`, otherwise cached tokens get billed twice.

### Billing breakdown (before fix)

| Item | Tokens | How billed |
|---|---|---|
| `promptTokens` | 16202 (includes 15802 cached) | × modelRatio |
| `cacheTokens` | 15802 | × cacheRatio |

The 15802 cached tokens are charged **twice**: once at full input price, once at cache price.

### Billing breakdown (after fix)

| Item | Tokens | How billed |
|---|---|---|
| `promptTokens` | 400 (16202 − 15802) | × modelRatio |
| `cacheTokens` | 15802 | × cacheRatio |

## Root Cause

`PostClaudeConsumeQuota` only subtracted cache tokens for `ChannelTypeOpenRouter`. The existing `postConsumeQuota` in `relay/compatible_handler.go` already handles this correctly using `GetFinalRequestRelayFormat() == RelayFormatClaude` to distinguish usage semantics — `PostClaudeConsumeQuota` was missing the same guard.

## Fix

Lift the cache-token subtraction out of the OpenRouter-only block and apply it to **all non-Claude-semantic** usage, consistent with `compatible_handler.go`:

```go
isClaudeUsageSemantic := relayInfo.GetFinalRequestRelayFormat() == types.RelayFormatClaude
if !isClaudeUsageSemantic {
    promptTokens -= cacheTokens
    promptTokens -= cacheCreationTokens
}
```

The OpenRouter-specific cache-creation estimation logic is preserved as-is (it runs before the subtraction).

## Affected Scenarios

Any request that:
1. Enters via the Claude Messages endpoint (`/v1/messages`)
2. Is relayed to a **non-Claude** provider (Gemini, OpenAI, Azure, DeepSeek, etc.)
3. Has cached tokens returned in the response usage

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached tokens are no longer deducted from prompt token totals for Claude-format final requests.
  * Other formats continue to deduct cached tokens from prompt totals.
  * Cache-creation tokens still count toward quota as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->