### PR TITLE
fix(GroupTable): prevent Input cursor jumping to end on keystroke

### DIFF
--- a/web/src/pages/Setting/Ratio/components/GroupTable.jsx
+++ b/web/src/pages/Setting/Ratio/components/GroupTable.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import {
   Button,
   Input,
@@ -61,60 +61,63 @@ export function serializeGroupTable(rows) {
   };
 }
 
-export default function GroupTable({
-  groupRatio,
-  userUsableGroups,
-  onChange,
-}) {
+export default function GroupTable({ groupRatio, userUsableGroups, onChange }) {
   const { t } = useTranslation();
 
   const [rows, setRows] = useState(() =>
     buildRows(groupRatio, userUsableGroups),
   );
 
-  const emitChange = useCallback(
-    (newRows) => {
-      setRows(newRows);
-      onChange?.(serializeGroupTable(newRows));
-    },
-    [onChange],
-  );
+  // Use functional setRows to keep updateRow/addRow/removeRow referentially
+  // stable, preventing columns useMemo from rebuilding on every keystroke
+  // which causes the Input cursor to jump to end (cursor reset bug).
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  const emitAndSet = useCallback((updater) => {
+    setRows((prev) => {
+      const next = typeof updater === 'function' ? updater(prev) : updater;
+      onChangeRef.current?.(serializeGroupTable(next));
+      return next;
+    });
+  }, []);
 
   const updateRow = useCallback(
     (id, field, value) => {
-      const next = rows.map((r) =>
-        r._id === id ? { ...r, [field]: value } : r,
+      emitAndSet((prev) =>
+        prev.map((r) => (r._id === id ? { ...r, [field]: value } : r)),
       );
-      emitChange(next);
     },
-    [rows, emitChange],
+    [emitAndSet],
   );
 
   const addRow = useCallback(() => {
-    const existingNames = new Set(rows.map((r) => r.name));
-    let counter = 1;
-    let newName = `group_${counter}`;
-    while (existingNames.has(newName)) {
-      counter++;
-      newName = `group_${counter}`;
-    }
-    emitChange([
-      ...rows,
-      {
-        _id: uid(),
-        name: newName,
-        ratio: 1,
-        selectable: true,
-        description: '',
-      },
-    ]);
-  }, [rows, emitChange]);
+    emitAndSet((prev) => {
+      const existingNames = new Set(prev.map((r) => r.name));
+      let counter = 1;
+      let newName = `group_${counter}`;
+      while (existingNames.has(newName)) {
+        counter++;
+        newName = `group_${counter}`;
+      }
+      return [
+        ...prev,
+        {
+          _id: uid(),
+          name: newName,
+          ratio: 1,
+          selectable: true,
+          description: '',
+        },
+      ];
+    });
+  }, [emitAndSet]);
 
   const removeRow = useCallback(
     (id) => {
-      emitChange(rows.filter((r) => r._id !== id));
+      emitAndSet((prev) => prev.filter((r) => r._id !== id));
     },
-    [rows, emitChange],
+    [emitAndSet],
   );
 
   const groupNames = useMemo(() => rows.map((r) => r.name), [rows]);
@@ -127,6 +130,11 @@ export default function GroupTable({
     return new Set(Object.keys(counts).filter((k) => counts[k] > 1));
   }, [groupNames]);
 
+  // Use ref so column render functions always read the latest duplicate set
+  // without adding duplicateNames to columns deps (which would break cursor).
+  const duplicateNamesRef = useRef(duplicateNames);
+  duplicateNamesRef.current = duplicateNames;
+
   const columns = useMemo(
     () => [
       {
@@ -138,7 +146,9 @@ export default function GroupTable({
           <Input
             size='small'
             value={record.name}
-            status={duplicateNames.has(record.name) ? 'warning' : undefined}
+            status={
+              duplicateNamesRef.current.has(record.name) ? 'warning' : undefined
+            }
             onChange={(v) => updateRow(record._id, 'name', v)}
           />
         ),
@@ -212,7 +222,7 @@ export default function GroupTable({
         ),
       },
     ],
-    [t, duplicateNames, updateRow, removeRow],
+    [t, updateRow, removeRow],
   );
 
   return (
@@ -223,9 +233,7 @@ export default function GroupTable({
         rowKey='_id'
         hidePagination
         size='small'
-        empty={
-          <Text type='tertiary'>{t('暂无分组，点击下方按钮添加')}</Text>
-        }
+        empty={<Text type='tertiary'>{t('暂无分组，点击下方按钮添加')}</Text>}
       />
       <div className='mt-3 flex justify-center'>
         <Button icon={<IconPlus />} theme='outline' onClick={addRow}>
@@ -234,7 +242,8 @@ export default function GroupTable({
       </div>
       {duplicateNames.size > 0 && (
         <Text type='warning' size='small' className='mt-2 block'>
-          {t('存在重复的分组名称：')}{Array.from(duplicateNames).join(', ')}
+          {t('存在重复的分组名称：')}
+          {Array.from(duplicateNames).join(', ')}
         </Text>
       )}
     </div>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

在分组设置的 GroupTable 中编辑分组名称时，每输入一个字符光标就跳到末尾，无法在中间位置插入或修改文字。

根本原因：`updateRow` / `addRow` / `removeRow` 闭包捕获了 `rows` 状态，导致它们在每次 state 变化后引用都变，进而让 `columns` 的 `useMemo` 失效重建。Semi UI `<Table>` 检测到 columns 引用变化后整体 re-render，`<Input>` 组件被重新挂载，光标位置丢失。

修复方式：
1. `updateRow` / `addRow` / `removeRow` 改用 `setRows(prev => ...)` 函数式更新，不再依赖 `rows` 闭包
2. `onChange` 和 `duplicateNames` 改用 `useRef` 存储，列渲染函数通过 ref 读取最新值
3. `columns` 的 `useMemo` 依赖项从 `[t, duplicateNames, updateRow, removeRow]` 精简为 `[t, updateRow, removeRow]`

这样 `columns` 在 keystroke 间保持引用稳定，`<Input>` 不会被重新挂载，光标位置正常保留。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4206

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地验证：
1. 进入 系统设置 → 计费 → 分组设置
2. 点击分组名称输入框，将光标定位到中间位置
3. 输入字符 → 修复前：光标跳到末尾；修复后：光标留在输入位置
4. 连续快速输入多个字符 → 行为正常，无闪烁、无跳转

```
cd web && bun run build   # 前端构建通过，无错误
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management and callback handling in the group settings component to enhance performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->