### PR TITLE
feat: add logs content tooltip

### DIFF
--- a/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
+++ b/web/src/components/table/usage-logs/UsageLogsColumnDefs.jsx
@@ -897,6 +897,10 @@ export const getLogsColumns = ({
             <Typography.Paragraph
               ellipsis={{
                 rows: 2,
+                showTooltip: {
+                  type: 'popover',
+                  opts: { style: { width: 240 } },
+                },
               }}
               style={{ maxWidth: 200, marginBottom: 0 }}
             >


### PR DESCRIPTION
修复使用日志当详情为普通文本的时候, tooltip因重构丢失的问题
<img width="2410" height="314" alt="image" src="https://github.com/user-attachments/assets/5130b8af-54a0-49f2-8bc9-d3b6567784f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover tooltips to display truncated detail text in full, enabling users to preview complete information without modifying the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->