### PR TITLE
fix: prevent double-counting of image count n in billing

### DIFF
--- a/dto/openai_image.go
+++ b/dto/openai_image.go
@@ -148,15 +148,14 @@ func (i *ImageRequest) GetTokenCountMeta() *types.TokenCountMeta {
 		}
 	}
 
-	// not support token count for dalle
-	n := uint(1)
-	if i.N != nil {
-		n = *i.N
-	}
+	// n is NOT included here; it is handled via OtherRatio("n") in
+	// image_handler.go (default) or channel adaptors (actual count).
+	// Including n here caused double-counting for channels that also
+	// set OtherRatio("n") (e.g. Ali/Bailian).
 	return &types.TokenCountMeta{
 		CombineText:     i.Prompt,
 		MaxTokens:       1584,
-		ImagePriceRatio: sizeRatio * qualityRatio * float64(n),
+		ImagePriceRatio: sizeRatio * qualityRatio,
 	}
 }
 

--- a/relay/channel/ali/image.go
+++ b/relay/channel/ali/image.go
@@ -54,7 +54,6 @@ func oaiImage2AliImageRequest(info *relaycommon.RelayInfo, request dto.ImageRequ
 		}
 	}
 
-	// 检查n参数
 	if imageRequest.Parameters.N != 0 {
 		info.PriceData.AddOtherRatio("n", float64(imageRequest.Parameters.N))
 	}
@@ -328,7 +327,6 @@ func aliImageHandler(a *Adaptor, c *gin.Context, resp *http.Response, info *rela
 	}
 
 	imageResponses := responseAli2OpenAIImage(c, aliResponse, originRespBody, info, responseFormat)
-	// 可能生成多张图片，修正计费数量n
 	if aliResponse.Usage.ImageCount != 0 {
 		info.PriceData.AddOtherRatio("n", float64(aliResponse.Usage.ImageCount))
 	} else if len(imageResponses.Data) != 0 {

--- a/relay/image_handler.go
+++ b/relay/image_handler.go
@@ -117,11 +117,20 @@ func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *type
 	if request.N != nil {
 		imageN = *request.N
 	}
+
+	// n is handled via OtherRatio so it is applied exactly once in quota
+	// calculation (both price-based and ratio-based paths).
+	// Adaptors may have already set a more accurate count from the
+	// upstream response; only set the default when they haven't.
+	if _, hasN := info.PriceData.OtherRatios["n"]; !hasN {
+		info.PriceData.AddOtherRatio("n", float64(imageN))
+	}
+
 	if usage.(*dto.Usage).TotalTokens == 0 {
-		usage.(*dto.Usage).TotalTokens = int(imageN)
+		usage.(*dto.Usage).TotalTokens = 1
 	}
 	if usage.(*dto.Usage).PromptTokens == 0 {
-		usage.(*dto.Usage).PromptTokens = int(imageN)
+		usage.(*dto.Usage).PromptTokens = 1
 	}
 
 	quality := "standard"


### PR DESCRIPTION
## Summary

Fix double-counting of image count `n` in billing for channels that set `OtherRatio("n")` (e.g. Ali/Bailian qwen-image-2.0 series).

Supersedes #3512 — the original PR simply commented out `AddOtherRatio("n")` in the Ali adaptor, which fixes double-counting but introduces a billing evasion risk (users could specify a large `n` via `extra["parameters"]` while `request.N` stays at 1).

### Problem

The image count `n` was applied **twice** in quota calculation:

1. `ImagePriceRatio` in `GetTokenCountMeta()` included `n`, which multiplied `modelPrice` by `n` in `ModelPriceHelper` (price billing), and `promptTokens` was set to `n` in `ImageHelper` (ratio billing).
2. Channel adaptors (e.g. Ali) added `OtherRatio("n")`, which multiplied the quota again in `calculateTextQuotaSummary`.

This resulted in **n² billing** instead of n. For example with `n=3` and base price `$0.2`:
- **Before**: model price = `$0.2 × 3 = $0.6`, then `× OtherRatio(3)` → charged 9× base
- **After**: model price = `$0.2`, then `× OtherRatio(3)` → charged 3× base ✓

### Changes

- **`dto/openai_image.go`**: Remove `n` from `ImagePriceRatio` in `GetTokenCountMeta()`. Keep only `sizeRatio * qualityRatio` (DALL-E size/quality adjustments).
- **`relay/image_handler.go`**: Set fallback tokens to `1` (base unit) instead of `imageN`. Add default `OtherRatio("n", imageN)` only when the adaptor hasn't already set one — ensures `n` is applied exactly once across all billing paths.
- **`relay/channel/ali/image.go`**: Keep `AddOtherRatio("n")` intact (minor comment cleanup only). The Ali adaptor uses actual upstream parameters/response count, which prevents billing evasion via `extra["parameters"]`.

## Test plan

- [ ] Test Ali/Bailian qwen-image-2.0 with `n=3`: verify model price shows base price (e.g. `$0.2`), not `$0.2 × n`
- [ ] Test DALL-E models with various sizes/qualities/n: verify billing unchanged
- [ ] Test Ali image with `n` specified via `extra["parameters"]`: verify billing uses actual parameter count
- [ ] Test ratio-based billing path for image models: verify `n` applied once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected image generation pricing calculation to prevent double-counting the number of images, ensuring accurate quota charges and billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->