### PR TITLE
feat: add GLM Coding Plan support for ZhipuV4 channel

### DIFF
--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -2984,6 +2984,7 @@ const EditChannelModal = (props) => {
                       {inputs.type !== 3 &&
                         inputs.type !== 8 &&
                         inputs.type !== 22 &&
+                        inputs.type !== 26 &&
                         inputs.type !== 36 &&
                         (inputs.type !== 45 || doubaoApiEditUnlocked) && (
                           <div>
@@ -3036,6 +3037,35 @@ const EditChannelModal = (props) => {
                               handleInputChange('base_url', value)
                             }
                             showClear
+                            disabled={isIonetLocked}
+                          />
+                        </div>
+                      )}
+
+                      {inputs.type === 26 && (
+                        <div>
+                          <Form.Select
+                            field='base_url'
+                            label={t('API地址')}
+                            placeholder={t('请选择API地址')}
+                            onChange={(value) =>
+                              handleInputChange('base_url', value)
+                            }
+                            optionList={[
+                              {
+                                value: 'https://open.bigmodel.cn',
+                                label: 'https://open.bigmodel.cn (标准)',
+                              },
+                              {
+                                value: 'glm-coding-plan',
+                                label: 'GLM Coding Plan (国内)',
+                              },
+                              {
+                                value: 'glm-coding-plan-international',
+                                label: 'GLM Coding Plan (国际)',
+                              },
+                            ]}
+                            defaultValue='https://open.bigmodel.cn'
                             disabled={isIonetLocked}
                           />
                         </div>


### PR DESCRIPTION
## Summary
- Add dropdown selector for ZhipuV4 (type 26) channel base_url
- Options include:
  - Standard: https://open.bigmodel.cn
  - GLM Coding Plan (China): glm-coding-plan
  - GLM Coding Plan (International): glm-coding-plan-international

## Motivation
智谱 GLM Coding Plan 是智谱提供的特殊套餐服务，使用不同的 API 端点：
- 国内: https://open.bigmodel.cn/api/coding/paas/v4/chat/completions
- 国际: https://api.z.ai/api/coding/paas/v4/chat/completions

当前用户需要手动输入完整的 Coding Plan URL，容易出错。此 PR 添加了下拉选择器，方便用户快速选择正确的端点。

## Backend Support
后端支持已存在于 constant/channel.go：
```go
"glm-coding-plan": {
    ClaudeBaseURL: "https://open.bigmodel.cn/api/anthropic",
    OpenAIBaseURL: "https://open.bigmodel.cn/api/coding/paas/v4",
},
"glm-coding-plan-international": {
    ClaudeBaseURL: "https://api.z.ai/api/anthropic",
    OpenAIBaseURL: "https://api.z.ai/api/coding/paas/v4",
},
```

## Test Plan
- [ ] 创建 ZhipuV4 渠道，验证下拉选项显示正确
- [ ] 选择 Coding Plan 选项，验证 API 调用正确路由
- [ ] 测试国内和国际两个 Coding Plan 端点

## Screenshots
前端修改后的下拉选项：
- https://open.bigmodel.cn (标准)
- GLM Coding Plan (国内)
- GLM Coding Plan (国际)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced API address configuration with a new dropdown selector offering predefined options for faster setup.
  * Applied intelligent default selection to streamline initial configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->