### PR TITLE
fix(channel): 修复多密钥管理弹窗索引显示，将索引值调整为从1开始

### DIFF
--- a/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
+++ b/web/src/components/table/channels/modals/MultiKeyManageModal.jsx
@@ -360,7 +360,7 @@ const MultiKeyManageModal = ({ visible, onCancel, channel, onRefresh }) => {
     {
       title: t('索引'),
       dataIndex: 'index',
-      render: (text) => `#${text}`,
+      render: (text) => `#${Number(text) + 1}`,
     },
     // {
     //   title: t('密钥预览'),


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 统一了“查看密钥”与“多密钥管理”界面的索引编号逻辑，解决了 0 索引与 1 编号混用导致的视觉不一致问题。

## 📝 变更描述 / Description
优化了多密钥管理界面的交互体验。原本“查看密钥”弹窗使用 1-based 编号（如：密钥 1），而“多密钥管理”使用 0-based 索引（如：#0），这种不一致给用户带来了认知负担。

本次改动仅针对前端显示逻辑，在 `MultiKeyManageModal` 的表格渲染器中将 `index` 加 1 显示（`#1, #2...`），从而确保两个界面的编号完全对齐。该改动不影响后端数据交互逻辑，所有后台请求依然匹配原始索引。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [x] ⚡ 性能优化 / 重构 (Refactor) - *UI/UX 体验一致性优化*
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，确认不是重复提交。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在测试环境下验证索引编号已正确对齐。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
修改后，“多密钥管理”弹窗中的 **#0, #1** 索引现已显示为 **#1, #2**，完美对应“查看密钥”中的 **密钥 1, 密钥 2**。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table index column display to use 1-based numbering for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->