### PR TITLE
feat: Add support for counting cache-hit tokens in llama.cpp

### DIFF
--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -704,9 +704,7 @@ func extractLlamaCachedTokensFromBody(body []byte) (int, bool) {
 
 	var payload struct {
 		Timings struct {
-			Usage struct {
-				CachedTokens *int `json:"cache_n"`
-			} `json:"usage"`
+			CachedTokens *int `json:"cache_n"`
 		} `json:"timings"`
 	}
 
@@ -714,8 +712,8 @@ func extractLlamaCachedTokensFromBody(body []byte) (int, bool) {
 		return 0, false
 	}
 
-	if payload.Timings.Usage.CachedTokens == nil {
+	if payload.Timings.CachedTokens == nil {
 		return 0, false
 	}
-	return *payload.Timings.Usage.CachedTokens, true
+	return *payload.Timings.CachedTokens, true
 }


### PR DESCRIPTION
The current new-api cannot accurately count the number of tokens from llama.cpp or llama-swap backends that hit the cache, which prevents the application of caching billing rules. This PR adds the functionality to identify such cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced usage reporting to correctly capture cached token counts from responses, improving accuracy of API token metrics.
  * Improved handling when cached-token data is missing or not present in responses, making usage displays more complete and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->