### PR TITLE
fix: 客户端断开连接后取消上游请求，避免持续计费

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -319,6 +319,10 @@ func shouldRetry(c *gin.Context, openaiErr *types.NewAPIError, retryTimes int) b
 	if openaiErr == nil {
 		return false
 	}
+	// Client already disconnected, retrying is pointless and wastes upstream tokens
+	if c.Request.Context().Err() != nil {
+		return false
+	}
 	if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {
 		return false
 	}

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -295,7 +295,7 @@ func DoApiRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBody
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -326,7 +326,7 @@ func DoFormRequest(a Adaptor, c *gin.Context, info *common.RelayInfo, requestBod
 	if common2.DebugEnabled {
 		println("fullRequestURL:", fullRequestURL)
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}
@@ -534,7 +534,7 @@ func DoTaskApiRequest(a TaskAdaptor, c *gin.Context, info *common.RelayInfo, req
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(c.Request.Method, fullRequestURL, requestBody)
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, fullRequestURL, requestBody)
 	if err != nil {
 		return nil, fmt.Errorf("new request failed: %w", err)
 	}


### PR DESCRIPTION
## 概述

客户端断开连接（如取消流式请求）后，上游 API 请求继续处理并计费，因为请求 context 没有传递到上游 HTTP 请求。

修复 #4186

## 改动

### 1. `relay/channel/api_request.go`

将三个函数中的 `http.NewRequest()` 替换为 `http.NewRequestWithContext(c.Request.Context(), ...)`：
- `DoApiRequest`
- `DoFormRequest`
- `DoTaskApiRequest`

上游 HTTP 请求绑定客户端 context 后，客户端断开时 Go 的 HTTP transport 会自动关闭上游连接。

### 2. `controller/relay.go`

在 `shouldRetry()` 开头增加 context 取消检查：

```go
if c.Request.Context().Err() != nil {
    return false
}
```

客户端已断开时跳过重试，避免浪费上游 token。

## 影响

没有此修复时，一次带大上下文的取消请求（如 Claude 带 200K cache_creation token）上游可产生 $9+ 费用。长期累积损失显著。