### PR TITLE
fix(token): add batch keys endpoint to prevent 429 rate limit on bulk copy

### DIFF
--- a/controller/token.go
+++ b/controller/token.go
@@ -94,6 +94,37 @@ func GetTokenKey(c *gin.Context) {
 	})
 }
 
+func BatchGetTokenKeys(c *gin.Context) {
+	userId := c.GetInt("id")
+	var req struct {
+		Ids []int `json:"ids"`
+	}
+	if err := common.DecodeJson(c.Request.Body, &req); err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	if len(req.Ids) == 0 {
+		common.ApiError(c, fmt.Errorf("ids is empty"))
+		return
+	}
+	if len(req.Ids) > 100 {
+		common.ApiError(c, fmt.Errorf("batch size exceeds limit (max 100)"))
+		return
+	}
+	tokens, err := model.GetTokensByIdsAndUserId(req.Ids, userId)
+	if err != nil {
+		common.ApiError(c, err)
+		return
+	}
+	keys := make(map[int]string, len(tokens))
+	for _, token := range tokens {
+		keys[token.Id] = token.GetFullKey()
+	}
+	common.ApiSuccess(c, gin.H{
+		"keys": keys,
+	})
+}
+
 func GetTokenStatus(c *gin.Context) {
 	tokenId := c.GetInt("token_id")
 	userId := c.GetInt("id")

--- a/model/token.go
+++ b/model/token.go
@@ -234,6 +234,15 @@ func ValidateUserToken(key string) (token *Token, err error) {
 	}
 }
 
+func GetTokensByIdsAndUserId(ids []int, userId int) ([]*Token, error) {
+	if len(ids) == 0 || userId == 0 {
+		return nil, errors.New("ids 或 userId 为空！")
+	}
+	var tokens []*Token
+	err := DB.Where("id IN ? AND user_id = ?", ids, userId).Find(&tokens).Error
+	return tokens, err
+}
+
 func GetTokenByIds(id int, userId int) (*Token, error) {
 	if id == 0 || userId == 0 {
 		return nil, errors.New("id 或 userId 为空！")

--- a/router/api-router.go
+++ b/router/api-router.go
@@ -257,6 +257,7 @@ func SetApiRouter(router *gin.Engine) {
 			tokenRoute.PUT("/", controller.UpdateToken)
 			tokenRoute.DELETE("/:id", controller.DeleteToken)
 			tokenRoute.POST("/batch", controller.DeleteTokenBatch)
+			tokenRoute.POST("/batch/keys", middleware.CriticalRateLimit(), middleware.DisableCache(), controller.BatchGetTokenKeys)
 		}
 
 		usageRoute := apiRouter.Group("/usage")

--- a/web/src/helpers/token.js
+++ b/web/src/helpers/token.js
@@ -34,6 +34,20 @@ export async function fetchTokenKey(tokenId) {
 }
 
 /**
+ * 批量获取多个令牌的真实 key（单次请求）
+ * @param {number[]} tokenIds
+ * @returns {Promise<Record<number, string>>} { tokenId: key } 映射
+ */
+export async function fetchTokenKeysBatch(tokenIds) {
+  const response = await API.post('/api/token/batch/keys', { ids: tokenIds });
+  const { success, data, message } = response.data || {};
+  if (!success || !data?.keys) {
+    throw new Error(message || 'Failed to batch fetch token keys');
+  }
+  return data.keys;
+}
+
+/**
  * 获取可用的 token keys
  * @returns {Promise<string[]>} 返回 active 状态的不带 sk- 前缀的真实 token key 数组
  */

--- a/web/src/hooks/tokens/useTokensData.jsx
+++ b/web/src/hooks/tokens/useTokensData.jsx
@@ -31,6 +31,7 @@ import { ITEMS_PER_PAGE } from '../../constants';
 import { useTableCompactMode } from '../common/useTableCompactMode';
 import {
   fetchTokenKey as fetchTokenKeyById,
+  fetchTokenKeysBatch,
   getServerAddress,
   encodeChannelConnectionString,
 } from '../../helpers/token';
@@ -408,14 +409,15 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
       return;
     }
     try {
-      const keys = await Promise.all(
-        selectedKeys.map((token) => fetchTokenKey(token, { suppressError: true })),
-      );
+      const ids = selectedKeys.map((token) => token.id);
+      const keysMap = await fetchTokenKeysBatch(ids);
+      setResolvedTokenKeys((prev) => ({ ...prev, ...keysMap }));
       let content = '';
-      for (let i = 0; i < selectedKeys.length; i++) {
-        const fullKey = keys[i];
+      for (const token of selectedKeys) {
+        const fullKey = keysMap[token.id];
+        if (!fullKey) continue;
         if (copyType === 'name+key') {
-          content += `${selectedKeys[i].name}    sk-${fullKey}\n`;
+          content += `${token.name}    sk-${fullKey}\n`;
         } else {
           content += `sk-${fullKey}\n`;
         }


### PR DESCRIPTION
## Problem

When users batch-copy 50+ token keys from the token management page, the frontend fires N individual `POST /api/token/:id/key` requests simultaneously via `Promise.all`. The `CriticalRateLimit` (20 req/20min per IP) rejects most of them with HTTP 429, **making the batch copy feature completely broken**.

## Solution

Add a single `POST /api/token/batch/keys` endpoint that accepts an array of token IDs and returns all keys in **one request**, eliminating the N-request problem entirely.

## Changes (5 files, +63 / -6)

| File | Change |
|------|--------|
| `model/token.go` | Add `GetTokensByIdsAndUserId` for batch DB query |
| `controller/token.go` | Add `BatchGetTokenKeys` handler (max 100 IDs) |
| `router/api-router.go` | Register `POST /api/token/batch/keys` route |
| `web/src/helpers/token.js` | Add `fetchTokenKeysBatch` calling batch endpoint |
| `web/src/hooks/tokens/useTokensData.jsx` | Rewrite `batchCopyTokens` to use single batch request |

## Security

- Retains `CriticalRateLimit` + `UserAuth` middleware on the new endpoint
- Only returns keys owned by the authenticated user (`WHERE user_id = ?`)
- Hard cap of 100 IDs per request

## Before vs After

| | Before | After |
|---|---|---|
| Copy 50 keys | 50x `POST /api/token/:id/key` | **1x** `POST /api/token/batch/keys` |
| Rate limit consumption | 50 (triggers 429) | **1** (no issue) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch token key retrieval API endpoint supporting up to 100 tokens per request
  * Optimized multi-token operations to use single API call instead of individual requests
  * Implemented input validation to prevent invalid batch requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->