### PR TITLE
fix: 添加 HTTP Server 超时参数解决连接数持续增长问题

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,16 @@ func main() {
 	// Log startup success message
 	common.LogStartupSuccess(startTime, port)
 
-	err = server.Run(":" + port)
+	// 使用自定义 http.Server 设置超时参数，防止空闲连接堆积
+	httpServer := &http.Server{
+		Addr:              ":" + port,
+		Handler:           server,
+		IdleTimeout:       30 * time.Second,  // 空闲连接 30 秒后关闭（解决 FRP 代理下连接堆积问题）
+		ReadHeaderTimeout: 10 * time.Second,  // 读取请求头超时
+		WriteTimeout:      0,                 // 禁用写入超时
+	}
+
+	err = httpServer.ListenAndServe()
 	if err != nil {
 		common.FatalLog("failed to start HTTP server: " + err.Error())
 	}


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)

在通过Frp代理流量到本地时，因frp连接复用的特性，会导致建立的连接一直处于ESTABLISHED，长期下去一台服务器在8小时在低强度使用的情况下可建立4K左右的链接，再添加了IdleTimeout后可主动关闭空闲的连接避免无限增长耗尽系统资源。

## 🚀 变更类型 / Type of change
- [] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [√] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [√] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [√] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [√] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [√] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [√] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [√] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [√] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="1555" height="236" alt="7f5a7b8947d08320e5746066306ed9cb" src="https://github.com/user-attachments/assets/32eaef35-23bf-46ba-92de-87d8d16f0048" />
<img width="571" height="231" alt="e4c660513e4a5a1bb3e7987b3dac820e" src="https://github.com/user-attachments/assets/85933476-788d-4b05-bab0-dfa27cd35dda" />
<img width="1180" height="208" alt="9b351124e11e3273a14b882352511274" src="https://github.com/user-attachments/assets/46eac29b-3956-4bf7-855d-92e54182b993" />
<img width="510" height="85" alt="5e9053e7113e3e4708830cc560800506" src="https://github.com/user-attachments/assets/6620247f-c388-4cea-bc58-af2059e500dc" />
以上是修复前，修复后自动释放空闲的连接。
<img width="496" height="95" alt="6a8121d58f93b739906ef4504e9ea8f1" src="https://github.com/user-attachments/assets/a9b72068-7963-443d-897c-60589be13b37" />
<img width="485" height="165" alt="7b37689f56e60ecf70d046690184d4d8" src="https://github.com/user-attachments/assets/288f7d65-8f01-4cf3-9a5c-e09148388583" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to an explicit HTTP server startup for clearer lifecycle control.
  * Added timeout configuration to improve stability: 30s idle timeout, 10s read-header timeout; write timeout disabled.
  * Improved startup error reporting to surface server launch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->