### PR TITLE
fix issue 3200 Stripe订阅报错400

### DIFF
--- a/controller/subscription_payment_stripe.go
+++ b/controller/subscription_payment_stripe.go
@@ -125,7 +125,6 @@ func genStripeSubscriptionLink(referenceId string, customerId string, email stri
 		if "" != email {
 			params.CustomerEmail = stripe.String(email)
 		}
-		params.CustomerCreation = stripe.String(string(stripe.CheckoutSessionCustomerCreationAlways))
 	} else {
 		params.Customer = stripe.String(customerId)
 	}


### PR DESCRIPTION
#3200 

 ## Problem
 
 When creating a Stripe Checkout Session in `subscription` mode, the `customer_creation` parameter was being set to `"always"`. Stripe only allows this parameter in `payment` mode, resulting in the following API error:
 
 ```
 `customer_creation` can only be used in `payment` mode.
 ```
 
 ## Root Cause
 
 The [genStripeSubscriptionLink()](cci:1://file:///Users/dhb/project/opensource/new-api/controller/subscription_payment_stripe.go:107:0-136:1) function in [subscription_payment_stripe.go](cci:7://file:///Users/dhb/project/opensource/new-api/controller/subscription_payment_stripe.go:0:0-0:0) was reusing the same customer-handling logic from the one-time payment flow ([genStripeLink()](cci:1://file:///Users/dhb/project/opensource/new-api/controller/topup_stripe.go:258:0-315:1)), which correctly sets `customer_creation = "always"` for `payment` mode. However, this parameter is invalid for `subscription` mode — Stripe automatically creates a customer for every subscription checkout session.
 
 ## Fix
 
 Removed the `CustomerCreation` assignment from [genStripeSubscriptionLink()](cci:1://file:///Users/dhb/project/opensource/new-api/controller/subscription_payment_stripe.go:107:0-136:1). The `CustomerEmail` parameter is still set when no existing Stripe customer ID is available, allowing Stripe to associate the email with the auto-created customer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted subscription payment checkout behavior to use Stripe's default customer creation settings instead of always forcing customer creation. This provides more flexible handling of customer accounts during the checkout process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->