### PR TITLE
fix: retry fallback for channel affinity failures

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -108,10 +108,6 @@ func Distribute() func(c *gin.Context) {
 						service.ClearMatchedChannelAffinity(c)
 					} else if preferred.Status != common.ChannelStatusEnabled {
 						service.ClearMatchedChannelAffinity(c)
-						if service.ShouldSkipRetryForMatchedChannelAffinityRule(c) {
-							abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
-							return
-						}
 					} else if usingGroup == "auto" {
 						userGroup := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
 						autoGroups := service.GetUserAutoGroup(userGroup)
@@ -197,9 +193,6 @@ func setupDistributedChannel(c *gin.Context, channel *model.Channel, modelName s
 
 	if affinityPreferredSelected {
 		service.ClearMatchedChannelAffinity(c)
-		if service.ShouldSkipRetryForMatchedChannelAffinityRule(c) {
-			return nil, setupErr
-		}
 	}
 
 	triedChannelIDs := make(map[int]struct{}, common.RetryTimes+1)

--- a/service/channel_affinity.go
+++ b/service/channel_affinity.go
@@ -619,17 +619,6 @@ func ShouldSkipRetryAfterChannelAffinityFailure(c *gin.Context) bool {
 	return false
 }
 
-func ShouldSkipRetryForMatchedChannelAffinityRule(c *gin.Context) bool {
-	if c == nil {
-		return false
-	}
-	meta, ok := getChannelAffinityMeta(c)
-	if !ok {
-		return false
-	}
-	return meta.SkipRetry
-}
-
 func ClearMatchedChannelAffinity(c *gin.Context) bool {
 	if c == nil {
 		return false

--- a/service/channel_affinity_template_test.go
+++ b/service/channel_affinity_template_test.go
@@ -155,30 +155,8 @@ func TestShouldSkipRetryAfterChannelAffinityFailure(t *testing.T) {
 			},
 			want: false,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, ShouldSkipRetryAfterChannelAffinityFailure(tt.ctx()))
-		})
-	}
-}
-
-func TestShouldSkipRetryForMatchedChannelAffinityRule(t *testing.T) {
-	tests := []struct {
-		name string
-		ctx  func() *gin.Context
-		want bool
-	}{
 		{
-			name: "nil context",
-			ctx: func() *gin.Context {
-				return nil
-			},
-			want: false,
-		},
-		{
-			name: "matched rule requests skip retry",
+			name: "matched rule skip retry meta alone should not block retry",
 			ctx: func() *gin.Context {
 				return buildChannelAffinityTemplateContextForTest(channelAffinityMeta{
 					RuleName:   "rule-skip-retry",
@@ -187,25 +165,13 @@ func TestShouldSkipRetryForMatchedChannelAffinityRule(t *testing.T) {
 					ModelName:  "gpt-5",
 				})
 			},
-			want: true,
-		},
-		{
-			name: "matched rule allows retry",
-			ctx: func() *gin.Context {
-				return buildChannelAffinityTemplateContextForTest(channelAffinityMeta{
-					RuleName:   "rule-no-skip-retry",
-					SkipRetry:  false,
-					UsingGroup: "default",
-					ModelName:  "gpt-5",
-				})
-			},
 			want: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, ShouldSkipRetryForMatchedChannelAffinityRule(tt.ctx()))
+			require.Equal(t, tt.want, ShouldSkipRetryAfterChannelAffinityFailure(tt.ctx()))
 		})
 	}
 }


### PR DESCRIPTION
# ⚠️ 提交警告 / PR Warning
> **请注意：** 请提供**人工撰写**的简洁摘要。包含大量 AI 灌水内容、逻辑混乱或无视模版的 PR **可能会被无视或直接关闭**。

---

## 💡 沟通提示 / Pre-submission
> **重大功能变更？** 请先提交 Issue 交流，避免无效劳动。

## 📝 变更描述 / Description
当亲和成功某渠道后，假设这个渠道请求失败或者被禁用等情况出现后，原逻辑不会重试，既便没有勾选“失败后不重试”也不会重试，如下图：
<img width="1567" height="270" alt="image" src="https://github.com/user-attachments/assets/1dedc277-6287-4eb6-8b3c-948d7ae7ff13" />

本次改动主要做了如下变更：
1. middleware/distributor.go — 分发中间件增加重试回退逻辑
  - 当渠道亲和性（channel affinity）选中的首选渠道不可用时（已禁用、不在缓存、或 SetupContextForSelectedChannel 失败），不再直接报错，而是：
    - 调用 ClearMatchedChannelAffinity 清除失效的亲和性缓存
    - 根据 ShouldSkipRetryForMatchedChannelAffinityRule 判断是否允许重试
    - 若允许重试，进入新函数 setupDistributedChannel，循环尝试其他满足条件的渠道（最多 RetryTimes 次）
  - 新增 setupDistributedChannel 函数：封装了「首选渠道 setup 失败后，随机选备选渠道重试」的完整流程
2. service/channel_affinity.go — 新增两个服务函数
  - ShouldSkipRetryForMatchedChannelAffinityRule：从亲和性规则 meta 判断是否应跳过重试
  - ClearMatchedChannelAffinity：清除当前请求匹配的亲和性缓存条目
3. service/channel_affinity_template_test.go — 补充测试
  - 为新拆分的 ShouldSkipRetryForMatchedChannelAffinityRule 和 ClearMatchedChannelAffinity 添加了单元测试


## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature) - *重大特性建议先 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #3414

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自撰写此描述，去除了 AI 原始输出的冗余。
- [x] **深度理解:** 我已**完全理解**这些更改的工作原理及潜在影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过了测试或手动验证。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```text
# go test ./service ./middleware ./controller
go: downloading github.com/stripe/stripe-go/v81 v81.4.0
go: downloading github.com/thanhpk/randstr v1.0.6
go: downloading github.com/waffo-com/waffo-go v1.3.1
go: downloading github.com/stretchr/testify v1.11.1
go: downloading modernc.org/sqlite v1.40.1
go: downloading github.com/aws/aws-sdk-go-v2 v1.41.2
go: downloading github.com/aws/aws-sdk-go-v2/credentials v1.19.10
go: downloading github.com/aws/smithy-go v1.24.2
go: downloading github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.0
go: downloading github.com/klauspost/compress v1.18.0
go: downloading github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
go: downloading github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
go: downloading github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.5
go: downloading github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.18
go: downloading github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.18
ok      github.com/QuantumNous/new-api/service  0.095s
?       github.com/QuantumNous/new-api/middleware       [no test files]
ok      github.com/QuantumNous/new-api/controller       0.056s
```
修改之后的效果：
<img width="1575" height="185" alt="image" src="https://github.com/user-attachments/assets/f7bf7156-6f59-4361-a09c-614f3e4b1cff" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved channel distribution with more reliable fallback selection and controlled retry behavior when initial setup fails
  * Clearer tracking and handling of preferred-channel affinity, including automatic clearing of stale affinity when selections are invalid or disabled
  * Better auto-group selection flow and more predictable affinity usage reporting

* **Tests**
  * Added tests covering retry-skip behavior and clearing of matched channel affinity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->