### PR TITLE
feat: 添加 Google OAuth 登录支持

### DIFF
--- a/controller/misc.go
+++ b/controller/misc.go
@@ -54,6 +54,8 @@ func GetStatus(c *gin.Context) {
 		"email_verification":          common.EmailVerificationEnabled,
 		"github_oauth":                common.GitHubOAuthEnabled,
 		"github_client_id":            common.GitHubClientId,
+		"google_oauth":                system_setting.GetGoogleSettings().Enabled,
+		"google_client_id":            system_setting.GetGoogleSettings().ClientId,
 		"discord_oauth":               system_setting.GetDiscordSettings().Enabled,
 		"discord_client_id":           system_setting.GetDiscordSettings().ClientId,
 		"linuxdo_oauth":               common.LinuxDOOAuthEnabled,

--- a/controller/oauth.go
+++ b/controller/oauth.go
@@ -308,6 +308,7 @@ func findOrCreateOAuthUser(c *gin.Context, provider oauth.Provider, oauthUser *o
 			provider.SetProviderUserID(user, oauthUser.ProviderUserID)
 			if err := tx.Model(user).Updates(map[string]interface{}{
 				"github_id":   user.GitHubId,
+				"google_id":   user.GoogleId,
 				"discord_id":  user.DiscordId,
 				"oidc_id":     user.OidcId,
 				"linux_do_id": user.LinuxDOId,

--- a/controller/option.go
+++ b/controller/option.go
@@ -139,6 +139,14 @@ func UpdateOption(c *gin.Context) {
 			})
 			return
 		}
+	case "google.enabled":
+		if option.Value == "true" && (system_setting.GetGoogleSettings().ClientId == "" || system_setting.GetGoogleSettings().ClientSecret == "") {
+			c.JSON(http.StatusOK, gin.H{
+				"success": false,
+				"message": "无法启用 Google OAuth，请先填入 Google Client Id 以及 Google Client Secret！",
+			})
+			return
+		}
 	case "oidc.enabled":
 		if option.Value == "true" && system_setting.GetOIDCSettings().ClientId == "" {
 			c.JSON(http.StatusOK, gin.H{

--- a/model/user.go
+++ b/model/user.go
@@ -30,6 +30,7 @@ type User struct {
 	Status           int            `json:"status" gorm:"type:int;default:1"` // enabled, disabled
 	Email            string         `json:"email" gorm:"index" validate:"max=50"`
 	GitHubId         string         `json:"github_id" gorm:"column:github_id;index"`
+	GoogleId         string         `json:"google_id" gorm:"column:google_id;index"`
 	DiscordId        string         `json:"discord_id" gorm:"column:discord_id;index"`
 	OidcId           string         `json:"oidc_id" gorm:"column:oidc_id;index"`
 	WeChatId         string         `json:"wechat_id" gorm:"column:wechat_id;index"`
@@ -547,6 +548,7 @@ func (user *User) ClearBinding(bindingType string) error {
 	bindingColumnMap := map[string]string{
 		"email":    "email",
 		"github":   "github_id",
+		"google":   "google_id",
 		"discord":  "discord_id",
 		"oidc":     "oidc_id",
 		"wechat":   "wechat_id",
@@ -633,6 +635,14 @@ func (user *User) FillUserByGitHubId() error {
 	return nil
 }
 
+func (user *User) FillUserByGoogleId() error {
+	if user.GoogleId == "" {
+		return errors.New("Google id 为空！")
+	}
+	DB.Where(User{GoogleId: user.GoogleId}).First(user)
+	return nil
+}
+
 // UpdateGitHubId updates the user's GitHub ID (used for migration from login to numeric ID)
 func (user *User) UpdateGitHubId(newGitHubId string) error {
 	if user.Id == 0 {
@@ -686,6 +696,10 @@ func IsWeChatIdAlreadyTaken(wechatId string) bool {
 
 func IsGitHubIdAlreadyTaken(githubId string) bool {
 	return DB.Unscoped().Where("github_id = ?", githubId).Find(&User{}).RowsAffected == 1
+}
+
+func IsGoogleIdAlreadyTaken(googleId string) bool {
+	return DB.Unscoped().Where("google_id = ?", googleId).Find(&User{}).RowsAffected == 1
 }
 
 func IsDiscordIdAlreadyTaken(discordId string) bool {

--- a/oauth/google.go
+++ b/oauth/google.go
@@ -1,0 +1,159 @@
+package oauth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/i18n"
+	"github.com/QuantumNous/new-api/logger"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	Register("google", &GoogleProvider{})
+}
+
+// GoogleProvider implements OAuth for Google
+type GoogleProvider struct{}
+
+type googleOAuthResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+	IDToken     string `json:"id_token"`
+}
+
+type googleUser struct {
+	Sub   string `json:"sub"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+func (p *GoogleProvider) GetName() string {
+	return "Google"
+}
+
+func (p *GoogleProvider) IsEnabled() bool {
+	return system_setting.GetGoogleSettings().Enabled
+}
+
+func (p *GoogleProvider) ExchangeToken(ctx context.Context, code string, c *gin.Context) (*OAuthToken, error) {
+	_ = c
+	if code == "" {
+		return nil, NewOAuthError(i18n.MsgOAuthInvalidCode, nil)
+	}
+
+	logger.LogDebug(ctx, "[OAuth-Google] ExchangeToken: code=%s...", code[:min(len(code), 10)])
+
+	settings := system_setting.GetGoogleSettings()
+	redirectUri := fmt.Sprintf("%s/oauth/google", system_setting.ServerAddress)
+	values := url.Values{}
+	values.Set("client_id", settings.ClientId)
+	values.Set("client_secret", settings.ClientSecret)
+	values.Set("code", code)
+	values.Set("grant_type", "authorization_code")
+	values.Set("redirect_uri", redirectUri)
+
+	logger.LogDebug(ctx, "[OAuth-Google] ExchangeToken: redirect_uri=%s", redirectUri)
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://oauth2.googleapis.com/token", strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	client := http.Client{Timeout: 5 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		logger.LogError(ctx, fmt.Sprintf("[OAuth-Google] ExchangeToken error: %s", err.Error()))
+		return nil, NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, map[string]any{"Provider": "Google"}, err.Error())
+	}
+	defer res.Body.Close()
+
+	logger.LogDebug(ctx, "[OAuth-Google] ExchangeToken response status: %d", res.StatusCode)
+
+	var googleResponse googleOAuthResponse
+	if err = common.DecodeJson(res.Body, &googleResponse); err != nil {
+		logger.LogError(ctx, fmt.Sprintf("[OAuth-Google] ExchangeToken decode error: %s", err.Error()))
+		return nil, err
+	}
+
+	if googleResponse.AccessToken == "" {
+		logger.LogError(ctx, "[OAuth-Google] ExchangeToken failed: empty access token")
+		return nil, NewOAuthError(i18n.MsgOAuthTokenFailed, map[string]any{"Provider": "Google"})
+	}
+
+	return &OAuthToken{
+		AccessToken: googleResponse.AccessToken,
+		TokenType:   googleResponse.TokenType,
+		ExpiresIn:   googleResponse.ExpiresIn,
+		Scope:       googleResponse.Scope,
+		IDToken:     googleResponse.IDToken,
+	}, nil
+}
+
+func (p *GoogleProvider) GetUserInfo(ctx context.Context, token *OAuthToken) (*OAuthUser, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://openidconnect.googleapis.com/v1/userinfo", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+
+	client := http.Client{Timeout: 5 * time.Second}
+	res, err := client.Do(req)
+	if err != nil {
+		logger.LogError(ctx, fmt.Sprintf("[OAuth-Google] GetUserInfo error: %s", err.Error()))
+		return nil, NewOAuthErrorWithRaw(i18n.MsgOAuthConnectFailed, map[string]any{"Provider": "Google"}, err.Error())
+	}
+	defer res.Body.Close()
+
+	logger.LogDebug(ctx, "[OAuth-Google] GetUserInfo response status: %d", res.StatusCode)
+
+	if res.StatusCode != http.StatusOK {
+		return nil, NewOAuthError(i18n.MsgOAuthGetUserErr, nil)
+	}
+
+	var userInfo googleUser
+	if err = common.DecodeJson(res.Body, &userInfo); err != nil {
+		logger.LogError(ctx, fmt.Sprintf("[OAuth-Google] GetUserInfo decode error: %s", err.Error()))
+		return nil, err
+	}
+
+	if userInfo.Sub == "" {
+		logger.LogError(ctx, "[OAuth-Google] GetUserInfo failed: empty sub")
+		return nil, NewOAuthError(i18n.MsgOAuthUserInfoEmpty, map[string]any{"Provider": "Google"})
+	}
+
+	return &OAuthUser{
+		ProviderUserID: userInfo.Sub,
+		Username:       userInfo.Email,
+		DisplayName:    userInfo.Name,
+		Email:          userInfo.Email,
+	}, nil
+}
+
+func (p *GoogleProvider) IsUserIDTaken(providerUserID string) bool {
+	return model.IsGoogleIdAlreadyTaken(providerUserID)
+}
+
+func (p *GoogleProvider) FillUserByProviderID(user *model.User, providerUserID string) error {
+	user.GoogleId = providerUserID
+	return user.FillUserByGoogleId()
+}
+
+func (p *GoogleProvider) SetProviderUserID(user *model.User, providerUserID string) {
+	user.GoogleId = providerUserID
+}
+
+func (p *GoogleProvider) GetProviderPrefix() string {
+	return "google_"
+}

--- a/setting/system_setting/google.go
+++ b/setting/system_setting/google.go
@@ -1,0 +1,19 @@
+package system_setting
+
+import "github.com/QuantumNous/new-api/setting/config"
+
+type GoogleSettings struct {
+	Enabled      bool   `json:"enabled"`
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+var defaultGoogleSettings = GoogleSettings{}
+
+func init() {
+	config.GlobalConfig.Register("google", &defaultGoogleSettings)
+}
+
+func GetGoogleSettings() *GoogleSettings {
+	return &defaultGoogleSettings
+}

--- a/web/src/components/auth/LoginForm.jsx
+++ b/web/src/components/auth/LoginForm.jsx
@@ -32,6 +32,7 @@ import {
   getOAuthProviderIcon,
   setUserData,
   onGitHubOAuthClicked,
+  onGoogleOAuthClicked,
   onDiscordOAuthClicked,
   onOIDCClicked,
   onLinuxDOOAuthClicked,
@@ -65,7 +66,7 @@ import WeChatIcon from '../common/logo/WeChatIcon';
 import LinuxDoIcon from '../common/logo/LinuxDoIcon';
 import TwoFAVerification from './TwoFAVerification';
 import { useTranslation } from 'react-i18next';
-import { SiDiscord } from 'react-icons/si';
+import { SiDiscord, SiGoogle } from 'react-icons/si';
 
 const LoginForm = () => {
   let navigate = useNavigate();
@@ -92,6 +93,7 @@ const LoginForm = () => {
   const [showEmailLogin, setShowEmailLogin] = useState(false);
   const [wechatLoading, setWechatLoading] = useState(false);
   const [githubLoading, setGithubLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [discordLoading, setDiscordLoading] = useState(false);
   const [oidcLoading, setOidcLoading] = useState(false);
   const [linuxdoLoading, setLinuxdoLoading] = useState(false);
@@ -135,6 +137,7 @@ const LoginForm = () => {
     (status.custom_oauth_providers || []).length > 0;
   const hasOAuthLoginOptions = Boolean(
     status.github_oauth ||
+      status.google_oauth ||
       status.discord_oauth ||
       status.oidc_enabled ||
       status.wechat_login ||
@@ -334,6 +337,20 @@ const LoginForm = () => {
     } finally {
       // 由于重定向，这里不会执行到，但为了完整性添加
       setTimeout(() => setGithubLoading(false), 3000);
+    }
+  };
+
+  // 包装的Google登录点击处理
+  const handleGoogleClick = () => {
+    if ((hasUserAgreement || hasPrivacyPolicy) && !agreedToTerms) {
+      showInfo(t('请先阅读并同意用户协议和隐私政策'));
+      return;
+    }
+    setGoogleLoading(true);
+    try {
+      onGoogleOAuthClicked(status.google_client_id, { shouldLogout: true });
+    } finally {
+      setTimeout(() => setGoogleLoading(false), 3000);
     }
   };
 
@@ -545,6 +562,27 @@ const LoginForm = () => {
                     disabled={githubButtonDisabled}
                   >
                     <span className='ml-3'>{githubButtonText}</span>
+                  </Button>
+                )}
+
+                {status.google_oauth && (
+                  <Button
+                    theme='outline'
+                    className='w-full h-12 flex items-center justify-center !rounded-full border border-gray-200 hover:bg-gray-50 transition-colors'
+                    type='tertiary'
+                    icon={
+                      <SiGoogle
+                        style={{
+                          color: '#4285F4',
+                          width: '20px',
+                          height: '20px',
+                        }}
+                      />
+                    }
+                    onClick={handleGoogleClick}
+                    loading={googleLoading}
+                  >
+                    <span className='ml-3'>{t('使用 Google 继续')}</span>
                   </Button>
                 )}
 

--- a/web/src/components/auth/RegisterForm.jsx
+++ b/web/src/components/auth/RegisterForm.jsx
@@ -29,8 +29,12 @@ import {
   getSystemName,
   getOAuthProviderIcon,
   setUserData,
+  onGitHubOAuthClicked,
+  onGoogleOAuthClicked,
   onDiscordOAuthClicked,
   onCustomOAuthClicked,
+  onLinuxDOOAuthClicked,
+  onOIDCClicked,
 } from '../../helpers';
 import Turnstile from 'react-turnstile';
 import {
@@ -51,11 +55,6 @@ import {
   IconLock,
   IconKey,
 } from '@douyinfe/semi-icons';
-import {
-  onGitHubOAuthClicked,
-  onLinuxDOOAuthClicked,
-  onOIDCClicked,
-} from '../../helpers';
 import OIDCIcon from '../common/logo/OIDCIcon';
 import LinuxDoIcon from '../common/logo/LinuxDoIcon';
 import WeChatIcon from '../common/logo/WeChatIcon';
@@ -63,7 +62,7 @@ import TelegramLoginButton from 'react-telegram-login/src';
 import { UserContext } from '../../context/User';
 import { StatusContext } from '../../context/Status';
 import { useTranslation } from 'react-i18next';
-import { SiDiscord } from 'react-icons/si';
+import { SiDiscord, SiGoogle } from 'react-icons/si';
 
 const RegisterForm = () => {
   let navigate = useNavigate();
@@ -91,6 +90,7 @@ const RegisterForm = () => {
   const [showEmailRegister, setShowEmailRegister] = useState(false);
   const [wechatLoading, setWechatLoading] = useState(false);
   const [githubLoading, setGithubLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [discordLoading, setDiscordLoading] = useState(false);
   const [oidcLoading, setOidcLoading] = useState(false);
   const [linuxdoLoading, setLinuxdoLoading] = useState(false);
@@ -133,6 +133,7 @@ const RegisterForm = () => {
     (status.custom_oauth_providers || []).length > 0;
   const hasOAuthRegisterOptions = Boolean(
     status.github_oauth ||
+      status.google_oauth ||
       status.discord_oauth ||
       status.oidc_enabled ||
       status.wechat_login ||
@@ -301,6 +302,15 @@ const RegisterForm = () => {
     }
   };
 
+  const handleGoogleClick = () => {
+    setGoogleLoading(true);
+    try {
+      onGoogleOAuthClicked(status.google_client_id, { shouldLogout: true });
+    } finally {
+      setTimeout(() => setGoogleLoading(false), 3000);
+    }
+  };
+
   const handleDiscordClick = () => {
     setDiscordLoading(true);
     try {
@@ -436,6 +446,27 @@ const RegisterForm = () => {
                     disabled={githubButtonDisabled}
                   >
                     <span className='ml-3'>{githubButtonText}</span>
+                  </Button>
+                )}
+
+                {status.google_oauth && (
+                  <Button
+                    theme='outline'
+                    className='w-full h-12 flex items-center justify-center !rounded-full border border-gray-200 hover:bg-gray-50 transition-colors'
+                    type='tertiary'
+                    icon={
+                      <SiGoogle
+                        style={{
+                          color: '#4285F4',
+                          width: '20px',
+                          height: '20px',
+                        }}
+                      />
+                    }
+                    onClick={handleGoogleClick}
+                    loading={googleLoading}
+                  >
+                    <span className='ml-3'>{t('使用 Google 继续')}</span>
                   </Button>
                 )}
 

--- a/web/src/components/settings/SystemSetting.jsx
+++ b/web/src/components/settings/SystemSetting.jsx
@@ -56,6 +56,9 @@ const SystemSetting = () => {
     'discord.enabled': '',
     'discord.client_id': '',
     'discord.client_secret': '',
+    'google.enabled': '',
+    'google.client_id': '',
+    'google.client_secret': '',
     'oidc.enabled': '',
     'oidc.client_id': '',
     'oidc.client_secret': '',
@@ -184,6 +187,7 @@ const SystemSetting = () => {
           case 'SMTPSSLEnabled':
           case 'LinuxDOOAuthEnabled':
           case 'discord.enabled':
+          case 'google.enabled':
           case 'oidc.enabled':
           case 'passkey.enabled':
           case 'passkey.allow_insecure_origin':
@@ -495,6 +499,30 @@ const SystemSetting = () => {
       options.push({
         key: 'discord.client_secret',
         value: inputs['discord.client_secret'],
+      });
+    }
+
+    if (options.length > 0) {
+      await updateOptions(options);
+    }
+  };
+
+  const submitGoogleOAuth = async () => {
+    const options = [];
+
+    if (originInputs['google.client_id'] !== inputs['google.client_id']) {
+      options.push({
+        key: 'google.client_id',
+        value: inputs['google.client_id'],
+      });
+    }
+    if (
+      originInputs['google.client_secret'] !== inputs['google.client_secret'] &&
+      inputs['google.client_secret'] !== ''
+    ) {
+      options.push({
+        key: 'google.client_secret',
+        value: inputs['google.client_secret'],
       });
     }
 
@@ -1054,6 +1082,13 @@ const SystemSetting = () => {
                         {t('允许通过 Discord 账户登录 & 注册')}
                       </Form.Checkbox>
                       <Form.Checkbox
+                        field='google.enabled'
+                        noLabel
+                        onChange={(e) => handleCheckboxChange('google.enabled', e)}
+                      >
+                        {t('允许通过 Google 账户登录 & 注册')}
+                      </Form.Checkbox>
+                      <Form.Checkbox
                         field='LinuxDOOAuthEnabled'
                         noLabel
                         onChange={(e) =>
@@ -1477,6 +1512,37 @@ const SystemSetting = () => {
                   </Row>
                   <Button onClick={submitDiscordOAuth}>
                     {t('保存 Discord OAuth 设置')}
+                  </Button>
+                </Form.Section>
+              </Card>
+              <Card>
+                <Form.Section text={t('配置 Google OAuth')}>
+                  <Text>{t('用以支持通过 Google 进行登录注册')}</Text>
+                  <Banner
+                    type='info'
+                    description={`${t('Homepage URL 填')} ${inputs.ServerAddress ? inputs.ServerAddress : t('网站地址')}，${t('Authorization callback URL 填')} ${inputs.ServerAddress ? inputs.ServerAddress : t('网站地址')}/oauth/google`}
+                    style={{ marginBottom: 20, marginTop: 16 }}
+                  />
+                  <Row
+                    gutter={{ xs: 8, sm: 16, md: 24, lg: 24, xl: 24, xxl: 24 }}
+                  >
+                    <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                      <Form.Input
+                        field="['google.client_id']"
+                        label={t('Google Client ID')}
+                      />
+                    </Col>
+                    <Col xs={24} sm={24} md={12} lg={12} xl={12}>
+                      <Form.Input
+                        field="['google.client_secret']"
+                        label={t('Google Client Secret')}
+                        type='password'
+                        placeholder={t('敏感信息不会发送到前端显示')}
+                      />
+                    </Col>
+                  </Row>
+                  <Button onClick={submitGoogleOAuth}>
+                    {t('保存 Google OAuth 设置')}
                   </Button>
                 </Form.Section>
               </Card>

--- a/web/src/helpers/api.js
+++ b/web/src/helpers/api.js
@@ -304,6 +304,17 @@ export async function onGitHubOAuthClicked(github_client_id, options = {}) {
   );
 }
 
+export async function onGoogleOAuthClicked(google_client_id, options = {}) {
+  const state = await prepareOAuthState(options);
+  if (!state) return;
+  const redirect_uri = `${window.location.origin}/oauth/google`;
+  const response_type = 'code';
+  const scope = 'openid profile email';
+  redirectToOAuthUrl(
+    `https://accounts.google.com/o/oauth2/v2/auth?client_id=${google_client_id}&redirect_uri=${redirect_uri}&response_type=${response_type}&scope=${scope}&state=${state}`,
+  );
+}
+
 export async function onLinuxDOOAuthClicked(
   linuxdo_client_id,
   options = { shouldLogout: false },


### PR DESCRIPTION
- 新增 Google OAuth 提供者实现，包括令牌交换和用户信息获取
- 在用户模型中添加 GoogleId 字段及相关查询方法
- 添加系统设置页面用于配置 Google OAuth 客户端信息
- 在前端登录和注册页面添加 Google 登录按钮
- 在用户状态更新时同步 GoogleId 字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google OAuth sign-in: Users can now log in using their Google accounts
  * Google OAuth registration: New users can register via Google
  * Google account binding: Existing users can link their Google accounts
  * Configuration panel: Administrators can manage Google OAuth settings including API credentials in system settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->