### PR TITLE
feat(ali): add explicit non-Qwen model support for Anthropic Messages…

### DIFF
--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -24,6 +24,27 @@ type Adaptor struct {
 	IsSyncImageModel bool
 }
 
+// https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=2949529
+// aliAnthropicExplicitModels 列出明确支持阿里云 Anthropic Messages 接口的非 Qwen 模型
+var aliAnthropicExplicitModels = map[string]struct{}{
+	"kimi-k2.5":        {},
+	"kimi-k2-thinking": {},
+	"glm-5":            {},
+	"glm-4.7":          {},
+	"glm-4.6":          {},
+	"minimax-m2.5":     {},
+	"minimax-m2.1":     {},
+}
+
+func supportsAliAnthropicMessages(modelName string) bool {
+	lower := strings.ToLower(modelName)
+	if strings.Contains(lower, "qwen") {
+		return true
+	}
+	_, ok := aliAnthropicExplicitModels[lower]
+	return ok
+}
+
 /*
 	var syncModels = []string{
 		"z-image",
@@ -31,16 +52,6 @@ type Adaptor struct {
 		"wan2.6",
 	}
 */
-func supportsAliAnthropicMessages(modelName string) bool {
-	// Only models with the "qwen" designation can use the Claude-compatible interface; others require conversion.
-	return strings.Contains(strings.ToLower(modelName), "qwen")
-}
-
-var syncModels = []string{
-	"z-image",
-	"qwen-image",
-	"wan2.6",
-}
 
 func isSyncImageModel(modelName string) bool {
 	return model_setting.IsSyncImageModel(modelName)


### PR DESCRIPTION
  📝 变更描述 / Description                                                                                                                                                          
                                                                                                                                                                                     
  supportsAliAnthropicMessages in relay/channel/ali/adaptor.go previously only matched Qwen models via substring check. Added an explicit allowlist aliAnthropicExplicitModels so    
  that kimi-k2.5, kimi-k2-thinking, glm-5, glm-4.7, glm-4.6, minimax-m2.5, and minimax-m2.1 are also routed to the Alibaba Cloud Anthropic Messages endpoint                         
  (/apps/anthropic/v1/messages). Models not in the list (e.g. glm-4.5) are unaffected.

  🚀 变更类型 / Type of change

  - ✨ 新功能 (New feature)

  🔗 关联任务 / Related Issue

  - N/A

  ✅ 提交前检查项 / Checklist

  - Human-written: This description was written by me, not raw AI output.
  - Fully understood: I understand how these changes work and their potential impact.
  - Focused scope: No unrelated code changes are included in this PR.
  - Security: No credentials exposed; code follows project conventions.