### PR TITLE
  feat: support qiniu ai provider

### DIFF
--- a/common/api_type.go
+++ b/common/api_type.go
@@ -7,6 +7,8 @@ func ChannelType2APIType(channelType int) (int, bool) {
 	switch channelType {
 	case constant.ChannelTypeOpenAI:
 		apiType = constant.APITypeOpenAI
+	case constant.ChannelTypeQiniu:
+		apiType = constant.APITypeOpenAI
 	case constant.ChannelTypeAnthropic:
 		apiType = constant.APITypeAnthropic
 	case constant.ChannelTypeBaidu:

--- a/constant/channel.go
+++ b/constant/channel.go
@@ -55,6 +55,7 @@ const (
 	ChannelTypeSora           = 55
 	ChannelTypeReplicate      = 56
 	ChannelTypeCodex          = 57
+	ChannelTypeQiniu          = 58
 	ChannelTypeDummy          // this one is only for count, do not add any channel after this
 
 )
@@ -118,6 +119,7 @@ var ChannelBaseURLs = []string{
 	"https://api.openai.com",                    //55
 	"https://api.replicate.com",                 //56
 	"https://chatgpt.com",                       //57
+	"https://api.qnaigc.com",                    //58
 }
 
 var ChannelTypeNames = map[int]string{
@@ -175,6 +177,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeSora:           "Sora",
 	ChannelTypeReplicate:      "Replicate",
 	ChannelTypeCodex:          "Codex",
+	ChannelTypeQiniu:          "Qiniu",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/controller/channel_upstream_update_qiniu_test.go
+++ b/controller/channel_upstream_update_qiniu_test.go
@@ -1,0 +1,47 @@
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+)
+
+func TestFetchChannelUpstreamModelIDs_Qiniu(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Fatalf("unexpected Authorization header: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"deepseek/deepseek-v3.1-terminus-thinking"},{"id":"gpt-4"}]}`))
+	}))
+	defer srv.Close()
+
+	ch := &model.Channel{
+		Id:     123,
+		Type:   constant.ChannelTypeQiniu,
+		Key:    "test-key",
+		Status: common.ChannelStatusEnabled,
+		BaseURL: common.GetPointer[string](srv.URL),
+	}
+
+	got, err := fetchChannelUpstreamModelIDs(ch)
+	if err != nil {
+		t.Fatalf("fetchChannelUpstreamModelIDs returned error: %v", err)
+	}
+	if len(got) != 2 || got[0] != "deepseek/deepseek-v3.1-terminus-thinking" || got[1] != "gpt-4" {
+		t.Fatalf("unexpected models: %#v", got)
+	}
+}
+

--- a/relay/channel/openai/adaptor.go
+++ b/relay/channel/openai/adaptor.go
@@ -244,7 +244,7 @@ func (a *Adaptor) ConvertOpenAIRequest(c *gin.Context, info *relaycommon.RelayIn
 	if request == nil {
 		return nil, errors.New("request is nil")
 	}
-	if info.ChannelType != constant.ChannelTypeOpenAI && info.ChannelType != constant.ChannelTypeAzure {
+	if !info.SupportStreamOptions {
 		request.StreamOptions = nil
 	}
 	if info.ChannelType == constant.ChannelTypeOpenRouter {

--- a/relay/common/relay_info.go
+++ b/relay/common/relay_info.go
@@ -305,6 +305,7 @@ func (info *RelayInfo) ToString() string {
 // 定义支持流式选项的通道类型
 var streamSupportedChannels = map[int]bool{
 	constant.ChannelTypeOpenAI:      true,
+	constant.ChannelTypeQiniu:       true,
 	constant.ChannelTypeAnthropic:   true,
 	constant.ChannelTypeAws:         true,
 	constant.ChannelTypeGemini:      true,

--- a/web/src/components/table/channels/modals/EditChannelModal.jsx
+++ b/web/src/components/table/channels/modals/EditChannelModal.jsx
@@ -132,6 +132,7 @@ const DEPRECATED_DOUBAO_CODING_PLAN_BASE_URL = 'doubao-coding-plan';
 // 支持并且已适配通过接口获取模型列表的渠道类型
 const MODEL_FETCHABLE_TYPES = new Set([
   1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  58,
 ]);
 
 function type2secretPrompt(type) {

--- a/web/src/constants/channel.constants.js
+++ b/web/src/constants/channel.constants.js
@@ -189,11 +189,17 @@ export const CHANNEL_OPTIONS = [
     color: 'blue',
     label: 'Codex (OpenAI OAuth)',
   },
+  {
+    value: 58,
+    color: 'green',
+    label: 'Qiniu',
+  },
 ];
 
 // Channel types that support upstream model list fetching in UI.
 export const MODEL_FETCHABLE_CHANNEL_TYPES = new Set([
   1, 4, 14, 34, 17, 26, 27, 24, 47, 25, 20, 23, 31, 40, 42, 48, 43,
+  58,
 ]);
 
 export const MODEL_TABLE_PAGE_SIZE = 10;

--- a/web/src/helpers/render.jsx
+++ b/web/src/helpers/render.jsx
@@ -330,6 +330,7 @@ export function getChannelIcon(channelType) {
     case 1: // OpenAI
     case 3: // Azure OpenAI
     case 57: // Codex
+    case 58: // Qiniu (OpenAI compatible)
       return <OpenAI size={iconSize} />;
     case 2: // Midjourney Proxy
     case 5: // Midjourney Proxy Plus


### PR DESCRIPTION
## 📝 变更描述 / Description

本 PR 为 **Qiniu（七牛）** 增加了一个独立的渠道类型（`type=58`），并将其按 **OpenAI 兼容供应商**接入现有转发链路：后端将 `ChannelTypeQiniu` 映射到 `APITypeOpenAI`，因此请求转发与鉴权逻辑复用 OpenAI adaptor（`Authorization: Bearer <key>`），无需额外的请求体/响应体转换。

同时，补齐了“从上游拉取模型列表”的能力：前端将 `type=58` 加入可拉取模型列表的白名单集合，使渠道编辑弹窗可以调用现有的 `/v1/models` 拉取流程；后端沿用统一的 `/v1/models` 解析逻辑，返回 `data[].id` 作为模型列表。新增单元测试使用 `httptest` 模拟上游 `/v1/models`，验证请求路径与 Bearer 鉴权头正确，并能正确解析模型 ID。

## 🚀 变更类型 / Type of change

- [ ] 🐛 Bug 修复 (Bug fix)
- [x] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- 无

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

本地测试通过（只跑本次新增覆盖项）：

```bash
go test ./controller -run Qiniu
ok  	github.com/QuantumNous/new-api/controller	0.456s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Qiniu as a new supported channel provider with complete integration across backend and frontend systems.
  * Enabled automatic upstream model list fetching and mapping capabilities for Qiniu channels, allowing dynamic model synchronization.
  * Implemented full streaming protocol support for Qiniu channels alongside request compatibility handling.
  * Enhanced the channel management interface to display Qiniu as an available provider option with dedicated UI controls for model management and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->