### PR TITLE
fix: add Azure channel support for /v1/responses/compact URL routing

### DIFF
--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -136,8 +136,8 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 			task = "chat/completions" + task
 		}
 
-		// 特殊处理 responses API
-		if info.RelayMode == relayconstant.RelayModeResponses {
+		// 特殊处理 responses API（包含 compact）
+		if info.RelayMode == relayconstant.RelayModeResponses || info.RelayMode == relayconstant.RelayModeResponsesCompact {
 			responsesApiVersion := "preview"
 
 			subUrl := "/openai/v1/responses"
@@ -148,6 +148,11 @@ func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 
 			if info.ChannelOtherSettings.AzureResponsesVersion != "" {
 				responsesApiVersion = info.ChannelOtherSettings.AzureResponsesVersion
+			}
+
+			// compact 模式追加 /compact
+			if info.RelayMode == relayconstant.RelayModeResponsesCompact {
+				subUrl = subUrl + "/compact"
 			}
 
 			requestURL = fmt.Sprintf("%s?api-version=%s", subUrl, responsesApiVersion)


### PR DESCRIPTION
## Problem

The Azure channel's `GetRequestURL` method in `relay/channel/openai/adaptor.go` only handles `RelayModeResponses` but misses `RelayModeResponsesCompact`. When Codex CLI/IDE triggers context compaction via `POST /v1/responses/compact`, requests routed through an Azure channel fall through to the generic deployments URL pattern, producing:

```
/openai/deployments/{model}/responses/compact?api-version=xxx
```

Azure doesn't recognize this path and returns 404.

## Fix

Extend the existing `RelayModeResponses` condition (line 139) to also match `RelayModeResponsesCompact`, and append `/compact` to `subUrl` when in compact mode.

### URL comparison (before → after)

| Scenario | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| Normal Azure | `/openai/deployments/{model}/responses/compact?api-version=xxx` | `/openai/v1/responses/compact?api-version=preview` |
| cognitiveservices.azure.com | same broken pattern | `/openai/responses/compact?api-version={apiVersion}` |
| Custom AzureResponsesVersion | ignored for compact | properly respected |

## Changes

- `relay/channel/openai/adaptor.go`: 7 lines changed (2 modified + 5 added)

## Testing

- Verified URL generation logic for all three Azure URL variants (normal, cognitiveservices, custom version)
- Confirmed that non-compact `/v1/responses` routing remains unchanged
- Response handling side (`DoResponse`, line 634) already has the `RelayModeResponsesCompact` case, so only the URL routing was missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Azure OpenAI compact response mode support, enabling more efficient response handling alongside standard responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->