### PR TITLE
fix(model): handle sqlite channel info scan values

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"bytes"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
@@ -74,7 +75,26 @@ func (c ChannelInfo) Value() (driver.Value, error) {
 
 // Scan implements sql.Scanner interface
 func (c *ChannelInfo) Scan(value interface{}) error {
-	bytesValue, _ := value.([]byte)
+	if value == nil {
+		*c = ChannelInfo{}
+		return nil
+	}
+
+	var bytesValue []byte
+	switch v := value.(type) {
+	case []byte:
+		bytesValue = v
+	case string:
+		bytesValue = []byte(v)
+	default:
+		return fmt.Errorf("unsupported ChannelInfo scan type: %T", value)
+	}
+
+	if len(bytes.TrimSpace(bytesValue)) == 0 {
+		*c = ChannelInfo{}
+		return nil
+	}
+
 	return common.Unmarshal(bytesValue, c)
 }
 

--- a/model/channel_scan_test.go
+++ b/model/channel_scan_test.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelInfoScanHandlesSQLiteString(t *testing.T) {
+	var info ChannelInfo
+	require.NoError(t, info.Scan(`{}`))
+	require.False(t, info.IsMultiKey)
+}
+
+func TestChannelInfoScanHandlesNilAndEmpty(t *testing.T) {
+	cases := []interface{}{nil, "", []byte{}}
+	for _, input := range cases {
+		var info ChannelInfo
+		require.NoError(t, info.Scan(input))
+		require.Equal(t, ChannelInfo{}, info)
+	}
+}
+
+func TestChannelRoundTripWithChannelInfoOnSQLite(t *testing.T) {
+	truncateTables(t)
+
+	channel := &Channel{
+		Type:   57,
+		Key:    `{"access_token":"test","account_id":"acct"}`,
+		Status: 1,
+		Name:   "sqlite-scan",
+		Models: "gpt-5",
+		Group:  "default",
+	}
+	require.NoError(t, DB.Create(channel).Error)
+
+	var loaded Channel
+	require.NoError(t, DB.First(&loaded, channel.Id).Error)
+	require.Equal(t, channel.Id, loaded.Id)
+	require.Equal(t, ChannelInfo{}, loaded.ChannelInfo)
+}


### PR DESCRIPTION
## Summary
- make `ChannelInfo.Scan` handle SQLite values returned as `string`, `nil`, or empty content
- return a zero-value `ChannelInfo` for nil/empty values instead of attempting to unmarshal invalid bytes
- add regression coverage for SQLite scan behavior and round-trip loading

## Testing
- `go test ./model -run ''TestChannelInfoScanHandlesSQLiteString|TestChannelInfoScanHandlesNilAndEmpty|TestChannelRoundTripWithChannelInfoOnSQLite''`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database input handling for channel data, now supporting multiple input formats and properly managing null or empty payloads.
  * Enhanced error reporting for unsupported input types.

* **Tests**
  * Added comprehensive tests to validate channel data storage and retrieval across database transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->