### PR TITLE
feat(codex): show ChatGPT plan type in channel list

### DIFF
--- a/controller/channel.go
+++ b/controller/channel.go
@@ -68,6 +68,61 @@ func clearChannelInfo(channel *model.Channel) {
 	}
 }
 
+// bestEffortSyncCodexPlanType refreshes the in-memory Codex plan type derived from the stored key payload.
+func bestEffortSyncCodexPlanType(channel *model.Channel, rawKey string) {
+	if channel == nil {
+		return
+	}
+	planType := ""
+	if channel.Type == constant.ChannelTypeCodex {
+		planType, _ = service.ExtractCodexPlanTypeFromOAuthKey(rawKey)
+	}
+	otherInfo, err := service.MergeCodexPlanTypeIntoOtherInfo(channel.OtherInfo, planType)
+	if err != nil {
+		common.SysError(fmt.Sprintf("failed to sync codex plan type for channel %d: %v", channel.Id, err))
+		return
+	}
+	channel.OtherInfo = otherInfo
+}
+
+// attachCodexPlanTypeForDisplay fills missing Codex plan types on channel rows before they are returned to the UI.
+func attachCodexPlanTypeForDisplay(channels []*model.Channel) {
+	if len(channels) == 0 {
+		return
+	}
+
+	type channelKeyRow struct {
+		Id  int
+		Key string
+	}
+
+	targets := make(map[int]*model.Channel)
+	ids := make([]int, 0)
+	for _, channel := range channels {
+		if channel == nil || channel.Type != constant.ChannelTypeCodex {
+			continue
+		}
+		if _, ok := service.ExtractCodexPlanTypeFromOtherInfo(channel.OtherInfo); ok {
+			continue
+		}
+		targets[channel.Id] = channel
+		ids = append(ids, channel.Id)
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	rows := make([]channelKeyRow, 0, len(ids))
+	if err := model.DB.Model(&model.Channel{}).Select("id", "key").Where("id IN ?", ids).Find(&rows).Error; err != nil {
+		common.SysError("failed to load codex channel keys for display: " + err.Error())
+		return
+	}
+	for _, row := range rows {
+		bestEffortSyncCodexPlanType(targets[row.Id], row.Key)
+	}
+}
+
+// GetAllChannels returns paged channel rows and backfills Codex plan types for display.
 func GetAllChannels(c *gin.Context) {
 	pageInfo := common.GetPageQuery(c)
 	channelData := make([]*model.Channel, 0)
@@ -143,6 +198,8 @@ func GetAllChannels(c *gin.Context) {
 			return
 		}
 	}
+
+	attachCodexPlanTypeForDisplay(channelData)
 
 	for _, datum := range channelData {
 		clearChannelInfo(datum)
@@ -245,6 +302,7 @@ func FixChannelsAbilities(c *gin.Context) {
 	})
 }
 
