### PR TITLE
fix: Claude 流式断流时不再整份覆盖 usage，保留 cache 计费字段

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -811,7 +811,8 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 		}
 		// 只补缺失字段，不整份覆盖——保留 message_start 已拿到的 cache 字段
 		fallback := service.ResponseText2Usage(c, claudeInfo.ResponseText.String(), info.UpstreamModelName, info.GetEstimatePromptTokens())
-		if claudeInfo.Usage.CompletionTokens == 0 {
+		if claudeInfo.Usage.CompletionTokens == 0 ||
+			(!claudeInfo.Done && fallback.CompletionTokens > claudeInfo.Usage.CompletionTokens) {
 			claudeInfo.Usage.CompletionTokens = fallback.CompletionTokens
 		}
 		if claudeInfo.Usage.PromptTokens == 0 {


### PR DESCRIPTION
## 问题

`HandleStreamFinalResponse` 在流式未正常结束（`!claudeInfo.Done` 或 `CompletionTokens == 0`）时，调用 `ResponseText2Usage` **整份覆盖** `claudeInfo.Usage`：

```go
claudeInfo.Usage = service.ResponseText2Usage(c, ..., claudeInfo.Usage.PromptTokens)
```

`ResponseText2Usage` 返回一个全新的空 `dto.Usage`，只填了 3 个字段。赋值后，`message_start` 阶段已获取的 `CachedTokens`、`CacheCreationInputTokens`、`ClaudeCacheCreation5mTokens` 等字段全部归零。

同时，`PromptTokens` 使用了 `claudeInfo.Usage.PromptTokens`（message_start 的占位值，常为 1），而其他所有渠道（OpenAI、Gemini、XAI、Cohere、Palm……）在类似 fallback 场景下都使用 `info.GetEstimatePromptTokens()`。

## 影响

- 上游 Anthropic 在 input 接收时即计费（含 cache_creation），但本地日志只记录 `prompt_tokens=1`
- 计费严重错配：上游扣 $9.26，本地只扣 $0.000024
- cache 相关字段在日志中全部为 0

## 修复

不整份覆盖 usage，只补缺失字段：

```go
fallback := service.ResponseText2Usage(c, ..., info.GetEstimatePromptTokens())
if claudeInfo.Usage.CompletionTokens == 0 {
    claudeInfo.Usage.CompletionTokens = fallback.CompletionTokens
}
if claudeInfo.Usage.PromptTokens == 0 {
    claudeInfo.Usage.PromptTokens = fallback.PromptTokens
}
claudeInfo.Usage.TotalTokens = claudeInfo.Usage.PromptTokens + claudeInfo.Usage.CompletionTokens
```

改动点：
1. 不再整份覆盖 `claudeInfo.Usage`，只补 `CompletionTokens` 和 `PromptTokens` 的缺失值
2. 保留 `CachedTokens`、`CacheCreationInputTokens` 等已从 `message_start` 获取的字段
3. `PromptTokens` 兜底改用 `info.GetEstimatePromptTokens()`（与其他渠道对齐）

Fixes #4129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage tracking accuracy by preserving cached usage information while intelligently filling in missing token counts.
  * Enhanced token calculation to merge fallback values with existing data instead of overwriting, preventing loss of cache-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->