### PR TITLE
feat: Add Xiaomi channel support and enhance TTS functionality

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -75,6 +75,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 		apiType = constant.APITypeReplicate
 	case constant.ChannelTypeCodex:
 		apiType = constant.APITypeCodex
+	case constant.ChannelTypeXiaomi:
+		apiType = constant.APITypeXiaomi
 	}
 	if apiType == -1 {
 		return constant.APITypeOpenAI, false

--- a/constant/api_type.go
+++ b/constant/api_type.go
@@ -36,5 +36,6 @@ const (
 	APITypeMiniMax
 	APITypeReplicate
 	APITypeCodex
+	APITypeXiaomi
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -55,6 +55,7 @@ const (
 	ChannelTypeSora           = 55
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
+	ChannelTypeXiaomi         = 58
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -118,6 +119,7 @@ var ChannelBaseURLs = []string{
 	"https://api.openai.com",                    //55
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
+	"https://api.xiaomimimo.com",                //58
 }
 
 var ChannelTypeNames = map[int]string{
@@ -175,6 +177,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSora:           "Sora",
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "Codex",
+	ChannelTypeXiaomi:         "Xiaomi",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/dto/openai_audio_response_test.go
+++ b/dto/openai_audio_response_test.go
@@ -1,0 +1,44 @@
+package dto
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAITextResponsePreservesMessageAudio(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"id":"chatcmpl-audio",
+		"object":"chat.completion",
+		"created":1,
+		"model":"mimo-v2.5-tts",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":null,
+				"audio":{"id":"audio_123","data":"QUJD","expires_at":123,"transcript":"ABC"}
+			},
+			"finish_reason":"stop"
+		}],
+		"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}
+	}`)
+
+	var resp OpenAITextResponse
+	require.NoError(t, common.Unmarshal(body, &resp))
+	require.JSONEq(t, `{"id":"audio_123","data":"QUJD","expires_at":123,"transcript":"ABC"}`, string(resp.Choices[0].Message.Audio))
+
+	encoded, err := common.Marshal(resp)
+	require.NoError(t, err)
+
+	var roundTrip map[string]any
+	require.NoError(t, common.Unmarshal(encoded, &roundTrip))
+	choice := roundTrip["choices"].([]any)[0].(map[string]any)
+	message := choice["message"].(map[string]any)
+	audio := message["audio"].(map[string]any)
+	require.Equal(t, "QUJD", audio["data"])
+	require.Equal(t, "ABC", audio["transcript"])
+}

--- a/dto/openai_request.go
+++ b/dto/openai_request.go
@@ -277,6 +277,7 @@ func (r *GeneralOpenAIRequest) ParseInput() []string {
 type Message struct {
 	Role             string          `json:"role"`
 	Content          any             `json:"content"`
+	Audio            json.RawMessage `json:"audio,omitempty"`
 	Name             *string         `json:"name,omitempty"`
 	Prefix           *bool           `json:"prefix,omitempty"`
 	ReasoningContent string          `json:"reasoning_content,omitempty"`

--- a/model/pricing_default.go
+++ b/model/pricing_default.go
@@ -19,6 +19,7 @@ var defaultVendorRules = map[string]string{
 	"glm-":     "智谱",
 	"qwen":     "阿里巴巴",
 	"deepseek": "DeepSeek",
+	"mimo":     "小米",
 	"abab":     "MiniMax",
 	"ernie":    "百度",
 	"spark":    "讯飞",

--- a/relay/channel/xiaomi/adaptor.go
+++ b/relay/channel/xiaomi/adaptor.go
@@ -1,0 +1,162 @@
+package xiaomi
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/relay/constant"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+type Adaptor struct {
+	audioFormat string
+}
+
+type xiaomiTTSMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type xiaomiTTSAudio struct {
+	Voice  string `json:"voice,omitempty"`
+	Format string `json:"format"`
+}
+
+type xiaomiTTSRequest struct {
+	Model    string             `json:"model"`
+	Messages []xiaomiTTSMessage `json:"messages"`
+	Audio    xiaomiTTSAudio     `json:"audio"`
+}
+
+func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
+}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	return fmt.Sprintf("%s/v1/chat/completions", info.ChannelBaseUrl), nil
+}
+
+func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Header, info *relaycommon.RelayInfo) error {
+	channel.SetupApiRequestHeader(info, c, req)
+	req.Set("Authorization", "Bearer "+info.ApiKey)
+	req.Set("api-key", info.ApiKey)
+	return nil
+}
+
+func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeneralOpenAIRequest) (any, error) {
+	if request == nil {
+		return nil, errors.New("request is nil")
+	}
+	return request, nil
+}
+
+func (a *Adaptor) ConvertRerankRequest(c *gin.Context, relayMode int, request dto.RerankRequest) (any, error) {
+	return nil, nil
+}
+
+func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.EmbeddingRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertAudioRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.AudioRequest) (io.Reader, error) {
+	if info.RelayMode != constant.RelayModeAudioSpeech {
+		return nil, errors.New("unsupported audio relay mode")
+	}
+	audioFormat := normalizeMimoAudioFormat(request.ResponseFormat)
+	voice := request.Voice
+	if shouldDefaultMimoVoice(request.Model) && voice == "" {
+		voice = "mimo_default"
+	}
+	mimoReq := xiaomiTTSRequest{
+		Model:    request.Model,
+		Messages: buildMimoTTSMessages(request),
+		Audio:    xiaomiTTSAudio{Voice: voice, Format: audioFormat},
+	}
+	if isMimoVoiceDesignModel(request.Model) {
+		mimoReq.Audio.Voice = ""
+	}
+	a.audioFormat = audioFormat
+	jsonData, err := common.Marshal(mimoReq)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(jsonData), nil
+}
+
+func buildMimoTTSMessages(request dto.AudioRequest) []xiaomiTTSMessage {
+	messages := make([]xiaomiTTSMessage, 0, 2)
+	if request.Instructions != "" {
+		messages = append(messages, xiaomiTTSMessage{
+			Role:    "user",
+			Content: request.Instructions,
+		})
+	}
+	messages = append(messages, xiaomiTTSMessage{
+		Role:    "assistant",
+		Content: request.Input,
+	})
+	return messages
+}
+
+func normalizeMimoAudioFormat(format string) string {
+	switch format {
+	case "":
+		return "wav"
+	case "pcm":
+		return "pcm16"
+	default:
+		return format
+	}
+}
+
+func shouldDefaultMimoVoice(model string) bool {
+	return !isMimoVoiceDesignModel(model)
+}
+
+func isMimoVoiceDesignModel(model string) bool {
+	return model == "mimo-v2.5-tts-voicedesign"
+}
+
+func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertClaudeRequest(c *gin.Context, info *relaycommon.RelayInfo, req *dto.ClaudeRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) ConvertGeminiRequest(c *gin.Context, info *relaycommon.RelayInfo, request *dto.GeminiChatRequest) (any, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (a *Adaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (any, error) {
+	return channel.DoApiRequest(a, c, info, requestBody)
+}
+
+func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (usage any, err *types.NewAPIError) {
+	if info.RelayMode == constant.RelayModeAudioSpeech {
+		return handleTTSResponse(c, resp, info, a.audioFormat)
+	}
+	adaptor := openai.Adaptor{}
+	return adaptor.DoResponse(c, resp, info)
+}
+
+func (a *Adaptor) GetModelList() []string {
+	return ModelList
+}
+
+func (a *Adaptor) GetChannelName() string {
+	return ChannelName
+}

--- a/relay/channel/xiaomi/constants.go
+++ b/relay/channel/xiaomi/constants.go
@@ -1,0 +1,14 @@
+package xiaomi
+
+var ModelList = []string{
+	"mimo-v2-pro",
+	"mimo-v2-flash",
+	"mimo-v2-omni",
+	"mimo-v2-tts",
+	"mimo-v2.5-tts",
+	"mimo-v2.5-tts-voicedesign",
+	"mimo-v2.5-pro",
+	"mimo-v2.5",
+}
+
+var ChannelName = "xiaomi"

--- a/relay/channel/xiaomi/tts.go
+++ b/relay/channel/xiaomi/tts.go
@@ -1,0 +1,93 @@
+package xiaomi
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+)
+
+type mimoTTSResponse struct {
+	Choices []struct {
+		Message struct {
+			Audio struct {
+				Data string `json:"data"`
+			} `json:"audio"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage dto.Usage `json:"usage"`
+}
+
+func getTTSContentType(format string) string {
+	switch format {
+	case "wav":
+		return "audio/wav"
+	case "mp3":
+		return "audio/mpeg"
+	case "pcm", "pcm16":
+		return "audio/pcm"
+	case "flac":
+		return "audio/flac"
+	case "opus":
+		return "audio/opus"
+	case "aac":
+		return "audio/aac"
+	default:
+		return "audio/wav"
+	}
+}
+
+func handleTTSResponse(c *gin.Context, resp *http.Response, _ *relaycommon.RelayInfo, audioFormat string) (usage any, err *types.NewAPIError) {
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil, types.NewErrorWithStatusCode(
+			fmt.Errorf("failed to read xiaomi TTS response: %w", readErr),
+			types.ErrorCodeReadResponseBodyFailed,
+			http.StatusInternalServerError,
+		)
+	}
+
+	var mimoResp mimoTTSResponse
+	if unmarshalErr := common.Unmarshal(body, &mimoResp); unmarshalErr != nil {
+		return nil, types.NewErrorWithStatusCode(
+			fmt.Errorf("failed to unmarshal xiaomi TTS response: %w", unmarshalErr),
+			types.ErrorCodeBadResponseBody,
+			http.StatusInternalServerError,
+		)
+	}
+
+	if len(mimoResp.Choices) == 0 || mimoResp.Choices[0].Message.Audio.Data == "" {
+		return nil, types.NewErrorWithStatusCode(
+			fmt.Errorf("no audio data in xiaomi TTS response"),
+			types.ErrorCodeBadResponse,
+			http.StatusBadRequest,
+		)
+	}
+
+	audioData, decodeErr := base64.StdEncoding.DecodeString(mimoResp.Choices[0].Message.Audio.Data)
+	if decodeErr != nil {
+		return nil, types.NewErrorWithStatusCode(
+			fmt.Errorf("failed to decode base64 audio data: %w", decodeErr),
+			types.ErrorCodeBadResponse,
+			http.StatusInternalServerError,
+		)
+	}
+
+	contentType := getTTSContentType(audioFormat)
+	c.Data(http.StatusOK, contentType, audioData)
+
+	usage = &dto.Usage{
+		PromptTokens:     mimoResp.Usage.PromptTokens,
+		CompletionTokens: mimoResp.Usage.CompletionTokens,
+		TotalTokens:      mimoResp.Usage.TotalTokens,
+	}
+
+	return usage, nil
+}

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -328,6 +328,7 @@ var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeMoonshot:    true,
 	constant.ChannelTypeMiniMax:     true,
 	constant.ChannelTypeSiliconFlow: true,