+// SearchChannels searches channels and backfills Codex plan types on the paged result set.
 func SearchChannels(c *gin.Context) {
 	keyword := c.Query("keyword")
 	group := c.Query("group")
@@ -342,6 +400,8 @@ func SearchChannels(c *gin.Context) {
 
 	pagedData := channelData[startIdx:endIdx]
 
+	attachCodexPlanTypeForDisplay(pagedData)
+
 	for _, datum := range pagedData {
 		clearChannelInfo(datum)
 	}
@@ -358,6 +418,7 @@ func SearchChannels(c *gin.Context) {
 	return
 }
 
+// GetChannel returns a single channel and ensures Codex plan type metadata is ready for display.
 func GetChannel(c *gin.Context) {
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -370,6 +431,7 @@ func GetChannel(c *gin.Context) {
 		return
 	}
 	if channel != nil {
+		attachCodexPlanTypeForDisplay([]*model.Channel{channel})
 		clearChannelInfo(channel)
 	}
 	c.JSON(http.StatusOK, gin.H{
@@ -492,6 +554,7 @@ func validateChannel(channel *model.Channel, isAdd bool) error {
 	return nil
 }
 
+// RefreshCodexChannelCredential refreshes the stored Codex OAuth credential for a channel.
 func RefreshCodexChannelCredential(c *gin.Context) {
 	channelId, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -517,6 +580,7 @@ func RefreshCodexChannelCredential(c *gin.Context) {
 			"last_refresh": oauthKey.LastRefresh,
 			"account_id":   oauthKey.AccountID,
 			"email":        oauthKey.Email,
+			"plan_type":    oauthKey.PlanType,
 			"channel_id":   ch.Id,
 			"channel_type": ch.Type,
 			"channel_name": ch.Name,
@@ -563,6 +627,7 @@ func getVertexArrayKeys(keys string) ([]string, error) {
 	return cleanKeys, nil
 }
 
+// AddChannel creates channels and derives Codex plan type metadata from newly provided OAuth keys.
 func AddChannel(c *gin.Context) {
 	addChannelRequest := AddChannelRequest{}
 	err := c.ShouldBindJSON(&addChannelRequest)
@@ -648,6 +713,7 @@ func AddChannel(c *gin.Context) {
 			}
 			localChannel.Name = fmt.Sprintf("%s %s", localChannel.Name, keyPrefix)
 		}
+		bestEffortSyncCodexPlanType(localChannel, localChannel.Key)
 		channels = append(channels, *localChannel)
 	}
 	err = model.BatchInsertChannels(channels)
@@ -839,6 +905,7 @@ type PatchChannel struct {
 	KeyMode      *string `json:"key_mode"` // 多key模式下密钥覆盖或者追加
 }
 
+// UpdateChannel updates a channel while preserving and resyncing Codex plan type metadata when needed.
 func UpdateChannel(c *gin.Context) {
 	channel := PatchChannel{}
 	err := c.ShouldBindJSON(&channel)
@@ -867,6 +934,9 @@ func UpdateChannel(c *gin.Context) {
 
 	// Always copy the original ChannelInfo so that fields like IsMultiKey and MultiKeySize are retained.
 	channel.ChannelInfo = originChannel.ChannelInfo
+	if strings.TrimSpace(channel.OtherInfo) == "" {
+		channel.OtherInfo = originChannel.OtherInfo
+	}
 
 	// If the request explicitly specifies a new MultiKeyMode, apply it on top of the original info.
 	if channel.MultiKeyMode != nil && *channel.MultiKeyMode != "" {
@@ -953,6 +1023,11 @@ func UpdateChannel(c *gin.Context) {
 			// 覆盖模式：直接使用新密钥（默认行为，不需要特殊处理）
 		}
 	}
+	rawKey := channel.Key
+	if strings.TrimSpace(rawKey) == "" {
+		rawKey = originChannel.Key
+	}
+	bestEffortSyncCodexPlanType(&channel.Channel, rawKey)
 	err = channel.Update()
 	if err != nil {
 		common.ApiError(c, err)

--- a/controller/codex_oauth.go
+++ b/controller/codex_oauth.go
@@ -123,6 +123,7 @@ func CompleteCodexOAuthForChannel(c *gin.Context) {
 	completeCodexOAuthWithChannelID(c, channelID)
 }
 
+// completeCodexOAuthWithChannelID finalizes a Codex OAuth flow and optionally writes the refreshed key back to a channel.
 func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	req := codexOAuthCompleteRequest{}
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -146,21 +147,22 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	}
 
 	channelProxy := ""
+	var channel *model.Channel
 	if channelID > 0 {
-		ch, err := model.GetChannelById(channelID, false)
+		channel, err = model.GetChannelById(channelID, false)
 		if err != nil {
 			common.ApiError(c, err)
 			return
 		}
-		if ch == nil {
+		if channel == nil {
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel not found"})
 			return
 		}
-		if ch.Type != constant.ChannelTypeCodex {
+		if channel.Type != constant.ChannelTypeCodex {
 			c.JSON(http.StatusOK, gin.H{"success": false, "message": "channel type is not Codex"})
 			return
 		}
-		channelProxy = ch.GetSetting().Proxy
+		channelProxy = channel.GetSetting().Proxy
 	}
 
 	session := sessions.Default(c)
@@ -193,12 +195,14 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	email, _ := service.ExtractEmailFromJWT(tokenRes.AccessToken)
 
 	key := codex.OAuthKey{
+		IDToken:      tokenRes.IDToken,
 		AccessToken:  tokenRes.AccessToken,
 		RefreshToken: tokenRes.RefreshToken,
 		AccountID:    accountID,
 		LastRefresh:  time.Now().Format(time.RFC3339),
 		Expired:      tokenRes.ExpiresAt.Format(time.RFC3339),
 		Email:        email,
+		PlanType:     tokenRes.PlanType,
 		Type:         "codex",
 	}
 	encoded, err := common.Marshal(key)
@@ -213,7 +217,15 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 	_ = session.Save()
 
 	if channelID > 0 {
-		if err := model.DB.Model(&model.Channel{}).Where("id = ?", channelID).Update("key", string(encoded)).Error; err != nil {
+		mergedOtherInfo := channel.OtherInfo
+		if otherInfo, mergeErr := service.MergeCodexPlanTypeIntoOtherInfo(channel.OtherInfo, key.PlanType); mergeErr == nil {
+			mergedOtherInfo = otherInfo
+		}
+		updates := map[string]any{
+			"key":        string(encoded),
+			"other_info": mergedOtherInfo,
+		}
+		if err := model.DB.Model(&model.Channel{}).Where("id = ?", channelID).Updates(updates).Error; err != nil {
 			common.ApiError(c, err)
 			return
 		}
@@ -226,6 +238,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 				"channel_id":   channelID,
 				"account_id":   accountID,
 				"email":        email,
+				"plan_type":    key.PlanType,
 				"expires_at":   key.Expired,
 				"last_refresh": key.LastRefresh,
 			},
@@ -240,6 +253,7 @@ func completeCodexOAuthWithChannelID(c *gin.Context, channelID int) {
 			"key":          string(encoded),
 			"account_id":   accountID,
 			"email":        email,
+			"plan_type":    key.PlanType,
 			"expires_at":   key.Expired,
 			"last_refresh": key.LastRefresh,
 		},

--- a/controller/codex_usage.go
+++ b/controller/codex_usage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// GetCodexChannelUsage returns Codex usage data and opportunistically persists refreshed OAuth metadata.
 func GetCodexChannelUsage(c *gin.Context) {
 	channelId, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
@@ -85,13 +86,28 @@ func GetCodexChannelUsage(c *gin.Context) {
 			oauthKey.RefreshToken = res.RefreshToken
 			oauthKey.LastRefresh = time.Now().Format(time.RFC3339)
 			oauthKey.Expired = res.ExpiresAt.Format(time.RFC3339)
+			if strings.TrimSpace(res.IDToken) != "" {
+				oauthKey.IDToken = strings.TrimSpace(res.IDToken)
+			}
+			if strings.TrimSpace(res.PlanType) != "" {
+				oauthKey.PlanType = strings.TrimSpace(res.PlanType)
+			}
 			if strings.TrimSpace(oauthKey.Type) == "" {
 				oauthKey.Type = "codex"
 			}
 
 			encoded, encErr := common.Marshal(oauthKey)
 			if encErr == nil {
-				_ = model.DB.Model(&model.Channel{}).Where("id = ?", ch.Id).Update("key", string(encoded)).Error
+				updates := map[string]any{
+					"key": string(encoded),
+				}
+				if otherInfo, mergeErr := service.MergeCodexPlanTypeIntoOtherInfo(ch.OtherInfo, oauthKey.PlanType); mergeErr == nil {
+					ch.OtherInfo = otherInfo
+					updates["other_info"] = otherInfo
+				}
+				if err := model.DB.Model(&model.Channel{}).Where("id = ?", ch.Id).Updates(updates).Error; err != nil {
+					common.SysLog(fmt.Sprintf("failed to persist refreshed codex oauth metadata: channel_id=%d, error=%v", ch.Id, err))
+				}
 				model.InitChannelCache()
 				service.ResetProxyClientCache()
 			}

--- a/relay/channel/codex/oauth_key.go
+++ b/relay/channel/codex/oauth_key.go
@@ -2,10 +2,12 @@ package codex
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/QuantumNous/new-api/common"
 )
 
+// OAuthKey is the serialized Codex OAuth credential payload stored in channel keys.
 type OAuthKey struct {
 	IDToken      string `json:"id_token,omitempty"`
 	AccessToken  string `json:"access_token,omitempty"`
@@ -14,12 +16,14 @@ type OAuthKey struct {
 	AccountID   string `json:"account_id,omitempty"`
 	LastRefresh string `json:"last_refresh,omitempty"`
 	Email       string `json:"email,omitempty"`
+	PlanType    string `json:"plan_type,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Expired     string `json:"expired,omitempty"`
 }
 
+// ParseOAuthKey parses a serialized Codex OAuth key payload.
 func ParseOAuthKey(raw string) (*OAuthKey, error) {
-	if raw == "" {
+	if strings.TrimSpace(raw) == "" {
 		return nil, errors.New("codex channel: empty oauth key")
 	}
 	var key OAuthKey

--- a/service/codex_credential_refresh.go
+++ b/service/codex_credential_refresh.go
@@ -12,10 +12,12 @@ import (
 	"github.com/QuantumNous/new-api/model"
 )
 
+// CodexCredentialRefreshOptions controls cache invalidation after credential refresh.
 type CodexCredentialRefreshOptions struct {
 	ResetCaches bool
 }
 
+// CodexOAuthKey is the persisted Codex OAuth credential payload stored on a channel.
 type CodexOAuthKey struct {
 	IDToken      string `json:"id_token,omitempty"`
 	AccessToken  string `json:"access_token,omitempty"`
@@ -24,10 +26,12 @@ type CodexOAuthKey struct {
 	AccountID   string `json:"account_id,omitempty"`
 	LastRefresh string `json:"last_refresh,omitempty"`
 	Email       string `json:"email,omitempty"`
+	PlanType    string `json:"plan_type,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Expired     string `json:"expired,omitempty"`
 }
 
+// parseCodexOAuthKey parses the stored Codex channel key payload into a typed struct.
 func parseCodexOAuthKey(raw string) (*CodexOAuthKey, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, errors.New("codex channel: empty oauth key")
@@ -39,6 +43,7 @@ func parseCodexOAuthKey(raw string) (*CodexOAuthKey, error) {
 	return &key, nil
 }
 
+// RefreshCodexChannelCredential refreshes a Codex channel token and keeps its derived metadata in sync.
 func RefreshCodexChannelCredential(ctx context.Context, channelID int, opts CodexCredentialRefreshOptions) (*CodexOAuthKey, *model.Channel, error) {
 	ch, err := model.GetChannelById(channelID, true)
 	if err != nil {
@@ -71,6 +76,12 @@ func RefreshCodexChannelCredential(ctx context.Context, channelID int, opts Code
 	oauthKey.RefreshToken = res.RefreshToken
 	oauthKey.LastRefresh = time.Now().Format(time.RFC3339)
 	oauthKey.Expired = res.ExpiresAt.Format(time.RFC3339)
+	if strings.TrimSpace(res.IDToken) != "" {
+		oauthKey.IDToken = strings.TrimSpace(res.IDToken)
+	}
+	if strings.TrimSpace(res.PlanType) != "" {
+		oauthKey.PlanType = strings.TrimSpace(res.PlanType)
+	}
 	if strings.TrimSpace(oauthKey.Type) == "" {
 		oauthKey.Type = "codex"
 	}
@@ -85,13 +96,26 @@ func RefreshCodexChannelCredential(ctx context.Context, channelID int, opts Code
 			oauthKey.Email = email
 		}
 	}
+	if strings.TrimSpace(oauthKey.PlanType) == "" {
+		if planType, ok := ExtractCodexPlanTypeFromOAuthKey(ch.Key); ok {
+			oauthKey.PlanType = planType
+		}
+	}
 
 	encoded, err := common.Marshal(oauthKey)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	if err := model.DB.Model(&model.Channel{}).Where("id = ?", ch.Id).Update("key", string(encoded)).Error; err != nil {
+	if otherInfo, err := MergeCodexPlanTypeIntoOtherInfo(ch.OtherInfo, oauthKey.PlanType); err == nil {
+		ch.OtherInfo = otherInfo
+	}
+
+	updates := map[string]any{
+		"key":        string(encoded),
+		"other_info": ch.OtherInfo,
+	}
+	if err := model.DB.Model(&model.Channel{}).Where("id = ?", ch.Id).Updates(updates).Error; err != nil {
 		return nil, nil, err
 	}
 

--- a/service/codex_oauth.go
+++ b/service/codex_oauth.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -23,15 +22,20 @@ const (
 	codexOAuthRedirectURI  = "http://localhost:1455/auth/callback"
 	codexOAuthScope        = "openid profile email offline_access"
 	codexJWTClaimPath      = "https://api.openai.com/auth"
+	codexPlanTypeInfoKey   = "codex_plan_type"
 	defaultHTTPTimeout     = 20 * time.Second
 )
 
+// CodexOAuthTokenResult carries the tokens returned by the Codex OAuth endpoints.
 type CodexOAuthTokenResult struct {
 	AccessToken  string
 	RefreshToken string
+	IDToken      string
 	ExpiresAt    time.Time
+	PlanType     string
 }
 
+// CodexOAuthAuthorizationFlow contains the PKCE parameters needed to start a Codex OAuth login.
 type CodexOAuthAuthorizationFlow struct {
 	State        string
 	Verifier     string
@@ -39,10 +43,12 @@ type CodexOAuthAuthorizationFlow struct {
 	AuthorizeURL string
 }
 
+// RefreshCodexOAuthToken refreshes a Codex OAuth token without a channel-specific proxy override.
 func RefreshCodexOAuthToken(ctx context.Context, refreshToken string) (*CodexOAuthTokenResult, error) {
 	return RefreshCodexOAuthTokenWithProxy(ctx, refreshToken, "")
 }
 
+// RefreshCodexOAuthTokenWithProxy refreshes a Codex OAuth token using an optional proxy URL.
 func RefreshCodexOAuthTokenWithProxy(ctx context.Context, refreshToken string, proxyURL string) (*CodexOAuthTokenResult, error) {
 	client, err := getCodexOAuthHTTPClient(proxyURL)
 	if err != nil {
@@ -51,10 +57,12 @@ func RefreshCodexOAuthTokenWithProxy(ctx context.Context, refreshToken string, p
 	return refreshCodexOAuthToken(ctx, client, codexOAuthTokenURL, codexOAuthClientID, refreshToken)
 }
 
+// ExchangeCodexAuthorizationCode exchanges a Codex authorization code without a proxy override.
 func ExchangeCodexAuthorizationCode(ctx context.Context, code string, verifier string) (*CodexOAuthTokenResult, error) {
 	return ExchangeCodexAuthorizationCodeWithProxy(ctx, code, verifier, "")
 }
 
+// ExchangeCodexAuthorizationCodeWithProxy exchanges a Codex authorization code using an optional proxy URL.
 func ExchangeCodexAuthorizationCodeWithProxy(ctx context.Context, code string, verifier string, proxyURL string) (*CodexOAuthTokenResult, error) {
 	client, err := getCodexOAuthHTTPClient(proxyURL)
 	if err != nil {
@@ -63,6 +71,7 @@ func ExchangeCodexAuthorizationCodeWithProxy(ctx context.Context, code string, v
 	return exchangeCodexAuthorizationCode(ctx, client, codexOAuthTokenURL, codexOAuthClientID, code, verifier, codexOAuthRedirectURI)
 }
 
+// CreateCodexOAuthAuthorizationFlow creates the PKCE state and authorize URL for a Codex login attempt.
 func CreateCodexOAuthAuthorizationFlow() (*CodexOAuthAuthorizationFlow, error) {
 	state, err := createStateHex(16)
 	if err != nil {
@@ -84,6 +93,7 @@ func CreateCodexOAuthAuthorizationFlow() (*CodexOAuthAuthorizationFlow, error) {
 	}, nil
 }
 
+// refreshCodexOAuthToken performs the OAuth refresh request and derives plan metadata from the response tokens.
 func refreshCodexOAuthToken(
 	ctx context.Context,
 	client *http.Client,
@@ -117,6 +127,7 @@ func refreshCodexOAuthToken(
 	var payload struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
 		ExpiresIn    int    `json:"expires_in"`
 	}
 
@@ -131,13 +142,17 @@ func refreshCodexOAuthToken(
 		return nil, errors.New("codex oauth refresh response missing fields")
 	}
 
-	return &CodexOAuthTokenResult{
+	result := &CodexOAuthTokenResult{
 		AccessToken:  strings.TrimSpace(payload.AccessToken),
 		RefreshToken: strings.TrimSpace(payload.RefreshToken),
+		IDToken:      strings.TrimSpace(payload.IDToken),
 		ExpiresAt:    time.Now().Add(time.Duration(payload.ExpiresIn) * time.Second),
-	}, nil
+	}
+	result.PlanType = extractCodexPlanTypeFromTokens(result.IDToken, result.AccessToken)
+	return result, nil
 }
 
+// exchangeCodexAuthorizationCode performs the authorization-code exchange and derives plan metadata from the response tokens.
 func exchangeCodexAuthorizationCode(
 	ctx context.Context,
 	client *http.Client,
@@ -179,6 +194,7 @@ func exchangeCodexAuthorizationCode(
 	var payload struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
 		ExpiresIn    int    `json:"expires_in"`
 	}
 	if err := common.DecodeJson(resp.Body, &payload); err != nil {
@@ -190,11 +206,14 @@ func exchangeCodexAuthorizationCode(
 	if strings.TrimSpace(payload.AccessToken) == "" || strings.TrimSpace(payload.RefreshToken) == "" || payload.ExpiresIn <= 0 {
 		return nil, errors.New("codex oauth token response missing fields")
 	}
-	return &CodexOAuthTokenResult{
+	result := &CodexOAuthTokenResult{
 		AccessToken:  strings.TrimSpace(payload.AccessToken),
 		RefreshToken: strings.TrimSpace(payload.RefreshToken),
+		IDToken:      strings.TrimSpace(payload.IDToken),
 		ExpiresAt:    time.Now().Add(time.Duration(payload.ExpiresIn) * time.Second),
-	}, nil
+	}
+	result.PlanType = extractCodexPlanTypeFromTokens(result.IDToken, result.AccessToken)
+	return result, nil
 }
 
 func getCodexOAuthHTTPClient(proxyURL string) (*http.Client, error) {
@@ -252,34 +271,21 @@ func generatePKCEPair() (verifier string, challenge string, err error) {
 	return verifier, challenge, nil
 }
 
+// ExtractCodexAccountIDFromJWT reads the Codex account id claim from a JWT payload.
 func ExtractCodexAccountIDFromJWT(token string) (string, bool) {
-	claims, ok := decodeJWTClaims(token)
-	if !ok {
-		return "", false
-	}
-	raw, ok := claims[codexJWTClaimPath]
-	if !ok {
-		return "", false
-	}
-	obj, ok := raw.(map[string]any)
-	if !ok {
-		return "", false
-	}
-	v, ok := obj["chatgpt_account_id"]
-	if !ok {
-		return "", false
-	}
-	s, ok := v.(string)
-	if !ok {
-		return "", false
-	}
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return "", false
-	}
-	return s, true
+	return extractCodexAuthClaimFromJWT(token, "chatgpt_account_id")
 }
 
+// ExtractCodexPlanTypeFromJWT reads and normalizes the Codex plan type claim from a JWT payload.
+func ExtractCodexPlanTypeFromJWT(token string) (string, bool) {
+	planType, ok := extractCodexAuthClaimFromJWT(token, "chatgpt_plan_type")
+	if !ok {
+		return "", false
+	}
+	return normalizeCodexPlanType(planType), true
+}
+
+// ExtractEmailFromJWT reads the email claim from a JWT payload.
 func ExtractEmailFromJWT(token string) (string, bool) {
 	claims, ok := decodeJWTClaims(token)
 	if !ok {
@@ -300,6 +306,80 @@ func ExtractEmailFromJWT(token string) (string, bool) {
 	return s, true
 }
 
+// ExtractCodexPlanTypeFromOAuthKey loads a serialized Codex OAuth key and returns its plan type.
+func ExtractCodexPlanTypeFromOAuthKey(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	var payload struct {
+		PlanType    string `json:"plan_type,omitempty"`
+		IDToken     string `json:"id_token,omitempty"`
+		AccessToken string `json:"access_token,omitempty"`
+	}
+	if err := common.Unmarshal([]byte(raw), &payload); err != nil {
+		return "", false
+	}
+	if planType := normalizeCodexPlanType(payload.PlanType); planType != "" {
+		return planType, true
+	}
+	planType := extractCodexPlanTypeFromTokens(payload.IDToken, payload.AccessToken)
+	return planType, planType != ""
+}
+
+// ExtractCodexPlanTypeFromOtherInfo reads the persisted Codex plan type from channel metadata.
+func ExtractCodexPlanTypeFromOtherInfo(otherInfo string) (string, bool) {
+	trimmed := strings.TrimSpace(otherInfo)
+	if trimmed == "" {
+		return "", false
+	}
+	var payload map[string]any
+	if err := common.Unmarshal([]byte(trimmed), &payload); err != nil {
+		return "", false
+	}
+	value, ok := payload[codexPlanTypeInfoKey]
+	if !ok {
+		return "", false
+	}
+	planType, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	planType = normalizeCodexPlanType(planType)
+	if planType == "" {
+		return "", false
+	}
+	return planType, true
+}
+
+// MergeCodexPlanTypeIntoOtherInfo upserts the normalized plan type into channel metadata JSON.
+func MergeCodexPlanTypeIntoOtherInfo(otherInfo string, planType string) (string, error) {
+	normalizedPlanType := normalizeCodexPlanType(planType)
+	trimmed := strings.TrimSpace(otherInfo)
+	payload := make(map[string]any)
+	if trimmed != "" {
+		if err := common.Unmarshal([]byte(trimmed), &payload); err != nil {
+			return "", err
+		}
+	}
+
+	if normalizedPlanType == "" {
+		delete(payload, codexPlanTypeInfoKey)
+	} else {
+		payload[codexPlanTypeInfoKey] = normalizedPlanType
+	}
+
+	if len(payload) == 0 {
+		return "", nil
+	}
+	encoded, err := common.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	return string(encoded), nil
+}
+
+// decodeJWTClaims decodes the payload section of a JWT without signature verification.
 func decodeJWTClaims(token string) (map[string]any, bool) {
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
@@ -310,8 +390,53 @@ func decodeJWTClaims(token string) (map[string]any, bool) {
 		return nil, false
 	}
 	var claims map[string]any
-	if err := json.Unmarshal(payloadRaw, &claims); err != nil {
+	if err := common.Unmarshal(payloadRaw, &claims); err != nil {
 		return nil, false
 	}
 	return claims, true
+}
+
+// extractCodexAuthClaimFromJWT reads a nested OpenAI auth claim from a JWT payload.
+func extractCodexAuthClaimFromJWT(token string, claim string) (string, bool) {
+	claims, ok := decodeJWTClaims(token)
+	if !ok {
+		return "", false
+	}
+	raw, ok := claims[codexJWTClaimPath]
+	if !ok {
+		return "", false
+	}
+	obj, ok := raw.(map[string]any)
+	if !ok {
+		return "", false
+	}
+	value, ok := obj[claim]
+	if !ok {
+		return "", false
+	}
+	s, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	return s, true
+}
+
+// extractCodexPlanTypeFromTokens prefers the id token and falls back to the access token for plan type detection.
+func extractCodexPlanTypeFromTokens(idToken string, accessToken string) string {
+	if planType, ok := ExtractCodexPlanTypeFromJWT(idToken); ok {
+		return planType
+	}
+	if planType, ok := ExtractCodexPlanTypeFromJWT(accessToken); ok {
+		return planType
+	}
+	return ""
+}
+
+// normalizeCodexPlanType canonicalizes plan type values for persistence and display.
+func normalizeCodexPlanType(planType string) string {
+	return strings.ToLower(strings.TrimSpace(planType))
 }

--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -52,8 +52,42 @@ import {
 import { FaRandom } from 'react-icons/fa';
 
 // Render functions
+// parseChannelOtherInfo safely parses channel metadata used by channel table helpers.
+const parseChannelOtherInfo = (otherInfo) => {
+  if (!otherInfo) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(otherInfo);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch (error) {
+    return null;
+  }
+};
+
+// getCodexPlanTypeLabel normalizes Codex plan types into stable UI labels.
+const getCodexPlanTypeLabel = (planType) => {
+  const normalized = String(planType || '')
+    .trim()
+    .toLowerCase();
+  switch (normalized) {
+    case 'plus':
+      return 'Plus';
+    case 'team':
+      return 'Team';
+    case 'chatgptpro':
+    case 'pro':
+      return 'Pro';
+    case 'free':
+      return 'Free';
+    default:
+      return String(planType || '').trim();
+  }
+};
+
 const renderType = (type, record = {}, t) => {
   const channelInfo = record?.channel_info;
+  const parsedOtherInfo = parseChannelOtherInfo(record?.other_info);
   let type2label = new Map();
   for (let i = 0; i < CHANNEL_OPTIONS.length; i++) {
     type2label[CHANNEL_OPTIONS[i].value] = CHANNEL_OPTIONS[i];
@@ -83,20 +117,29 @@ const renderType = (type, record = {}, t) => {
     </Tag>
   );
 
-  let ionetMeta = null;
-  if (record?.other_info) {
-    try {
-      const parsed = JSON.parse(record.other_info);
-      if (parsed && typeof parsed === 'object' && parsed.source === 'ionet') {
-        ionetMeta = parsed;
-      }
-    } catch (error) {
-      // ignore invalid metadata
-    }
-  }
+  const planTypeLabel = getCodexPlanTypeLabel(
+    parsedOtherInfo?.codex_plan_type,
+  );
+  const planTypeTag = planTypeLabel ? (
+    <Tag color='cyan' shape='circle' type='light'>
+      {planTypeLabel}
+    </Tag>
+  ) : null;
+
+  const ionetMeta =
+    parsedOtherInfo && parsedOtherInfo.source === 'ionet'
+      ? parsedOtherInfo
+      : null;
 
   if (!ionetMeta) {
-    return typeTag;
+    return planTypeTag ? (
+      <Space spacing={6}>
+        {typeTag}
+        {planTypeTag}
+      </Space>
+    ) : (
+      typeTag
+    );
   }
 
   const handleNavigate = (event) => {
@@ -111,6 +154,7 @@ const renderType = (type, record = {}, t) => {
   return (
     <Space spacing={6}>
       {typeTag}
+      {planTypeTag}
       <Tooltip
         content={
           <div className='max-w-xs'>


### PR DESCRIPTION
Extract Codex OAuth plan_type from OpenAI JWTs during code exchange and token refresh, then persist it to both the OAuth key JSON and channel other_info for safe list rendering without exposing channel keys.

Also backfill the plan type for existing Codex channels when loading channel records, and render a Plus/Team/Pro/Free badge after the type tag in the channel management table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Codex channels now display their plan type (Plus, Team, Pro, or Free) in channel listings and details

* **Improvements**
  * Plan type information is automatically extracted and synced from OAuth credentials during channel operations
  * Enhanced credential refresh process with improved error handling and metadata persistence
  * Optimized handling of channel metadata across all retrieval and update operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->