### PR TITLE
feat(web): show Codex quota bars in channel table

### DIFF
--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -300,12 +300,15 @@ const renderCodexWindowUsage = (record, field, updateChannelBalance, t) => {
 
   const displayPercent = clampPercent(percent);
   const loadingTip = usage.loading ? ` · ${t('刷新中')}` : '';
+  const usageLabel = `${t('查看 Codex 帐号信息与用量')} (${displayPercent}%)`;
 
   return (
     <Tooltip content={`${t('点击查看 Codex 帐号信息与用量')}${loadingTip}`}>
-      <div
-        className='min-w-[120px] cursor-pointer'
+      <button
+        type='button'
+        className='min-w-[120px] cursor-pointer border-0 bg-transparent p-0 text-left'
         onClick={() => updateChannelBalance(record)}
+        aria-label={usageLabel}
       >
         <div className='mb-1 flex items-center justify-between gap-2 text-xs text-semi-color-text-2'>
           <span>{displayPercent}%</span>
@@ -317,7 +320,7 @@ const renderCodexWindowUsage = (record, field, updateChannelBalance, t) => {
           showInfo={false}
           size='small'
         />
-      </div>
+      </button>
     </Tooltip>
   );
 };

--- a/web/src/components/table/channels/ChannelsColumnDefs.jsx
+++ b/web/src/components/table/channels/ChannelsColumnDefs.jsx
@@ -23,11 +23,11 @@ import {
   Dropdown,
   InputNumber,
   Modal,
+  Progress,
   Space,
   SplitButtonGroup,
   Tag,
   Tooltip,
-  Typography,
 } from '@douyinfe/semi-ui';
 import {
   timestamp2string,
@@ -50,6 +50,10 @@ import {
   IconAlertTriangle,
 } from '@douyinfe/semi-icons';
 import { FaRandom } from 'react-icons/fa';
+import {
+  clampPercent,
+  CODEX_CHANNEL_TYPE,
+} from './codexUsageUtils';
 
 // Render functions
 const renderType = (type, record = {}, t) => {
@@ -251,6 +255,71 @@ const renderResponseTime = (responseTime, t) => {
       </Tag>
     );
   }
+};
+
+const pickCodexUsageStroke = (percent) => {
+  const parsed = clampPercent(percent);
+  if (parsed >= 95) {
+    return '#ef4444';
+  }
+  if (parsed >= 80) {
+    return '#f59e0b';
+  }
+  return '#3b82f6';
+};
+
+const renderCodexWindowUsage = (record, field, updateChannelBalance, t) => {
+  if (record.children !== undefined || record.type !== CODEX_CHANNEL_TYPE) {
+    return '-';
+  }
+
+  const usage = record.codex_usage || {};
+  const percent = usage?.summary?.[field];
+
+  if (usage.loading && percent == null) {
+    return (
+      <Tag color='grey' shape='circle'>
+        {t('加载中')}
+      </Tag>
+    );
+  }
+
+  if (usage.error && percent == null) {
+    return (
+      <Tooltip content={usage.error}>
+        <Tag color='red' shape='circle'>
+          {t('获取失败')}
+        </Tag>
+      </Tooltip>
+    );
+  }
+
+  if (percent == null) {
+    return '-';
+  }
+
+  const displayPercent = clampPercent(percent);
+  const loadingTip = usage.loading ? ` · ${t('刷新中')}` : '';
+
+  return (
+    <Tooltip content={`${t('点击查看 Codex 帐号信息与用量')}${loadingTip}`}>
+      <div
+        className='min-w-[120px] cursor-pointer'
+        onClick={() => updateChannelBalance(record)}
+      >
+        <div className='mb-1 flex items-center justify-between gap-2 text-xs text-semi-color-text-2'>
+          <span>{displayPercent}%</span>
+          {usage.loading ? <span>{t('刷新中')}</span> : null}
+        </div>
+        <Progress
+          percent={displayPercent}
+          stroke={pickCodexUsageStroke(displayPercent)}
+          showInfo={false}
+          size='small'
+        />
+      </div>
+    </Tooltip>
+  );
 };
 
 const isRequestPassThroughEnabled = (record) => {
@@ -538,7 +607,7 @@ export const getChannelsColumns = ({
                 </Tooltip>
                 <Tooltip
                   content={
-                    record.type === 57
+                    record.type === CODEX_CHANNEL_TYPE
                       ? t('查看 Codex 帐号信息与用量')
                       : t('剩余额度') +
                         ': ' +
@@ -547,13 +616,21 @@ export const getChannelsColumns = ({
                   }
                 >
                   <Tag
-                    color={record.type === 57 ? 'light-blue' : 'white'}
-                    type={record.type === 57 ? 'light' : 'ghost'}
+                    color={
+                      record.type === CODEX_CHANNEL_TYPE
+                        ? 'light-blue'
+                        : 'white'
+                    }
+                    type={
+                      record.type === CODEX_CHANNEL_TYPE ? 'light' : 'ghost'
+                    }
                     shape='circle'
-                    className={record.type === 57 ? 'cursor-pointer' : ''}
+                    className={
+                      record.type === CODEX_CHANNEL_TYPE ? 'cursor-pointer' : ''
+                    }
                     onClick={() => updateChannelBalance(record)}
                   >
-                    {record.type === 57
+                    {record.type === CODEX_CHANNEL_TYPE
                       ? t('帐号信息')
                       : renderQuotaWithAmount(record.balance)}
                   </Tag>
@@ -571,6 +648,30 @@ export const getChannelsColumns = ({
           );
         }
       },
+    },
+    {
+      key: COLUMN_KEYS.CODEX_FIVE_HOUR,
+      title: t('Codex 5小时'),
+      dataIndex: 'codex_usage',
+      render: (text, record) =>
+        renderCodexWindowUsage(
+          record,
+          'fiveHourPercent',
+          updateChannelBalance,
+          t,
+        ),
+    },
+    {
+      key: COLUMN_KEYS.CODEX_WEEKLY,
+      title: t('Codex 每周'),
+      dataIndex: 'codex_usage',
+      render: (text, record) =>
+        renderCodexWindowUsage(
+          record,
+          'weeklyPercent',
+          updateChannelBalance,
+          t,
+        ),
     },
     {
       key: COLUMN_KEYS.PRIORITY,

--- a/web/src/components/table/channels/codexUsageUtils.js
+++ b/web/src/components/table/channels/codexUsageUtils.js
@@ -86,7 +86,10 @@ export const extractCodexUsageSummary = (payload) => {
     if (!windowData) {
       return null;
     }
-    return clampPercent(windowData?.used_percent ?? 0);
+    if (windowData?.used_percent == null) {
+      return null;
+    }
+    return clampPercent(windowData.used_percent);
   };
 
   return {

--- a/web/src/components/table/channels/codexUsageUtils.js
+++ b/web/src/components/table/channels/codexUsageUtils.js
@@ -1,0 +1,98 @@
+export const CODEX_CHANNEL_TYPE = 57;
+
+export const clampPercent = (value) => {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(100, parsed));
+};
+
+const normalizePlanType = (value) => {
+  if (value == null) {
+    return '';
+  }
+  return String(value).trim().toLowerCase();
+};
+
+const getWindowDurationSeconds = (windowData) => {
+  const value = Number(windowData?.limit_window_seconds);
+  if (!Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return value;
+};
+
+const classifyWindowByDuration = (windowData) => {
+  const seconds = getWindowDurationSeconds(windowData);
+  if (seconds == null) {
+    return null;
+  }
+  return seconds >= 24 * 60 * 60 ? 'weekly' : 'fiveHour';
+};
+
+export const resolveRateLimitWindows = (data) => {
+  const rateLimit = data?.rate_limit ?? {};
+  const primary = rateLimit?.primary_window ?? null;
+  const secondary = rateLimit?.secondary_window ?? null;
+  const windows = [primary, secondary].filter(Boolean);
+  const planType = normalizePlanType(data?.plan_type ?? rateLimit?.plan_type);
+
+  let fiveHourWindow = null;
+  let weeklyWindow = null;
+
+  for (const windowData of windows) {
+    const bucket = classifyWindowByDuration(windowData);
+    if (bucket === 'fiveHour' && !fiveHourWindow) {
+      fiveHourWindow = windowData;
+      continue;
+    }
+    if (bucket === 'weekly' && !weeklyWindow) {
+      weeklyWindow = windowData;
+    }
+  }
+
+  if (planType === 'free') {
+    if (!weeklyWindow) {
+      weeklyWindow = primary ?? secondary ?? null;
+    }
+    return { fiveHourWindow: null, weeklyWindow };
+  }
+
+  if (!fiveHourWindow && !weeklyWindow) {
+    return {
+      fiveHourWindow: primary ?? null,
+      weeklyWindow: secondary ?? null,
+    };
+  }
+
+  if (!fiveHourWindow) {
+    fiveHourWindow =
+      windows.find((windowData) => windowData !== weeklyWindow) ?? null;
+  }
+  if (!weeklyWindow) {
+    weeklyWindow =
+      windows.find((windowData) => windowData !== fiveHourWindow) ?? null;
+  }
+
+  return { fiveHourWindow, weeklyWindow };
+};
+
+export const extractCodexUsageSummary = (payload) => {
+  const data = payload?.data ?? null;
+  const { fiveHourWindow, weeklyWindow } = resolveRateLimitWindows(data);
+
+  const readPercent = (windowData) => {
+    if (!windowData) {
+      return null;
+    }
+    return clampPercent(windowData?.used_percent ?? 0);
+  };
+
+  return {
+    fiveHourPercent: readPercent(fiveHourWindow),
+    weeklyPercent: readPercent(weeklyWindow),
+    accountType: data?.plan_type ?? data?.rate_limit?.plan_type ?? '',
+    upstreamStatus: payload?.upstream_status ?? null,
+  };
+};

--- a/web/src/components/table/channels/modals/CodexUsageModal.jsx
+++ b/web/src/components/table/channels/modals/CodexUsageModal.jsx
@@ -29,14 +29,12 @@ import {
   Collapse,
 } from '@douyinfe/semi-ui';
 import { API, showError } from '../../../../helpers';
+import {
+  clampPercent,
+  resolveRateLimitWindows,
+} from '../codexUsageUtils';
 
 const { Text } = Typography;
-
-const clampPercent = (value) => {
-  const v = Number(value);
-  if (!Number.isFinite(v)) return 0;
-  return Math.max(0, Math.min(100, v));
-};
 
 const pickStrokeColor = (percent) => {
   const p = clampPercent(percent);
@@ -48,63 +46,6 @@ const pickStrokeColor = (percent) => {
 const normalizePlanType = (value) => {
   if (value == null) return '';
   return String(value).trim().toLowerCase();
-};
-
-const getWindowDurationSeconds = (windowData) => {
-  const value = Number(windowData?.limit_window_seconds);
-  if (!Number.isFinite(value) || value <= 0) return null;
-  return value;
-};
-
-const classifyWindowByDuration = (windowData) => {
-  const seconds = getWindowDurationSeconds(windowData);
-  if (seconds == null) return null;
-  return seconds >= 24 * 60 * 60 ? 'weekly' : 'fiveHour';
-};
-
-const resolveRateLimitWindows = (data) => {
-  const rateLimit = data?.rate_limit ?? {};
-  const primary = rateLimit?.primary_window ?? null;
-  const secondary = rateLimit?.secondary_window ?? null;
-  const windows = [primary, secondary].filter(Boolean);
-  const planType = normalizePlanType(data?.plan_type ?? rateLimit?.plan_type);
-
-  let fiveHourWindow = null;
-  let weeklyWindow = null;
-
-  for (const windowData of windows) {
-    const bucket = classifyWindowByDuration(windowData);
-    if (bucket === 'fiveHour' && !fiveHourWindow) {
-      fiveHourWindow = windowData;
-      continue;
-    }
-    if (bucket === 'weekly' && !weeklyWindow) {
-      weeklyWindow = windowData;
-    }
-  }
-
-  if (planType === 'free') {
-    if (!weeklyWindow) {
-      weeklyWindow = primary ?? secondary ?? null;
-    }
-    return { fiveHourWindow: null, weeklyWindow };
-  }
-
-  if (!fiveHourWindow && !weeklyWindow) {
-    return {
-      fiveHourWindow: primary ?? null,
-      weeklyWindow: secondary ?? null,
-    };
-  }
-
-  if (!fiveHourWindow) {
-    fiveHourWindow = windows.find((windowData) => windowData !== weeklyWindow) ?? null;
-  }
-  if (!weeklyWindow) {
-    weeklyWindow = windows.find((windowData) => windowData !== fiveHourWindow) ?? null;
-  }
-
-  return { fiveHourWindow, weeklyWindow };
 };
 
 const formatDurationSeconds = (seconds, t) => {

--- a/web/src/hooks/channels/useChannelsData.jsx
+++ b/web/src/hooks/channels/useChannelsData.jsx
@@ -45,6 +45,7 @@ import {
 } from '../../components/table/channels/codexUsageUtils';
 
 const CODEX_USAGE_CACHE_TTL_MS = 60 * 1000;
+const CODEX_USAGE_FETCH_CONCURRENCY = 4;
 
 export const useChannelsData = () => {
   const { t } = useTranslation();
@@ -385,50 +386,60 @@ export const useChannelsData = () => {
       return;
     }
 
-    await Promise.all(
-      codexChannels.map(async (channel) => {
-        const cached = codexUsageCacheRef.current.get(channel.id);
-        const isFresh =
-          !!cached && now - cached.fetchedAt < CODEX_USAGE_CACHE_TTL_MS;
-        if (isFresh) {
-          return;
-        }
+    for (
+      let i = 0;
+      i < codexChannels.length;
+      i += CODEX_USAGE_FETCH_CONCURRENCY
+    ) {
+      const batch = codexChannels.slice(
+        i,
+        i + CODEX_USAGE_FETCH_CONCURRENCY,
+      );
+      await Promise.all(
+        batch.map(async (channel) => {
+          const cached = codexUsageCacheRef.current.get(channel.id);
+          const isFresh =
+            !!cached && now - cached.fetchedAt < CODEX_USAGE_CACHE_TTL_MS;
+          if (isFresh) {
+            return;
+          }
 
-        updateChannelProperty(channel.id, (currentChannel) => {
-          const currentUsage = currentChannel.codex_usage || {};
-          currentChannel.codex_usage = {
-            ...currentUsage,
-            loading: true,
-            error: '',
-            payload: currentUsage.payload || cached?.payload || null,
-            summary:
-              currentUsage.summary ||
-              (cached?.payload
-                ? extractCodexUsageSummary(cached.payload)
-                : null),
-            fetched_at: currentUsage.fetched_at || cached?.fetchedAt || 0,
-          };
-        });
+          updateChannelProperty(channel.id, (currentChannel) => {
+            const currentUsage = currentChannel.codex_usage || {};
+            currentChannel.codex_usage = {
+              ...currentUsage,
+              loading: true,
+              error: '',
+              payload: currentUsage.payload || cached?.payload || null,
+              summary:
+                currentUsage.summary ||
+                (cached?.payload
+                  ? extractCodexUsageSummary(cached.payload)
+                  : null),
+              fetched_at: currentUsage.fetched_at || cached?.fetchedAt || 0,
+            };
+          });
 
-        const payload = await fetchCodexUsageForChannel(channel.id);
-        const fetchedAt = Date.now();
-        codexUsageCacheRef.current.set(channel.id, {
-          payload,
-          fetchedAt,
-        });
-
-        updateChannelProperty(channel.id, (currentChannel) => {
-          currentChannel.codex_usage = {
-            loading: false,
-            error:
-              payload?.success === false ? payload?.message || '' : '',
+          const payload = await fetchCodexUsageForChannel(channel.id);
+          const fetchedAt = Date.now();
+          codexUsageCacheRef.current.set(channel.id, {
             payload,
-            summary: extractCodexUsageSummary(payload),
-            fetched_at: fetchedAt,
-          };
-        });
-      }),
-    );
+            fetchedAt,
+          });
+
+          updateChannelProperty(channel.id, (currentChannel) => {
+            currentChannel.codex_usage = {
+              loading: false,
+              error:
+                payload?.success === false ? payload?.message || '' : '',
+              payload,
+              summary: extractCodexUsageSummary(payload),
+              fetched_at: fetchedAt,
+            };
+          });
+        }),
+      );
+    }
   };
 
   // Get form values helper
@@ -721,21 +732,35 @@ export const useChannelsData = () => {
   // Update channel property
   const updateChannelProperty = (channelId, updateFn) => {
     setChannels((prevChannels) => {
-      const newChannels = [...prevChannels];
       let updated = false;
 
-      newChannels.forEach((channel) => {
+      const newChannels = prevChannels.map((channel) => {
         if (channel.children !== undefined) {
-          channel.children.forEach((child) => {
-            if (child.id === channelId) {
-              updateFn(child);
-              updated = true;
+          let childUpdated = false;
+          const children = channel.children.map((child) => {
+            if (child.id !== channelId) {
+              return child;
             }
+            const nextChild = { ...child };
+            updateFn(nextChild);
+            childUpdated = true;
+            updated = true;
+            return nextChild;
           });
-        } else if (channel.id === channelId) {
-          updateFn(channel);
-          updated = true;
+          if (childUpdated) {
+            return { ...channel, children };
+          }
+          return channel;
         }
+
+        if (channel.id === channelId) {
+          const nextChannel = { ...channel };
+          updateFn(nextChannel);
+          updated = true;
+          return nextChannel;
+        }
+
+        return channel;
       });
 
       return updated ? newChannels : prevChannels;

--- a/web/src/hooks/channels/useChannelsData.jsx
+++ b/web/src/hooks/channels/useChannelsData.jsx
@@ -39,6 +39,12 @@ import { useChannelUpstreamUpdates } from './useChannelUpstreamUpdates';
 import { parseUpstreamUpdateMeta } from './upstreamUpdateUtils';
 import { Modal, Button } from '@douyinfe/semi-ui';
 import { openCodexUsageModal } from '../../components/table/channels/modals/CodexUsageModal';
+import {
+  CODEX_CHANNEL_TYPE,
+  extractCodexUsageSummary,
+} from '../../components/table/channels/codexUsageUtils';
+
+const CODEX_USAGE_CACHE_TTL_MS = 60 * 1000;
 
 export const useChannelsData = () => {
   const { t } = useTranslation();
@@ -122,6 +128,8 @@ export const useChannelsData = () => {
   const requestCounter = useRef(0);
   const allSelectingRef = useRef(false);
   const [formApi, setFormApi] = useState(null);
+  const codexUsageCacheRef = useRef(new Map());
+  const codexUsageInflightRef = useRef(new Map());
 
   const formInitValues = {
     searchKeyword: '',
@@ -138,6 +146,8 @@ export const useChannelsData = () => {
     STATUS: 'status',
     RESPONSE_TIME: 'response_time',
     BALANCE: 'balance',
+    CODEX_FIVE_HOUR: 'codex_five_hour',
+    CODEX_WEEKLY: 'codex_weekly',
     PRIORITY: 'priority',
     WEIGHT: 'weight',
     OPERATE: 'operate',
@@ -178,6 +188,8 @@ export const useChannelsData = () => {
       [COLUMN_KEYS.STATUS]: true,
       [COLUMN_KEYS.RESPONSE_TIME]: true,
       [COLUMN_KEYS.BALANCE]: true,
+      [COLUMN_KEYS.CODEX_FIVE_HOUR]: true,
+      [COLUMN_KEYS.CODEX_WEEKLY]: true,
       [COLUMN_KEYS.PRIORITY]: true,
       [COLUMN_KEYS.WEIGHT]: true,
       [COLUMN_KEYS.OPERATE]: true,
@@ -231,6 +243,34 @@ export const useChannelsData = () => {
     setVisibleColumns(updatedColumns);
   };
 
+  const getCachedCodexUsage = (channelId) => {
+    const cached = codexUsageCacheRef.current.get(channelId);
+    if (!cached?.payload) {
+      return null;
+    }
+    return {
+      loading: false,
+      error:
+        cached.payload?.success === false ? cached.payload?.message || '' : '',
+      payload: cached.payload,
+      summary: extractCodexUsageSummary(cached.payload),
+      fetched_at: cached.fetchedAt,
+    };
+  };
+
+  const attachCodexUsageState = (channel) => {
+    if (!channel || channel.type !== CODEX_CHANNEL_TYPE) {
+      return;
+    }
+    channel.codex_usage = getCachedCodexUsage(channel.id) || {
+      loading: false,
+      error: '',
+      payload: null,
+      summary: null,
+      fetched_at: 0,
+    };
+  };
+
   // Data formatting
   const setChannelFormat = (channels, enableTagMode) => {
     let channelDates = [];
@@ -241,6 +281,7 @@ export const useChannelsData = () => {
         channels[i].settings,
       );
       channels[i].key = '' + channels[i].id;
+      attachCodexUsageState(channels[i]);
       if (!enableTagMode) {
         channelDates.push(channels[i]);
       } else {
@@ -306,6 +347,90 @@ export const useChannelsData = () => {
     setChannels(channelDates);
   };
 
+  const fetchCodexUsageForChannel = async (channelId) => {
+    const inflight = codexUsageInflightRef.current.get(channelId);
+    if (inflight) {
+      return inflight;
+    }
+
+    const request = API.get(`/api/channel/${channelId}/codex/usage`, {
+      skipErrorHandler: true,
+    })
+      .then((res) => res?.data ?? { success: false, message: t('获取用量失败') })
+      .catch((error) => ({
+        success: false,
+        message:
+          error?.response?.data?.message ||
+          error?.message ||
+          t('获取用量失败'),
+      }))
+      .finally(() => {
+        codexUsageInflightRef.current.delete(channelId);
+      });
+
+    codexUsageInflightRef.current.set(channelId, request);
+    return request;
+  };
+
+  const syncCodexUsage = async (items) => {
+    if (!Array.isArray(items) || items.length === 0) {
+      return;
+    }
+
+    const now = Date.now();
+    const codexChannels = items.filter(
+      (item) => item?.type === CODEX_CHANNEL_TYPE && item?.id,
+    );
+    if (codexChannels.length === 0) {
+      return;
+    }
+
+    await Promise.all(
+      codexChannels.map(async (channel) => {
+        const cached = codexUsageCacheRef.current.get(channel.id);
+        const isFresh =
+          !!cached && now - cached.fetchedAt < CODEX_USAGE_CACHE_TTL_MS;
+        if (isFresh) {
+          return;
+        }
+
+        updateChannelProperty(channel.id, (currentChannel) => {
+          const currentUsage = currentChannel.codex_usage || {};
+          currentChannel.codex_usage = {
+            ...currentUsage,
+            loading: true,
+            error: '',
+            payload: currentUsage.payload || cached?.payload || null,
+            summary:
+              currentUsage.summary ||
+              (cached?.payload
+                ? extractCodexUsageSummary(cached.payload)
+                : null),
+            fetched_at: currentUsage.fetched_at || cached?.fetchedAt || 0,
+          };
+        });
+
+        const payload = await fetchCodexUsageForChannel(channel.id);
+        const fetchedAt = Date.now();
+        codexUsageCacheRef.current.set(channel.id, {
+          payload,
+          fetchedAt,
+        });
+
+        updateChannelProperty(channel.id, (currentChannel) => {
+          currentChannel.codex_usage = {
+            loading: false,
+            error:
+              payload?.success === false ? payload?.message || '' : '',
+            payload,
+            summary: extractCodexUsageSummary(payload),
+            fetched_at: fetchedAt,
+          };
+        });
+      }),
+    );
+  };
+
   // Get form values helper
   const getFormValues = () => {
     const formValues = formApi ? formApi.getValues() : {};
@@ -365,6 +490,7 @@ export const useChannelsData = () => {
         setTypeCounts({ ...type_counts, all: sumAll });
       }
       setChannelFormat(items, enableTagMode);
+      syncCodexUsage(items).catch(() => {});
       setChannelCount(total);
     } else {
       showError(message);
@@ -410,6 +536,7 @@ export const useChannelsData = () => {
         );
         setTypeCounts({ ...type_counts, all: sumAll });
         setChannelFormat(items, enableTagMode);
+        syncCodexUsage(items).catch(() => {});
         setChannelCount(total);
         setActivePage(page);
       } else {
@@ -593,26 +720,26 @@ export const useChannelsData = () => {
 
   // Update channel property
   const updateChannelProperty = (channelId, updateFn) => {
-    const newChannels = [...channels];
-    let updated = false;
+    setChannels((prevChannels) => {
+      const newChannels = [...prevChannels];
+      let updated = false;
 
-    newChannels.forEach((channel) => {
-      if (channel.children !== undefined) {
-        channel.children.forEach((child) => {
-          if (child.id === channelId) {
-            updateFn(child);
-            updated = true;
-          }
-        });
-      } else if (channel.id === channelId) {
-        updateFn(channel);
-        updated = true;
-      }
+      newChannels.forEach((channel) => {
+        if (channel.children !== undefined) {
+          channel.children.forEach((child) => {
+            if (child.id === channelId) {
+              updateFn(child);
+              updated = true;
+            }
+          });
+        } else if (channel.id === channelId) {
+          updateFn(channel);
+          updated = true;
+        }
+      });
+
+      return updated ? newChannels : prevChannels;
     });
-
-    if (updated) {
-      setChannels(newChannels);
-    }
   };
 
   // Tag edit
@@ -754,10 +881,11 @@ export const useChannelsData = () => {
   };
 
   const updateChannelBalance = async (record) => {
-    if (record?.type === 57) {
+    if (record?.type === CODEX_CHANNEL_TYPE) {
       openCodexUsageModal({
         t,
         record,
+        payload: record?.codex_usage?.payload ?? null,
         onCopy: async (text) => {
           const ok = await copy(text);
           if (ok) showSuccess(t('已复制'));


### PR DESCRIPTION
## Summary\n- add Codex 5-hour and weekly usage columns to the channel table\n- reuse shared Codex usage parsing logic between the modal and table views\n- fetch and cache Codex usage for visible channels so the table can show progress bars and open the existing usage modal\n\n## Testing\n- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex usage visualization with 5-hour and weekly percentage metrics, color-coded progress bars, and clickable percentage to view details.
  * New table columns show Codex usage with clear loading and error states.

* **Improvements**
  * Balance tooltip/tag now correctly applies to Codex channels and is clickable where appropriate.
  * Faster, more efficient Codex usage loading to reduce redundant requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->