### PR TITLE
feat: upgrade MiniMax default model to M2.7

### DIFF
--- a/model/pricing_default.go
+++ b/model/pricing_default.go
@@ -20,6 +20,7 @@ var defaultVendorRules = map[string]string{
 	"qwen":     "阿里巴巴",
 	"deepseek": "DeepSeek",
 	"abab":     "MiniMax",
+	"minimax":  "MiniMax",
 	"ernie":    "百度",
 	"spark":    "讯飞",
 	"hunyuan":  "腾讯",

--- a/relay/channel/minimax/constants.go
+++ b/relay/channel/minimax/constants.go
@@ -14,6 +14,8 @@ var ModelList = []string{
 	"speech-02-turbo",
 	"speech-01-hd",
 	"speech-01-turbo",
+	"MiniMax-M2.7",
+	"MiniMax-M2.7-highspeed",
 	"MiniMax-M2.1",
 	"MiniMax-M2.1-highspeed",
 	"MiniMax-M2",

--- a/relay/channel/minimax/constants_test.go
+++ b/relay/channel/minimax/constants_test.go
@@ -1,0 +1,84 @@
+package minimax
+
+import (
+	"testing"
+)
+
+func TestModelListContainsM27(t *testing.T) {
+	found := false
+	for _, model := range ModelList {
+		if model == "MiniMax-M2.7" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ModelList should contain MiniMax-M2.7")
+	}
+}
+
+func TestModelListContainsM27Highspeed(t *testing.T) {
+	found := false
+	for _, model := range ModelList {
+		if model == "MiniMax-M2.7-highspeed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("ModelList should contain MiniMax-M2.7-highspeed")
+	}
+}
+
+func TestModelListM27BeforeOlderModels(t *testing.T) {
+	m27Idx := -1
+	m25Idx := -1
+	m21Idx := -1
+	for i, model := range ModelList {
+		switch model {
+		case "MiniMax-M2.7":
+			m27Idx = i
+		case "MiniMax-M2.5":
+			m25Idx = i
+		case "MiniMax-M2.1":
+			m21Idx = i
+		}
+	}
+
+	if m27Idx == -1 {
+		t.Fatal("MiniMax-M2.7 not found in ModelList")
+	}
+	if m25Idx == -1 {
+		t.Fatal("MiniMax-M2.5 not found in ModelList")
+	}
+	if m21Idx == -1 {
+		t.Fatal("MiniMax-M2.1 not found in ModelList")
+	}
+	if m27Idx >= m25Idx {
+		t.Errorf("MiniMax-M2.7 (index %d) should come before MiniMax-M2.5 (index %d)", m27Idx, m25Idx)
+	}
+	if m27Idx >= m21Idx {
+		t.Errorf("MiniMax-M2.7 (index %d) should come before MiniMax-M2.1 (index %d)", m27Idx, m21Idx)
+	}
+}
+
+func TestModelListPreservesOlderModels(t *testing.T) {
+	requiredModels := []string{
+		"MiniMax-M2.5",
+		"MiniMax-M2.5-highspeed",
+		"MiniMax-M2.1",
+		"MiniMax-M2.1-highspeed",
+		"MiniMax-M2",
+	}
+
+	modelSet := make(map[string]bool)
+	for _, model := range ModelList {
+		modelSet[model] = true
+	}
+
+	for _, required := range requiredModels {
+		if !modelSet[required] {
+			t.Errorf("ModelList should still contain %s", required)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to include the latest M2.7 model.

## Changes
- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to the model selection list
- Place M2.7 models before older MiniMax-M* models in the list
- Add `minimax` vendor mapping rule for proper model-to-vendor resolution (alongside existing `abab` rule)
- Retain all previous models as available alternatives
- Add unit tests for model list validation

## Why
MiniMax-M2.7 is the latest flagship model with enhanced reasoning and coding capabilities. This ensures users have access to the newest MiniMax models through the API gateway.

## Testing
- Unit tests added and passing (`go test ./relay/channel/minimax/...`)
- Tests verify M2.7 models are in the list, ordered before older models, and older models are preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new MiniMax model variants: MiniMax-M2.7 and MiniMax-M2.7-highspeed.

* **Tests**
  * Added test suite for MiniMax model support, verifying model availability and version ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->