### PR TITLE
fix(dashboard): 修复消耗分布图表悬浮时滚动条闪烁

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -31,6 +31,13 @@ body {
   background-color: var(--semi-color-bg-0);
 }
 
+/* 桌面端禁止 body 纵向滚动 - 防止 VChart tooltip 触发页面滚动条 */
+@media (min-width: 768px) {
+  body {
+    overflow-y: hidden;
+  }
+}
+
 .app-layout {
   height: 100vh;
   height: 100dvh;


### PR DESCRIPTION
### 问题

在数据看板「模型数据分析 → 消耗分布」标签页，鼠标在柱状图上左右移动时，页面右侧滚动条会突然出现又突然消失，产生闪烁现象。

### 根因

VChart 的 HTML 模式 tooltip 以 `position: absolute` 的 DOM 元素挂载在 `document.body` 上。当 tooltip 被定位到靠近页面底部边缘时，会扩展 `body` 的可滚动区域，导致浏览器短暂显示滚动条；tooltip 消失后滚动条又随之消失，形成闪烁。

### 修复方案

在桌面端（`≥768px`）为 `body` 添加 `overflow-y: hidden`。

因为桌面端应用布局已使用 `height: 100vh` + 内部 `Layout` 组件的 `overflow: auto` 来管理页面滚动，`body` 本身不需要纵向滚动能力。通过阻止 `body` 层级的滚动，tooltip 的 DOM 元素不再触发页面级滚动条。

使用 `@media (min-width: 768px)` 媒体查询限定范围，确保移动端（`<768px`）不受影响，因为移动端依赖 `body` 进行页面滚动。

### 改动文件

| 文件 | 改动 |
|------|------|
| `web/src/index.css` | 添加桌面端 `body { overflow-y: hidden }` 媒体查询规则 |

### Diff

```css
+/* 桌面端禁止 body 纵向滚动 - 防止 VChart tooltip 触发页面滚动条 */
+@media (min-width: 768px) {
+  body {
+    overflow-y: hidden;
+  }
+}
```

### 测试验证

- [x] 桌面端悬浮柱状图时不再出现滚动条闪烁
- [x] tooltip 内容正常显示（所有模型明细 + 总计）
- [x] 其他标签页（消耗趋势、调用次数分布、调用次数排行）tooltip 正常
- [x] 移动端页面滚动不受影响


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Vertical scrolling is now disabled on larger screens and desktop devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->