### PR TITLE
fix: isStream status in error logs instead of hardcoded false

### DIFF
--- a/constant/context_key.go
+++ b/constant/context_key.go
@@ -65,4 +65,5 @@ const (
 
 	// ContextKeyLanguage stores the user's language preference for i18n
 	ContextKeyLanguage ContextKey = "language"
+	ContextKeyIsStream ContextKey = "is_stream"
 )

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -389,7 +389,7 @@ func processChannelError(c *gin.Context, channelError types.ChannelError, err *t
 			startTime = time.Now()
 		}
 		useTimeSeconds := int(time.Since(startTime).Seconds())
-		model.RecordErrorLog(c, userId, channelId, modelName, tokenName, err.MaskSensitiveErrorWithStatusCode(), tokenId, useTimeSeconds, false, userGroup, other)
+		model.RecordErrorLog(c, userId, channelId, modelName, tokenName, err.MaskSensitiveErrorWithStatusCode(), tokenId, useTimeSeconds, common.GetContextKeyBool(c, constant.ContextKeyIsStream), userGroup, other)
 	}
 
 }

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -438,6 +438,7 @@ func genBaseRelayInfo(c *gin.Context, request dto.Request) *RelayInfo {
 	if request != nil {
 		isStream = request.IsStream(c)
 	}
+	c.Set(string(constant.ContextKeyIsStream), isStream)
 
 	// firstResponseTime = time.Now() - 1 second
 


### PR DESCRIPTION
修复当调用错误时, 错误日志未正确记录流式状态
将写死的false 改为 正确的isSteam参数传入

## 📸 运行证明 / Proof of Work
<img width="2016" height="272" alt="image" src="https://github.com/user-attachments/assets/c27959db-dd7e-4023-95f2-0a5094c997fa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced request context tracking for streaming requests. Error logs now accurately capture streaming status, enabling better diagnostics and request context propagation throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->