### PR TITLE
feat: 支持通过环境变量配置搜索接口限流参数

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -177,6 +177,7 @@ var (
 	DownloadRateLimitDuration int64 = 60
 
 	// Per-user search rate limit (applies after authentication, keyed by user ID)
+	SearchRateLimitEnable         = true
 	SearchRateLimitNum            = 10
 	SearchRateLimitDuration int64 = 60
 )

--- a/common/init.go
+++ b/common/init.go
@@ -120,6 +120,10 @@ func InitEnv() {
 	CriticalRateLimitEnable = GetEnvOrDefaultBool("CRITICAL_RATE_LIMIT_ENABLE", true)
 	CriticalRateLimitNum = GetEnvOrDefault("CRITICAL_RATE_LIMIT", 20)
 	CriticalRateLimitDuration = int64(GetEnvOrDefault("CRITICAL_RATE_LIMIT_DURATION", 20*60))
+
+	SearchRateLimitEnable = GetEnvOrDefaultBool("SEARCH_RATE_LIMIT_ENABLE", true)
+	SearchRateLimitNum = GetEnvOrDefault("SEARCH_RATE_LIMIT", 10)
+	SearchRateLimitDuration = int64(GetEnvOrDefault("SEARCH_RATE_LIMIT_DURATION", 60))
 	initConstantEnv()
 }
 

--- a/middleware/rate-limit.go
+++ b/middleware/rate-limit.go
@@ -196,7 +196,10 @@ func userRedisRateLimiter(c *gin.Context, maxRequestNum int, duration int64, key
 }
 
 // SearchRateLimit returns a per-user rate limiter for search endpoints.
-// 10 requests per 60 seconds per user (by user ID, not IP).
+// Configurable via SEARCH_RATE_LIMIT_ENABLE / SEARCH_RATE_LIMIT / SEARCH_RATE_LIMIT_DURATION.
 func SearchRateLimit() func(c *gin.Context) {
+	if !common.SearchRateLimitEnable {
+		return defNext
+	}
 	return userRateLimitFactory(common.SearchRateLimitNum, common.SearchRateLimitDuration, "SR")
 }


### PR DESCRIPTION
## Summary

- 新增 `SEARCH_RATE_LIMIT_ENABLE` 环境变量，支持关闭搜索接口的限流
- 新增 `SEARCH_RATE_LIMIT` 环境变量，支持自定义搜索接口的请求数上限
- 新增 `SEARCH_RATE_LIMIT_DURATION` 环境变量，支持自定义搜索接口的限流窗口时长

## Background

搜索接口（`/api/token/search`、`/api/log/self/search` 等）原本硬编码为 **60 秒内最多 10 次**请求，无法通过配置调整。在并发较高或需要放宽限制的场景下，用户只能修改源码重新编译，体验较差。

本 PR 将搜索限流参数与现有的 `GLOBAL_API_RATE_LIMIT`、`CRITICAL_RATE_LIMIT` 等环境变量保持一致的风格，统一支持运行时配置。

## Changes

### `common/constants.go`

新增 `SearchRateLimitEnable` 变量，默认值 `true`，与现有 `SearchRateLimitNum` / `SearchRateLimitDuration` 归组：

```go
// Per-user search rate limit (applies after authentication, keyed by user ID)
SearchRateLimitEnable         = true
SearchRateLimitNum            = 10
SearchRateLimitDuration int64 = 60
```

### `common/init.go`

在初始化阶段从环境变量读取并覆盖默认值：

```go
SearchRateLimitEnable = GetEnvOrDefaultBool("SEARCH_RATE_LIMIT_ENABLE", true)
SearchRateLimitNum = GetEnvOrDefault("SEARCH_RATE_LIMIT", 10)
SearchRateLimitDuration = int64(GetEnvOrDefault("SEARCH_RATE_LIMIT_DURATION", 60))
```

### `middleware/rate-limit.go`

`SearchRateLimit()` 中加入开关判断，`SEARCH_RATE_LIMIT_ENABLE=false` 时直接跳过限流：

```go
func SearchRateLimit() func(c *gin.Context) {
    if !common.SearchRateLimitEnable {
        return defNext
    }
    return userRateLimitFactory(common.SearchRateLimitNum, common.SearchRateLimitDuration, "SR")
}
```

## New Environment Variables

| 环境变量 | 默认值 | 说明 |
|---|---|---|
| `SEARCH_RATE_LIMIT_ENABLE` | `true` | 是否开启搜索接口限流 |
| `SEARCH_RATE_LIMIT` | `10` | 限流窗口内允许的最大请求数（按用户 ID） |
| `SEARCH_RATE_LIMIT_DURATION` | `60`（秒）| 限流滑动窗口时长 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search rate limiting is now configurable. Administrators can enable/disable the feature and customize request limits and time windows via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->