### PR TITLE
feat: include admin username in quota adjustment logs

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -912,6 +912,7 @@ func ManageUser(c *gin.Context) {
 		}
 		user.Role = common.RoleCommonUser
 	case "add_quota":
+		adminName := c.GetString("username")
 		switch req.Mode {
 		case "add":
 			if req.Value <= 0 {
@@ -923,7 +924,7 @@ func ManageUser(c *gin.Context) {
 				return
 			}
 			model.RecordLog(user.Id, model.LogTypeManage,
-				fmt.Sprintf("管理员增加用户额度 %s", logger.LogQuota(req.Value)))
+				fmt.Sprintf("管理员(%s)增加用户额度 %s", adminName, logger.LogQuota(req.Value)))
 		case "subtract":
 			if req.Value <= 0 {
 				common.ApiErrorI18n(c, i18n.MsgUserQuotaChangeZero)
@@ -934,7 +935,7 @@ func ManageUser(c *gin.Context) {
 				return
 			}
 			model.RecordLog(user.Id, model.LogTypeManage,
-				fmt.Sprintf("管理员减少用户额度 %s", logger.LogQuota(req.Value)))
+				fmt.Sprintf("管理员(%s)减少用户额度 %s", adminName, logger.LogQuota(req.Value)))
 		case "override":
 			oldQuota := user.Quota
 			if err := model.DB.Model(&model.User{}).Where("id = ?", user.Id).Update("quota", req.Value).Error; err != nil {
@@ -942,7 +943,7 @@ func ManageUser(c *gin.Context) {
 				return
 			}
 			model.RecordLog(user.Id, model.LogTypeManage,
-				fmt.Sprintf("管理员覆盖用户额度从 %s 为 %s", logger.LogQuota(oldQuota), logger.LogQuota(req.Value)))
+				fmt.Sprintf("管理员(%s)覆盖用户额度从 %s 为 %s", adminName, logger.LogQuota(oldQuota), logger.LogQuota(req.Value)))
 		default:
 			common.ApiErrorI18n(c, i18n.MsgInvalidParams)
 			return


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
多个管理员变更用户额度时,记录操作的管理员username

## 📸 运行证明 / Proof of Work
* 修改前: 
<img width="247" height="58" alt="image" src="https://github.com/user-attachments/assets/94be2bc5-c605-4847-abcf-a1c93fa1ceea" />

* 修改后:
<img width="244" height="68" alt="image" src="https://github.com/user-attachments/assets/6a422539-5cd7-4924-87bb-67d12fa90a58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logs for quota management now include the acting administrator's name for add, subtract, and override operations, improving accountability and traceability of quota modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->