### PR TITLE
fix: handle non-image media types in Claude relay to prevent nil pointer panic

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -348,8 +348,37 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 					}
 					if mediaMessage.Type == "text" {
 						claudeMediaMessage.Text = common.GetPointer[string](mediaMessage.Text)
+					} else if mediaMessage.Type == dto.ContentTypeFile {
+						// Handle file/document types (PDF, etc.)
+						file := mediaMessage.GetFile()
+						if file == nil {
+							continue
+						}
+						if file.FileId != "" {
+							// FileId-based files not yet supported for Claude direct conversion
+							continue
+						}
+						fileSource := types.NewBase64FileSource(file.FileData, "")
+						base64Data, mimeType, err := service.GetBase64Data(c, fileSource, "formatting file for Claude")
+						if err != nil {
+							return nil, fmt.Errorf("get file data failed: %s", err.Error())
+						}
+						// PDF and text documents use "document" type, others use "image"
+						if strings.HasPrefix(mimeType, "application/pdf") || strings.HasPrefix(mimeType, "text/") {
+							claudeMediaMessage.Type = "document"
+						} else {
+							claudeMediaMessage.Type = "image"
+						}
+						claudeMediaMessage.Source = &dto.ClaudeMessageSource{
+							Type:      "base64",
+							MediaType: mimeType,
+							Data:      base64Data,
+						}
 					} else {
 						imageUrl := mediaMessage.GetImageMedia()
+						if imageUrl == nil {
+							continue // Skip unsupported content types
+						}
 						claudeMediaMessage.Type = "image"
 						claudeMediaMessage.Source = &dto.ClaudeMessageSource{
 							Type: "base64",


### PR DESCRIPTION
## Summary
- Add `ContentTypeFile` handling in `RequestOpenAI2ClaudeMessage` before the generic image branch
- Convert PDF/text files to Claude `document` blocks instead of treating them as images
- Add nil guard for `GetImageMedia()` as safety fallback for other unknown content types

## Problem
When users upload PDF files via OpenAI-compatible clients (e.g., CherryStudio), the request contains `type: "file"` content blocks. The current code treats all non-text content as images and calls `GetImageMedia()`, which returns `nil` for file types. Accessing `imageUrl.Url` on the nil pointer causes a panic crash.

## Root Cause
`relay-claude.go:~352` — the `else` branch after `type == "text"` assumes everything else is an image, but `ContentTypeFile` (PDF/documents) has no `ImageUrl` field, so `GetImageMedia()` returns `nil`.

## Fix
1. **New `ContentTypeFile` branch**: Intercepts file-type content before the image handler. Uses `GetFile()` to extract file data, then converts to Claude's `document` block format (for PDF/text) or `image` block (for other file types).
2. **Nil guard on `GetImageMedia()`**: Added `if imageUrl == nil { continue }` in the existing image branch as a safety net for any other unhandled content types.

## Reference
- Similar pattern already used in Gemini relay: `relay/channel/gemini/relay-gemini.go`
- Fixes #3481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Claude messaging to support file uploads, including PDFs, text documents, and image files with intelligent format classification for optimal processing

* **Bug Fixes**
  * Strengthened media content validation to properly identify and skip unsupported content types
  * Enhanced error handling with improved reporting when file conversion operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->