### PR TITLE
fix: normalize generic oauth bearer token type

### DIFF
--- a/oauth/generic.go
+++ b/oauth/generic.go
@@ -208,10 +208,7 @@ func (p *GenericOAuthProvider) GetUserInfo(ctx context.Context, token *OAuthToke
 	}
 
 	// Set authorization header
-	tokenType := token.TokenType
-	if tokenType == "" {
-		tokenType = "Bearer"
-	}
+	tokenType := normalizeAuthorizationTokenType(token.TokenType)
 	req.Header.Set("Authorization", fmt.Sprintf("%s %s", tokenType, token.AccessToken))
 	req.Header.Set("Accept", "application/json")
 
@@ -318,6 +315,14 @@ func (p *GenericOAuthProvider) GetProviderPrefix() string {
 // GetProviderId returns the provider ID for binding purposes
 func (p *GenericOAuthProvider) GetProviderId() int {
 	return p.config.Id
+}
+
+func normalizeAuthorizationTokenType(tokenType string) string {
+	tokenType = strings.TrimSpace(tokenType)
+	if tokenType == "" || strings.EqualFold(tokenType, "Bearer") {
+		return "Bearer"
+	}
+	return tokenType
 }
 
 // IsGenericProvider returns true for generic providers


### PR DESCRIPTION
fix #3348

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OAuth authentication to reliably handle authorization headers for various token type formats, including case-insensitive Bearer tokens and whitespace variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->