### PR TITLE
Expose Vertex traffic type in usage

### DIFF
--- a/dto/gemini.go
+++ b/dto/gemini.go
@@ -464,6 +464,7 @@ type GeminiUsageMetadata struct {
 	TotalTokenCount            int                         `json:"totalTokenCount"`
 	ThoughtsTokenCount         int                         `json:"thoughtsTokenCount"`
 	CachedContentTokenCount    int                         `json:"cachedContentTokenCount"`
+	TrafficType                string                      `json:"trafficType,omitempty"`
 	PromptTokensDetails        []GeminiPromptTokensDetails `json:"promptTokensDetails"`
 	ToolUsePromptTokensDetails []GeminiPromptTokensDetails `json:"toolUsePromptTokensDetails"`
 }

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -237,6 +237,9 @@ type Usage struct {
 
 	// OpenRouter Params
 	Cost any `json:"cost,omitempty"`
+
+	// Gemini/Vertex specific usage metadata.
+	TrafficType string `json:"traffic_type,omitempty"`
 }
 
 type OpenAIVideoResponse struct {

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1053,6 +1053,7 @@ func buildUsageFromGeminiMetadata(metadata dto.GeminiUsageMetadata, fallbackProm
 		PromptTokens:     promptTokens,
 		CompletionTokens: metadata.CandidatesTokenCount + metadata.ThoughtsTokenCount,
 		TotalTokens:      metadata.TotalTokenCount,
+		TrafficType:      metadata.TrafficType,
 	}
 	usage.CompletionTokenDetails.ReasoningTokens = metadata.ThoughtsTokenCount
 	usage.PromptTokensDetails.CachedTokens = metadata.CachedContentTokenCount

--- a/relay/channel/gemini/relay_gemini_usage_test.go
+++ b/relay/channel/gemini/relay_gemini_usage_test.go
@@ -20,7 +20,8 @@ func TestGeminiChatHandlerCompletionTokensExcludeToolUsePromptTokens(t *testing.
 	t.Parallel()
 
 	gin.SetMode(gin.TestMode)
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
 	info := &relaycommon.RelayInfo{
@@ -48,6 +49,7 @@ func TestGeminiChatHandlerCompletionTokensExcludeToolUsePromptTokens(t *testing.
 			CandidatesTokenCount:    1089,
 			ThoughtsTokenCount:      1120,
 			TotalTokenCount:         20689,
+			TrafficType:             "ON_DEMAND_PRIORITY",
 		},
 	}
 
@@ -65,11 +67,14 @@ func TestGeminiChatHandlerCompletionTokensExcludeToolUsePromptTokens(t *testing.
 	require.Equal(t, 2209, usage.CompletionTokens)
 	require.Equal(t, 20689, usage.TotalTokens)
 	require.Equal(t, 1120, usage.CompletionTokenDetails.ReasoningTokens)
+	require.Equal(t, "ON_DEMAND_PRIORITY", usage.TrafficType)
+	require.Contains(t, recorder.Body.String(), "\"trafficType\":\"ON_DEMAND_PRIORITY\"")
 }
 
 func TestGeminiStreamHandlerCompletionTokensExcludeToolUsePromptTokens(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
 	oldStreamingTimeout := constant.StreamingTimeout
@@ -79,7 +84,9 @@ func TestGeminiStreamHandlerCompletionTokensExcludeToolUsePromptTokens(t *testin
 	})
 
 	info := &relaycommon.RelayInfo{
-		OriginModelName: "gemini-3-flash-preview",
+		RelayFormat:        types.RelayFormatOpenAI,
+		OriginModelName:    "gemini-3-flash-preview",
+		ShouldIncludeUsage: true,
 		ChannelMeta: &relaycommon.ChannelMeta{
 			UpstreamModelName: "gemini-3-flash-preview",
 		},
@@ -102,6 +109,7 @@ func TestGeminiStreamHandlerCompletionTokensExcludeToolUsePromptTokens(t *testin
 			CandidatesTokenCount:    1089,
 			ThoughtsTokenCount:      1120,
 			TotalTokenCount:         20689,
+			TrafficType:             "ON_DEMAND_PRIORITY",
 		},
 	}
 
@@ -113,15 +121,64 @@ func TestGeminiStreamHandlerCompletionTokensExcludeToolUsePromptTokens(t *testin
 		Body: io.NopCloser(bytes.NewReader(streamBody)),
 	}
 
-	usage, newAPIError := geminiStreamHandler(c, info, resp, func(_ string, _ *dto.GeminiChatResponse) bool {
-		return true
-	})
+	usage, newAPIError := GeminiChatStreamHandler(c, info, resp)
 	require.Nil(t, newAPIError)
 	require.NotNil(t, usage)
 	require.Equal(t, 18480, usage.PromptTokens)
 	require.Equal(t, 2209, usage.CompletionTokens)
 	require.Equal(t, 20689, usage.TotalTokens)
 	require.Equal(t, 1120, usage.CompletionTokenDetails.ReasoningTokens)
+	require.Equal(t, "ON_DEMAND_PRIORITY", usage.TrafficType)
+	require.Contains(t, recorder.Body.String(), "\"traffic_type\":\"ON_DEMAND_PRIORITY\"")
+}
+
+func TestGeminiChatHandlerOpenAIResponseIncludesTrafficType(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	info := &relaycommon.RelayInfo{
+		RelayFormat:     types.RelayFormatOpenAI,
+		OriginModelName: "gemini-3-flash-preview",
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gemini-3-flash-preview",
+		},
+	}
+
+	payload := dto.GeminiChatResponse{
+		Candidates: []dto.GeminiChatCandidate{
+			{
+				Content: dto.GeminiChatContent{
+					Role: "model",
+					Parts: []dto.GeminiPart{
+						{Text: "ok"},
+					},
+				},
+			},
+		},
+		UsageMetadata: dto.GeminiUsageMetadata{
+			PromptTokenCount:     10,
+			CandidatesTokenCount: 20,
+			TotalTokenCount:      30,
+			TrafficType:          "ON_DEMAND_PRIORITY",
+		},
+	}
+
+	body, err := common.Marshal(payload)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		Body: io.NopCloser(bytes.NewReader(body)),
+	}
+
+	usage, newAPIError := GeminiChatHandler(c, info, resp)
+	require.Nil(t, newAPIError)
+	require.NotNil(t, usage)
+	require.Equal(t, "ON_DEMAND_PRIORITY", usage.TrafficType)
+	require.Contains(t, recorder.Body.String(), "\"traffic_type\":\"ON_DEMAND_PRIORITY\"")
 }
 
 func TestGeminiTextGenerationHandlerPromptTokensIncludeToolUsePromptTokens(t *testing.T) {


### PR DESCRIPTION
## Summary
- parse Vertex/Gemini `usageMetadata.trafficType` from upstream responses
- expose that value in OpenAI-compatible `usage.traffic_type`
- add coverage for normal and streaming Gemini handlers

## Testing
- go test ./relay/channel/gemini -run 'TestGemini(ChatHandlerCompletionTokensExcludeToolUsePromptTokens|StreamHandlerCompletionTokensExcludeToolUsePromptTokens|ChatHandlerOpenAIResponseIncludesTrafficType|TextGenerationHandlerPromptTokensIncludeToolUsePromptTokens|ChatHandlerUsesEstimatedPromptTokensWhenUsagePromptMissing|StreamHandlerUsesEstimatedPromptTokensWhenUsagePromptMissing|TextGenerationHandlerUsesEstimatedPromptTokensWhenUsagePromptMissing)$'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Usage metrics now include traffic type information, enabling better tracking and classification of API usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->