### PR TITLE
fix(relay): evict stale channel affinity cache when preferred channel is disabled

### DIFF
--- a/middleware/distributor.go
+++ b/middleware/distributor.go
@@ -103,10 +103,12 @@ func Distribute() func(c *gin.Context) {
 					preferred, err := model.CacheGetChannel(preferredChannelID)
 					if err == nil && preferred != nil {
 						if preferred.Status != common.ChannelStatusEnabled {
-							if service.ShouldSkipRetryAfterChannelAffinityFailure(c) {
-								abortWithOpenAiMessage(c, http.StatusForbidden, i18n.T(c, i18n.MsgDistributorChannelDisabled))
-								return
-							}
+							// Preferred channel disabled (manual or auto) — evict stale
+							// affinity cache so this and future requests use normal selection.
+							// After fallback succeeds, RecordChannelAffinity re-records the
+							// new channel automatically.
+							service.EvictChannelAffinityCache(c)
+							// fall through to CacheGetRandomSatisfiedChannel below
 						} else if usingGroup == "auto" {
 							userGroup := common.GetContextKeyString(c, constant.ContextKeyUserGroup)
 							autoGroups := service.GetUserAutoGroup(userGroup)

--- a/service/channel_affinity.go
+++ b/service/channel_affinity.go
@@ -645,15 +645,16 @@ func EvictChannelAffinityCache(c *gin.Context) {
 	if !ok || cacheKey == "" {
 		return
 	}
+	// Clear SkipRetry first, before attempting cache deletion.
+	// This must always run regardless of cache.DeleteMany outcome,
+	// otherwise ShouldSkipRetryAfterChannelAffinityFailure reads
+	// the stale meta from context and prevents retries on the fallback channel.
+	c.Set(ginKeyChannelAffinitySkipRetry, false)
 	cache := getChannelAffinityCache()
 	if _, err := cache.DeleteMany([]string{cacheKey}); err != nil {
 		common.SysError(fmt.Sprintf("channel affinity cache evict failed: key=%s, err=%v", cacheKey, err))
 		return
 	}
-	// Clear SkipRetry so the fallback channel can use normal retry logic.
-	// Without this, ShouldSkipRetryAfterChannelAffinityFailure would read
-	// the stale meta from context and prevent retries on the new channel.
-	c.Set(ginKeyChannelAffinitySkipRetry, false)
 	common.SysLog(fmt.Sprintf("channel affinity cache evicted (preferred channel disabled): key=%s", cacheKey))
 }
 

--- a/service/channel_affinity.go
+++ b/service/channel_affinity.go
@@ -636,6 +636,27 @@ func ShouldSkipRetryAfterChannelAffinityFailure(c *gin.Context) bool {
 	return meta.SkipRetry
 }
 
+// EvictChannelAffinityCache removes the current request's affinity cache entry.
+// Called when the preferred channel has been disabled (manually or auto-disabled),
+// so this and future requests go through normal channel selection.
+// Also clears the SkipRetry flag so the fallback channel can retry normally.
+func EvictChannelAffinityCache(c *gin.Context) {
+	cacheKey, _, ok := getChannelAffinityContext(c)
+	if !ok || cacheKey == "" {
+		return
+	}
+	cache := getChannelAffinityCache()
+	if _, err := cache.DeleteMany([]string{cacheKey}); err != nil {
+		common.SysError(fmt.Sprintf("channel affinity cache evict failed: key=%s, err=%v", cacheKey, err))
+		return
+	}
+	// Clear SkipRetry so the fallback channel can use normal retry logic.
+	// Without this, ShouldSkipRetryAfterChannelAffinityFailure would read
+	// the stale meta from context and prevent retries on the new channel.
+	c.Set(ginKeyChannelAffinitySkipRetry, false)
+	common.SysLog(fmt.Sprintf("channel affinity cache evicted (preferred channel disabled): key=%s", cacheKey))
+}
+
 func MarkChannelAffinityUsed(c *gin.Context, selectedGroup string, channelID int) {
 	if c == nil || channelID <= 0 {
 		return


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

当 channel affinity 缓存命中的首选渠道已被禁用（手动禁用或因额度耗尽自动禁用）时，当前逻辑会直接 abort 请求，而不是继续走正常渠道选择。这导致同分组下明明还有健康渠道，用户却收到"该渠道已被禁用"的错误。

这个 PR 做了两件事：

1. **`middleware/distributor.go`**：将 disabled channel 的处理从"abort"改为"evict + fallthrough"。发现首选渠道已禁用时，清除 stale affinity 缓存，然后走正常的 `CacheGetRandomSatisfiedChannel` 选路。请求成功后，已有的 `RecordChannelAffinity` 会自动把新渠道写回缓存。

2. **`service/channel_affinity.go`**：新增 `EvictChannelAffinityCache` 函数，删除缓存 key 的同时**清除请求上下文中的 `SkipRetry` 标志**。这是关键——`GetPreferredChannelByAffinity` 在查缓存前就把 `SkipRetry=true` 写进了 gin context，如果不清除，后续 `controller/relay.go` 的 `shouldRetry()` 会误读这个 flag，导致 fallback 渠道即使遇到可重试错误也不会重试。

之前的 PR #3413 被关闭的原因就是没有清除 `SkipRetry`，导致"成功亲和后，渠道请求失败仍然不会重试其他渠道"。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #3414

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证流程：
1. 分组内有 3 个渠道 (A/B/C)，affinity 缓存绑定到渠道 A
2. 手动禁用渠道 A
3. 发起请求 → 修复前：abort "该渠道已被禁用"；修复后：自动 fallback 到 B 或 C，请求成功
4. 后续请求直接走新渠道（affinity 自动更新）
5. 同时验证了 auto-disable 场景（额度耗尽触发自动禁用），行为一致

```
go build ./...   # 编译通过，无错误
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel affinity handling so disabled preferred channels are evicted from cache and the system falls back to alternate channels automatically.
  * Ensured cached channel preferences are cleared on selection failure to prevent stuck routing and improve request routing reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->