### PR TITLE
fix(pricing): add filtering for pricing based on usable groups

### DIFF
--- a/controller/pricing.go
+++ b/controller/pricing.go
@@ -1,12 +1,37 @@
 package controller
 
 import (
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/ratio_setting"
 
 	"github.com/gin-gonic/gin"
 )
+
+func filterPricingByUsableGroups(pricing []model.Pricing, usableGroup map[string]string) []model.Pricing {
+	if len(pricing) == 0 {
+		return pricing
+	}
+	if len(usableGroup) == 0 {
+		return []model.Pricing{}
+	}
+
+	filtered := make([]model.Pricing, 0, len(pricing))
+	for _, item := range pricing {
+		if common.StringsContains(item.EnableGroup, "all") {
+			filtered = append(filtered, item)
+			continue
+		}
+		for _, group := range item.EnableGroup {
+			if _, ok := usableGroup[group]; ok {
+				filtered = append(filtered, item)
+				break
+			}
+		}
+	}
+	return filtered
+}
 
 func GetPricing(c *gin.Context) {
 	pricing := model.GetPricing()
@@ -31,6 +56,7 @@ func GetPricing(c *gin.Context) {
 	}
 
 	usableGroup = service.GetUserUsableGroups(group)
+	pricing = filterPricingByUsableGroups(pricing, usableGroup)
 	// check groupRatio contains usableGroup
 	for group := range ratio_setting.GetGroupRatioCopy() {
 		if _, ok := usableGroup[group]; !ok {


### PR DESCRIPTION
修复模型广场模型泄露问题：`/api/pricing` 新增按用户可用分组过滤，避免仅在不可见分组启用的模型仍出现在模型广场。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing data filtering to properly respect group-based access controls. Pricing items are now correctly displayed based on group memberships, with special handling for unrestricted items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->