### PR TITLE
feat: add desktop horizontal scroll for wide card tables

### DIFF
--- a/web/src/components/common/ui/CardTable.jsx
+++ b/web/src/components/common/ui/CardTable.jsx
@@ -63,6 +63,12 @@ const CardTable = ({
       : tableProps;
     const horizontalScrollWidth = finalTableProps?.scroll?.x;
     const hasHorizontalScroll = Boolean(horizontalScrollWidth);
+    const {
+      className: desktopScrollClassName,
+      style: desktopScrollStyle,
+      id: desktopScrollId,
+      ...tableOnlyProps
+    } = finalTableProps;
     const desktopScrollInnerStyle = hasHorizontalScroll
       ? {
           minWidth: '100%',
@@ -78,7 +84,7 @@ const CardTable = ({
         dataSource={dataSource}
         loading={loading}
         rowKey={rowKey}
-        {...finalTableProps}
+        {...(hasHorizontalScroll ? tableOnlyProps : finalTableProps)}
       />
     );
 
@@ -87,7 +93,13 @@ const CardTable = ({
     }
 
     return (
-      <div className='card-table-desktop-scroll'>
+      <div
+        id={desktopScrollId}
+        className={['card-table-desktop-scroll', desktopScrollClassName]
+          .filter(Boolean)
+          .join(' ')}
+        style={desktopScrollStyle}
+      >
         <div
           className='card-table-desktop-scroll-inner'
           style={desktopScrollInnerStyle}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -25,8 +25,8 @@ body.sidebar-collapsed {
 }
 
 body {
-  font-family:
-    Lato, 'Helvetica Neue', Arial, Helvetica, 'Microsoft YaHei', sans-serif;
+  font-family: Lato, 'Helvetica Neue', Arial, Helvetica, 'Microsoft YaHei',
+    sans-serif;
   color: var(--semi-color-text-0);
   background-color: var(--semi-color-bg-0);
 }
@@ -49,8 +49,8 @@ body {
 }
 
 code {
-  font-family:
-    source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
+    monospace;
 }
 
 /* ==================== 布局相关样式 ==================== */
@@ -809,8 +809,11 @@ html:not(.dark) .blur-ball-teal {
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background:
-    radial-gradient(circle at -5% -10%, var(--pb1) 0%, transparent 60%),
+  background: radial-gradient(
+      circle at -5% -10%,
+      var(--pb1) 0%,
+      transparent 60%
+    ),
     radial-gradient(circle at 105% -10%, var(--pb2) 0%, transparent 55%),
     radial-gradient(circle at 5% 110%, var(--pb3) 0%, transparent 55%),
     radial-gradient(circle at 105% 110%, var(--pb4) 0%, transparent 50%);
@@ -857,6 +860,12 @@ html.dark .with-pastel-balls::before {
   overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--semi-grey-2), 0.3) transparent;
+}
+
+.card-table-desktop-scroll:hover {
+  scrollbar-color: rgba(var(--semi-grey-2), 0.5) transparent;
 }
 
 .card-table-desktop-scroll-inner {


### PR DESCRIPTION
## 📝 变更描述 / Description
- 为使用 `CardTable` 的桌面端宽表补上真正可拖动的横向滚动容器。
- 仅在显式声明 `scroll.x` 且为桌面端时启用，不影响未声明横向滚动的表格。
- 不改单页列定义与分页逻辑，只补齐缺失的滚动承载层与滚动条样式。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- 无

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自撰写此描述，去除了 AI 原始输出的冗余。
- [x] **深度理解:** 我已完全理解这些更改的工作原理及潜在影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过了测试或手动验证。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- `cd web && bunx prettier src/components/common/ui/CardTable.jsx src/index.css --write`
- `cd web && PATH=./node_modules/.bin:$PATH eslint src/components/common/ui/CardTable.jsx`
- `cd web && PATH=./node_modules/.bin:$PATH vite build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tables now support horizontal scrolling on desktop when content exceeds available width.

* **Style**
  * Enhanced scrollbar styling with improved visual consistency across browsers and hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->