### PR TITLE
fix: the "detail" field is empty, an empty field was sent to upstream

### DIFF
--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -393,7 +393,7 @@ func (m *MediaContent) GetVideoUrl() *MessageVideoUrl {
 
 type MessageImageUrl struct {
 	Url      string `json:"url"`
-	Detail   string `json:"detail"`
+	Detail   string `json:"detail,omitempty"`
 	MimeType string
 }
 


### PR DESCRIPTION
#3255 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API efficiency by omitting empty detail fields in image URL requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->