+	constant.ChannelTypeXiaomi:      true,
 }
 
 func GenRelayInfoWs(c *gin.Context, ws *websocket.Conn) *RelayInfo {

--- a/relay/relay_adaptor.go
+++ b/relay/relay_adaptor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/claude"
 	"github.com/QuantumNous/new-api/relay/channel/cloudflare"
 	"github.com/QuantumNous/new-api/relay/channel/codex"
+	"github.com/QuantumNous/new-api/relay/channel/xiaomi"
 	"github.com/QuantumNous/new-api/relay/channel/cohere"
 	"github.com/QuantumNous/new-api/relay/channel/coze"
 	"github.com/QuantumNous/new-api/relay/channel/deepseek"
@@ -120,6 +121,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &replicate.Adaptor{}
 	case constant.APITypeCodex:
 		return &codex.Adaptor{}
+	case constant.APITypeXiaomi:
+		return &xiaomi.Adaptor{}
 	}
 	return nil
 }

--- a/setting/ratio_setting/model_ratio.go
+++ b/setting/ratio_setting/model_ratio.go
@@ -249,6 +249,9 @@ var defaultModelRatio = map[string]float64{
 	"deepseek-chat":          0.27 / 2,
 	"deepseek-coder":         0.27 / 2,
 	"deepseek-reasoner":      0.55 / 2, // 0.55 / 1k tokens
+	"mimo-v2-pro":            0.2,
+	"mimo-v2-flash":          0.05,
+	"mimo-v2-omni":           0.5,
 	// Perplexity online 模型对搜索额外收费，有需要应自行调整，此处不计入搜索费用
 	"llama-3-sonar-small-32k-chat":   0.2 / 1000 * USD,
 	"llama-3-sonar-small-32k-online": 0.2 / 1000 * USD,

--- a/web/classic/src/constants/channel.constants.js
+++ b/web/classic/src/constants/channel.constants.js
@@ -58,6 +58,7 @@ export const CHANNEL_OPTIONS = [
   },
   { value: 39, color: 'grey', label: 'Cloudflare' },
   { value: 43, color: 'blue', label: 'DeepSeek' },
+  { value: 58, color: 'orange', label: 'Xiaomi MiMo' },
   {
     value: 15,
     color: 'blue',


### PR DESCRIPTION
添加小米渠道支持，并支持小米 tts 从 chat completion 接口到 openai tts 接口 的转换
fix #3353

测试结果 tts -> xiaomi tts chat 
<img width="1195" height="784" alt="image" src="https://github.com/user-attachments/assets/722c0825-04b9-4d37-8f96-075b19f27421" />

测试结构 chat -> xiaomi tts chat
<img width="840" height="759" alt="image" src="https://github.com/user-attachments/assets/36b91f9a-320a-4527-849d-543b65428c48" />


计费
<img width="1258" height="672" alt="image" src="https://github.com/user-attachments/assets/5f82bba0-8cac-4785-9052-ea378d9501d6" />

喜闻乐见
<img width="974" height="544" alt="image" src="https://github.com/user-attachments/assets/be97a9fc-ca39-481b-b48c-5570d5dbccd6" />
<img width="965" height="487" alt="image" src="https://github.com/user-attachments/assets/2ec984e5-999a-41b0-a34e-ed9a72ce1740" />
<img width="962" height="401" alt="image" src="https://github.com/user-attachments/assets/bb6a2b72-fcbc-4a46-a988-9fdb85c8ce35" />



This pull request adds support for the Xiaomi MiMo channel throughout the codebase, enabling Xiaomi MiMo as a new AI provider. The changes include defining new constants and configuration for Xiaomi, implementing the channel adaptor and response handling, updating pricing and model ratios, and exposing the channel in the frontend options.

**Xiaomi MiMo Channel Integration:**

* Added new channel and API type constants for Xiaomi MiMo, including `ChannelTypeXiaomi` and `APITypeXiaomi`, and updated mappings for names and base URLs. [[1]](diffhunk://#diff-ddeb53afcb4a9b4cde7805d2a66872bf21ad9ecdb922c604e1d4e42748fbddd6R58) [[2]](diffhunk://#diff-ddeb53afcb4a9b4cde7805d2a66872bf21ad9ecdb922c604e1d4e42748fbddd6R122) [[3]](diffhunk://#diff-ddeb53afcb4a9b4cde7805d2a66872bf21ad9ecdb922c604e1d4e42748fbddd6R180) [[4]](diffhunk://#diff-a5df8e649095f0bee96d87c3a7cc4937da817480b0d5a15386bf7019c98b274dR39) [[5]](diffhunk://#diff-aa6fac0218e2b7d8d8aeb349f3e32055251d633ea5d6238e51b67638db6dbaffR78-R79)
* Implemented Xiaomi MiMo channel adaptor (`adaptor.go`) and TTS response handler (`tts.go`), supporting audio requests and response decoding. [[1]](diffhunk://#diff-e6148cb781c2dc7043151ecd505680137449b2339c14aabff025d10bb4a849d9R1-R129) [[2]](diffhunk://#diff-dd2ce39846226dae99c3ba1025d7bd555a80d9cf1a06c8f87ed689d2b21320a8R1-R87)
* Added Xiaomi MiMo model list and channel name constants.
* Registered Xiaomi MiMo as a supported channel in the relay adaptor and enabled streaming support. [[1]](diffhunk://#diff-303220f2e92a58e52a0f192b4e9bbbee028d9614aa522cfa2c9d7121774d0344R15) [[2]](diffhunk://#diff-303220f2e92a58e52a0f192b4e9bbbee028d9614aa522cfa2c9d7121774d0344R124-R125) [[3]](diffhunk://#diff-8eba8613d156f9e7688842daa338914c57d16d75c9ee9646e69748c542416c7aR322)

**Pricing and Model Configuration:**

* Added Xiaomi MiMo vendor and model pricing information to default vendor rules and model ratio settings. [[1]](diffhunk://#diff-8e371f0a0ea1746a7192f92e134e89899cec259a21d7b49ec4a1632f92e58e48R22) [[2]](diffhunk://#diff-bc743daf60e914dbf3c2855cfe7abbd7572d9fb0c8292f5485a53d014ea3dee5R246-R248)

**Frontend Exposure:**

* Added Xiaomi MiMo as an option in the frontend channel selection list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Xiaomi MiMo channel integration with eight available models
  * Added text-to-speech (TTS) functionality for Xiaomi
  * Added audio payload support for chat messages
  * Xiaomi channel now available in channel selection UI

* **Bug Fixes**
  * Fixed Xiaomi channel type recognition in request routing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->