### PR TITLE
Make Claude auto tests mirror Claude Code traffic

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -36,6 +36,21 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+var claudeCodeTestHeaders = map[string]string{
+	"User-Agent":                                "claude-code/channel-test",
+	"X-Stainless-Arch":                          "arm64",
+	"X-Stainless-Lang":                          "js",
+	"X-Stainless-Os":                            "macos",
+	"X-Stainless-Package-Version":               "channel-test",
+	"X-Stainless-Retry-Count":                   "0",
+	"X-Stainless-Runtime":                       "node",
+	"X-Stainless-Runtime-Version":               "20.18.0",
+	"X-Stainless-Timeout":                       "600",
+	"X-App":                                     "claude-code",
+	"Anthropic-Version":                         "2023-06-01",
+	"Anthropic-Dangerous-Direct-Browser-Access": "false",
+}
+
 type testResult struct {
 	context     *gin.Context
 	localErr    error
@@ -54,6 +69,32 @@ func normalizeChannelTestEndpoint(channel *model.Channel, modelName, endpointTyp
 		return string(constant.EndpointTypeOpenAIResponse)
 	}
 	return normalized
+}
+
+func applyClaudeCodeTestFixtures(c *gin.Context, info *relaycommon.RelayInfo, request dto.Request) {
+	if c == nil || c.Request == nil || info == nil || info.RelayFormat != types.RelayFormatClaude {
+		return
+	}
+
+	for key, value := range claudeCodeTestHeaders {
+		if strings.TrimSpace(c.Request.Header.Get(key)) == "" {
+			c.Request.Header.Set(key, value)
+		}
+	}
+
+	if req, ok := request.(*dto.GeneralOpenAIRequest); ok && len(req.Metadata) == 0 {
+		req.Metadata = json.RawMessage(`{"user_id":"channel-test"}`)
+	}
+
+	runtimeHeaders := map[string]interface{}{}
+	for key, value := range relaycommon.GetEffectiveHeaderOverride(info) {
+		runtimeHeaders[key] = value
+	}
+	for key, value := range claudeCodeTestHeaders {
+		runtimeHeaders[key] = value
+	}
+	info.RuntimeHeadersOverride = runtimeHeaders
+	info.UseRuntimeHeadersOverride = true
 }
 
 func testChannel(channel *model.Channel, testModel string, endpointType string, isStream bool) testResult {
@@ -231,6 +272,7 @@ func testChannel(channel *model.Channel, testModel string, endpointType string, 
 
 	info.IsChannelTest = true
 	info.InitChannelMeta(c)
+	applyClaudeCodeTestFixtures(c, info, request)
 
 	err = helper.ModelMappedHelper(c, info, request)
 	if err != nil {
@@ -785,7 +827,7 @@ func TestChannel(c *gin.Context) {
 var testAllChannelsLock sync.Mutex
 var testAllChannelsRunning bool = false
 
-func testAllChannels(notify bool) error {
+func testAllChannels(notify bool, allowAutoDisable bool) error {
 
 	testAllChannelsLock.Lock()
 	if testAllChannelsRunning {
@@ -838,7 +880,17 @@ func testAllChannels(notify bool) error {
 
 			// disable channel
 			if isChannelEnabled && shouldBanChannel && channel.GetAutoBan() {
-				processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+				if allowAutoDisable {
+					processChannelError(result.context, *types.NewChannelError(channel.Id, channel.Type, channel.Name, channel.ChannelInfo.IsMultiKey, common.GetContextKeyString(result.context, constant.ContextKeyChannelKey), channel.GetAutoBan()), newAPIError)
+				} else {
+					common.SysLog(fmt.Sprintf(
+						"scheduled channel test detected unhealthy channel but skipped auto-disable: channel_id=%d name=%s status_code=%d reason=%s",
+						channel.Id,
+						channel.Name,
+						newAPIError.StatusCode,
+						newAPIError.Error(),
+					))
+				}
 			}
 
 			// enable channel
@@ -858,7 +910,7 @@ func testAllChannels(notify bool) error {
 }
 
 func TestAllChannels(c *gin.Context) {
-	err := testAllChannels(true)
+	err := testAllChannels(true, true)
 	if err != nil {
 		common.ApiError(c, err)
 		return
@@ -887,7 +939,7 @@ func AutomaticallyTestChannels() {
 				time.Sleep(time.Duration(int(math.Round(frequency))) * time.Minute)
 				common.SysLog(fmt.Sprintf("automatically test channels with interval %f minutes", frequency))
 				common.SysLog("automatically testing all channels")
-				_ = testAllChannels(false)
+				_ = testAllChannels(false, false)
 				common.SysLog("automatically channel test finished")
 				if !operation_setting.GetMonitorSetting().AutoTestChannelEnabled {
 					break

--- a/controller/channel_test_fixture_test.go
+++ b/controller/channel_test_fixture_test.go
@@ -1,0 +1,61 @@
+package controller
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyClaudeCodeTestFixturesInjectsHeadersAndMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	ctx.Request.Header.Set("Content-Type", "application/json")
+
+	req := &dto.GeneralOpenAIRequest{
+		Model: "claude-sonnet-4-6",
+		Messages: []dto.Message{
+			{Role: "user", Content: "hi"},
+		},
+	}
+	info := &relaycommon.RelayInfo{
+		RelayFormat: types.RelayFormatClaude,
+	}
+
+	applyClaudeCodeTestFixtures(ctx, info, req)
+
+	require.JSONEq(t, `{"user_id":"channel-test"}`, string(req.Metadata))
+	require.Equal(t, "claude-code/channel-test", ctx.Request.Header.Get("User-Agent"))
+	require.Equal(t, "2023-06-01", ctx.Request.Header.Get("Anthropic-Version"))
+	require.True(t, info.UseRuntimeHeadersOverride)
+	require.Equal(t, "claude-code", info.RuntimeHeadersOverride["X-App"])
+}
+
+func TestApplyClaudeCodeTestFixturesPreservesExistingMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	req := &dto.GeneralOpenAIRequest{
+		Model:    "claude-sonnet-4-6",
+		Metadata: json.RawMessage(`{"user_id":"existing-user"}`),
+	}
+	info := &relaycommon.RelayInfo{
+		RelayFormat: types.RelayFormatClaude,
+	}
+
+	applyClaudeCodeTestFixtures(ctx, info, req)
+
+	require.JSONEq(t, `{"user_id":"existing-user"}`, string(req.Metadata))
+}

--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -184,6 +184,9 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 		Temperature:   textRequest.Temperature,
 		Tools:         claudeTools,
 	}
+	if len(textRequest.Metadata) > 0 {
+		claudeRequest.Metadata = textRequest.Metadata
+	}
 	if maxTokens := textRequest.GetMaxTokens(); maxTokens > 0 {
 		claudeRequest.MaxTokens = common.GetPointer(maxTokens)
 	}

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -362,4 +363,21 @@ func TestRequestOpenAI2ClaudeMessage_ConvertsTextFileContentToText(t *testing.T)
 	require.Equal(t, "text", content[0].Type)
 	require.NotNil(t, content[0].Text)
 	require.Equal(t, "alpha\nbeta", *content[0].Text)
+}
+
+func TestRequestOpenAI2ClaudeMessage_PreservesMetadata(t *testing.T) {
+	request := dto.GeneralOpenAIRequest{
+		Model:    "claude-3-5-sonnet",
+		Metadata: json.RawMessage(`{"user_id":"channel-test"}`),
+		Messages: []dto.Message{
+			{
+				Role:    "user",
+				Content: "hi",
+			},
+		},
+	}
+
+	claudeRequest, err := RequestOpenAI2ClaudeMessage(nil, request)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"user_id":"channel-test"}`, string(claudeRequest.Metadata))
 }


### PR DESCRIPTION
## Summary
- make scheduled Claude health checks send Claude Code style headers
- attach `metadata.user_id` to Claude auto-test requests and preserve metadata in Claude conversion
- stop scheduled auto-tests from directly auto-disabling channels while keeping manual test disable behavior intact
- add targeted regression coverage for the Claude Code test fixtures

## Why
A large share of Claude channels were being auto-disabled even though manual Claude Code traffic could still succeed. The root cause was that auto-tests were not close enough to real Claude Code traffic, so Claude-only upstreams were returning false negatives. This change makes the synthetic traffic much closer to real Claude Code requests and removes the most dangerous part of the feedback loop: scheduled tests auto-banning channels.

## Testing
- go test ./controller -run 'TestApplyClaudeCodeTestFixtures'
- go test ./relay/channel/claude -run 'TestRequestOpenAI2ClaudeMessage_PreservesMetadata'
- go test ./controller ./service


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test fixtures and coverage for Claude-specific channel testing
  * Added validation for metadata preservation in request transformation

* **Refactor**
  * Enhanced channel test control flow with configurable auto-disable behavior
  * Improved metadata handling in Claude request processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->