### PR TITLE
在管理员充值账单中显示用户 ID

### DIFF
--- a/web/src/components/topup/modals/TopupHistoryModal.jsx
+++ b/web/src/components/topup/modals/TopupHistoryModal.jsx
@@ -161,6 +161,16 @@ const TopupHistoryModal = ({ visible, onCancel, t }) => {
 
   const columns = useMemo(() => {
     const baseColumns = [
+      ...(userIsAdmin
+        ? [
+            {
+              title: t('用户ID'),
+              dataIndex: 'user_id',
+              key: 'user_id',
+              render: (userId) => <Text>{userId ?? '-'}</Text>,
+            },
+          ]
+        : []),
       {
         title: t('订单号'),
         dataIndex: 'trade_no',


### PR DESCRIPTION
## 变更描述

当前管理员在“钱包管理 -> 账单”中查看全平台充值记录时，可以看到订单号、支付方式、金额和状态等信息，但无法直接知道这笔订单属于哪个用户。排查补单、核对支付记录时，往往还需要额外去查订单关联关系，效率较低。

这个 PR 采用最小改动方案：仅在管理员账单弹窗中新增“用户 ID”列，直接显示订单所属的 `user_id`。普通用户视图、后端接口和现有搜索逻辑均保持不变。

## 变更类型
- [x] 新功能 (New feature)
- [ ] Bug 修复 (Bug fix)
- [ ] 性能优化 / 重构 (Refactor)
- [ ] 文档更新 (Documentation)

## 关联任务
- Closes #（如有）

## 具体改动
- 管理员充值账单表格新增“用户 ID”列
- 复用现有接口返回的 `user_id` 字段，不新增后端接口字段
- 普通用户账单视图不受影响
- 不调整管理员账单现有搜索和操作逻辑

## 兼容性说明
- 不修改数据库结构
- 不需要迁移
- 不修改后端接口返回结构
- 仅管理员账单前端表格增加一列展示信息

## 提交前检查项
- [x] 我已人工整理并撰写此描述，没有直接粘贴未经处理的 AI 输出
- [x] 我已搜索现有的 Issues / PRs，确认不是重复提交
- [x] 我已理解这些改动的工作原理及可能影响
- [x] 本 PR 未包含与当前任务无关的代码改动
- [x] 已在本地完成验证
- [x] 代码中不包含敏感信息

## 运行证明 / 验证结果
- 人工验证：管理员打开充值账单时可直接看到订单对应的用户 ID
- `npm run build`