### PR TITLE
fix: upgrade gorm postgres driver to fix repeated ALTER TABLE on logs.request_id

### DIFF
--- a/model/log.go
+++ b/model/log.go
@@ -35,7 +35,7 @@ type Log struct {
 	TokenId          int    `json:"token_id" gorm:"default:0;index"`
 	Group            string `json:"group" gorm:"index"`
 	Ip               string `json:"ip" gorm:"index;default:''"`
-	RequestId        string `json:"request_id,omitempty" gorm:"type:varchar(64);index:idx_logs_request_id;default:''"`
+	RequestId        string `json:"request_id,omitempty" gorm:"size:64;index:idx_logs_request_id;default:''"`
 	Other            string `json:"other"`
 }
 


### PR DESCRIPTION
fix #4054

### 问题

`Log.RequestId` 的 GORM tag 使用了 `type:varchar(64)`，PostgreSQL 内部将 `varchar` 规范化为 `character varying` 存储。旧版 postgres driver (v1.5.2) 的类型比对存在 bug，每次 AutoMigrate 都会发起：

```sql
ALTER TABLE "logs" ALTER COLUMN "request_id" TYPE varchar(64) USING "request_id"::varchar(64)
```

带 `USING` 子句的 `ALTER COLUMN TYPE` 会触发全表重写，即使类型实际未变。

### 上游相关修复

此问题由以下 GORM 上游 bug 共同导致：

1. **go-gorm/postgres#261** — [Fix same type comparing](https://github.com/go-gorm/postgres/pull/261) (merged 2024-03-19)
   `DatabaseTypeName()` 返回小写，`fileType.SQL` 返回大写，导致类型比对误判。改用 `strings.EqualFold` 修复。

2. **go-gorm/postgres#211** — [fix: default value with typecast](https://github.com/go-gorm/postgres/pull/211) (merged 2023-10-10)
   PostgreSQL 返回 `''::character varying` 作为 default，与 tag 中的 `''` 不匹配，导致每次触发 `SET DEFAULT`。

3. **go-gorm/gorm#6543** — [Postgres: AutoMigrate not stable for `type:varchar;default:''`](https://github.com/go-gorm/gorm/issues/6543) (closed 2023-08-27)
   与本问题完全相同的场景：varchar + default:'' 在 PostgreSQL 上 AutoMigrate 不稳定。

这些修复均包含在 `gorm.io/driver/postgres` v1.5.2 之后的版本中。

### 修复

升级 GORM 依赖：

- `gorm.io/driver/postgres` v1.5.2 → v1.6.0
- `gorm.io/gorm` v1.25.2 → v1.31.1

### 测试验证

编写自动化测试覆盖 PostgreSQL 16 / MySQL 8.0 / SQLite：

**旧 GORM (postgres v1.5.2):**

| DB | AutoMigrate 稳定性 |
|----|--------------------|
| PostgreSQL | FAIL — 每次触发 ALTER TYPE + SET DEFAULT |
| MySQL | PASS |

**新 GORM (postgres v1.6.0):**

| DB | AutoMigrate 稳定性 |
|----|--------------------|
| PostgreSQL | PASS |
| MySQL | PASS |