### PR TITLE
fix: use json.RawMessage for Instructions field in OpenAIResponsesResponse

### DIFF
--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -272,7 +272,7 @@ type OpenAIResponsesResponse struct {
 	Status             json.RawMessage    `json:"status"`
 	Error              any                `json:"error,omitempty"`
 	IncompleteDetails  *IncompleteDetails `json:"incomplete_details,omitempty"`
-	Instructions       string             `json:"instructions"`
+	Instructions       json.RawMessage    `json:"instructions"`
 	MaxOutputTokens    int                `json:"max_output_tokens"`
 	Model              string             `json:"model"`
 	Output             []ResponsesOutput  `json:"output"`


### PR DESCRIPTION
## Problem

When proxying `/v1/responses` requests to upstream providers, both non-streaming and streaming calls return HTTP 500 if the upstream response contains `"instructions": null` (or any non-string value).

This happens because `OpenAIResponsesResponse.Instructions` is defined as `string`, but the OpenAI Responses API spec allows this field to be `null`, a string, or potentially other JSON types. Go's `json.Unmarshal` fails when trying to decode `null` into a `string` field, causing the entire response deserialization to fail.

## Root Cause

In `dto/openai_response.go`, the `OpenAIResponsesResponse` struct defines:

```go
Instructions       string             `json:"instructions"`
```

Other fields in the same struct (`Status`, `ToolChoice`, `Truncation`, `PreviousResponseID`, `User`, `Metadata`) already use `json.RawMessage` to handle polymorphic JSON values. The `Instructions` field was the only one left as `string`.

Notably, the **request-side** struct in `dto/openai_request.go` (line 828) already defines `Instructions` as `json.RawMessage` — this fix makes the response-side consistent with the request-side.

## Fix

Change `Instructions` from `string` to `json.RawMessage` in `OpenAIResponsesResponse`, matching the pattern used by all other polymorphic fields in the same struct.

## Impact

- One-line change, no behavioral difference for valid string values
- Fixes 500 errors when upstream returns `"instructions": null`
- Aligns response DTO with request DTO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **No user-facing changes**
  * Internal technical adjustment to data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->