### PR TITLE
fix: 修正 Codex free 账号用量显示到每周窗口

### DIFF
--- a/web/src/components/table/channels/modals/CodexUsageModal.jsx
+++ b/web/src/components/table/channels/modals/CodexUsageModal.jsx
@@ -43,6 +43,68 @@ const pickStrokeColor = (percent) => {
   return '#3b82f6';
 };
 
+const normalizePlanType = (value) => {
+  if (value == null) return '';
+  return String(value).trim().toLowerCase();
+};
+
+const getWindowDurationSeconds = (windowData) => {
+  const value = Number(windowData?.limit_window_seconds);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+};
+
+const classifyWindowByDuration = (windowData) => {
+  const seconds = getWindowDurationSeconds(windowData);
+  if (seconds == null) return null;
+  return seconds >= 24 * 60 * 60 ? 'weekly' : 'fiveHour';
+};
+
+const resolveRateLimitWindows = (data) => {
+  const rateLimit = data?.rate_limit ?? {};
+  const primary = rateLimit?.primary_window ?? null;
+  const secondary = rateLimit?.secondary_window ?? null;
+  const windows = [primary, secondary].filter(Boolean);
+  const planType = normalizePlanType(data?.plan_type ?? rateLimit?.plan_type);
+
+  let fiveHourWindow = null;
+  let weeklyWindow = null;
+
+  for (const windowData of windows) {
+    const bucket = classifyWindowByDuration(windowData);
+    if (bucket === 'fiveHour' && !fiveHourWindow) {
+      fiveHourWindow = windowData;
+      continue;
+    }
+    if (bucket === 'weekly' && !weeklyWindow) {
+      weeklyWindow = windowData;
+    }
+  }
+
+  if (planType === 'free') {
+    if (!weeklyWindow) {
+      weeklyWindow = primary ?? secondary ?? null;
+    }
+    return { fiveHourWindow: null, weeklyWindow };
+  }
+
+  if (!fiveHourWindow && !weeklyWindow) {
+    return {
+      fiveHourWindow: primary ?? null,
+      weeklyWindow: secondary ?? null,
+    };
+  }
+
+  if (!fiveHourWindow) {
+    fiveHourWindow = windows.find((windowData) => windowData !== weeklyWindow) ?? null;
+  }
+  if (!weeklyWindow) {
+    weeklyWindow = windows.find((windowData) => windowData !== fiveHourWindow) ?? null;
+  }
+
+  return { fiveHourWindow, weeklyWindow };
+};
+
 const formatDurationSeconds = (seconds, t) => {
   const tt = typeof t === 'function' ? t : (v) => v;
   const s = Number(seconds);
@@ -68,6 +130,10 @@ const formatUnixSeconds = (unixSeconds) => {
 
 const RateLimitWindowCard = ({ t, title, windowData }) => {
   const tt = typeof t === 'function' ? t : (v) => v;
+  const hasWindowData =
+    !!windowData &&
+    typeof windowData === 'object' &&
+    Object.keys(windowData).length > 0;
   const percent = clampPercent(windowData?.used_percent ?? 0);
   const resetAt = windowData?.reset_at;
   const resetAfterSeconds = windowData?.reset_after_seconds;
@@ -83,26 +149,30 @@ const RateLimitWindowCard = ({ t, title, windowData }) => {
         </Text>
       </div>
 
-      <div className='mt-2'>
-        <Progress
-          percent={percent}
-          stroke={pickStrokeColor(percent)}
-          showInfo={true}
-        />
-      </div>
+      {hasWindowData ? (
+        <div className='mt-2'>
+          <Progress
+            percent={percent}
+            stroke={pickStrokeColor(percent)}
+            showInfo={true}
+          />
+        </div>
+      ) : (
+        <div className='mt-3 text-sm text-semi-color-text-2'>-</div>
+      )}
 
       <div className='mt-1 flex flex-wrap items-center gap-2 text-xs text-semi-color-text-2'>
         <div>
           {tt('已使用：')}
-          {percent}%
+          {hasWindowData ? `${percent}%` : '-'}
         </div>
         <div>
           {tt('距离重置：')}
-          {formatDurationSeconds(resetAfterSeconds, tt)}
+          {hasWindowData ? formatDurationSeconds(resetAfterSeconds, tt) : '-'}
         </div>
         <div>
           {tt('窗口：')}
-          {formatDurationSeconds(limitWindowSeconds, tt)}
+          {hasWindowData ? formatDurationSeconds(limitWindowSeconds, tt) : '-'}
         </div>
       </div>
     </div>
@@ -113,9 +183,7 @@ const CodexUsageView = ({ t, record, payload, onCopy, onRefresh }) => {
   const tt = typeof t === 'function' ? t : (v) => v;
   const data = payload?.data ?? null;
   const rateLimit = data?.rate_limit ?? {};
-
-  const primary = rateLimit?.primary_window ?? null;
-  const secondary = rateLimit?.secondary_window ?? null;
+  const { fiveHourWindow, weeklyWindow } = resolveRateLimitWindows(data);
 
   const allowed = !!rateLimit?.allowed;
   const limitReached = !!rateLimit?.limit_reached;
@@ -163,12 +231,12 @@ const CodexUsageView = ({ t, record, payload, onCopy, onRefresh }) => {
         <RateLimitWindowCard
           t={tt}
           title={tt('5小时窗口')}
-          windowData={primary}
+          windowData={fiveHourWindow}
         />
         <RateLimitWindowCard
           t={tt}
           title={tt('每周窗口')}
-          windowData={secondary}
+          windowData={weeklyWindow}
         />
       </div>
 


### PR DESCRIPTION
## Summary

  - 修正 Codex 渠道 free 账号的额度窗口展示逻辑
  - 当上游返回 `"plan_type": "free"` 时，将实际用量展示到“每周窗口”而不是“5小时窗口”
  - 5小时窗口改为空态展示，避免误导性地显示 `0%`
  
<img width="850" height="140" alt="image" src="https://github.com/user-attachments/assets/b0eeb15c-5f5d-4768-ba8d-1e34d05c72ee" />

  ## Background

  Codex 渠道用量弹窗当前固定将 `rate_limit.primary_window` 渲染为“5小时窗口”，将 `rate_limit.secondary_window` 渲染为“每周窗口”。

  但在 free 账号场景下，上游返回中会包含 `"plan_type": "free"`，此类账号没有 5 小时窗口，只有每周窗口。由于前端没有根据 `plan_type`或窗口时长做实际归类，导致真实的周用量被错误展示在左侧“5小时窗口”中，右侧“每周窗口”反而为空或显示不正确。

  本 PR 修正该展示层问题，使 free 账号的额度信息能够正确落到每周窗口中，同时保留对非 free 场景的兼容。

  ## Changes

  ### `web/src/components/table/channels/modals/CodexUsageModal.jsx`

  新增额度窗口归类逻辑：

  - 增加 `plan_type` 归一化处理
  - 增加基于 `limit_window_seconds` 的窗口识别逻辑
  - 优先根据窗口时长识别“5小时窗口”与“每周窗口”
  - 当 `plan_type === 'free'` 时，强制将有效窗口映射到“每周窗口”，不再错误显示到“5小时窗口”

  调整窗口卡片展示逻辑：

  - 当窗口数据不存在时，显示空态 `-`
  - 不再对空窗口渲染误导性的进度条和 `0%`
  - 保持原有进度条、重置时间、距离重置、窗口时长等展示方式不变

  ## Testing

  - 本地执行前端构建，确认改动可正常编译
  - 本地启动服务并手动验证 Codex 用量弹窗展示
  - 验证 `plan_type: free` 场景下，用量显示在“每周窗口”
  - 验证无有效 5 小时窗口时，左侧卡片显示为空态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Rate limit window displays now gracefully handle missing data scenarios with placeholder indicators.
  * Improved rendering logic to ensure consistent display of usage metrics across different plan configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->