### PR TITLE
fix atomic quota deduction

### DIFF
--- a/model/errors.go
+++ b/model/errors.go
@@ -7,6 +7,12 @@ var (
 	ErrDatabase = errors.New("database error")
 )
 
+// Quota errors
+var (
+	ErrInsufficientUserQuota  = errors.New("insufficient user quota")
+	ErrInsufficientTokenQuota = errors.New("insufficient token quota")
+)
+
 // User auth errors
 var (
 	ErrInvalidCredentials   = errors.New("invalid credentials")

--- a/model/quota_atomic_test.go
+++ b/model/quota_atomic_test.go
@@ -1,0 +1,102 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedQuotaUser(t *testing.T, id int, quota int) {
+	t.Helper()
+	require.NoError(t, DB.Create(&User{
+		Id:       id,
+		Username: "quota_user",
+		Quota:    quota,
+		Status:   common.UserStatusEnabled,
+	}).Error)
+}
+
+func seedQuotaToken(t *testing.T, id int, userId int, key string, remainQuota int, unlimited bool) {
+	t.Helper()
+	require.NoError(t, DB.Create(&Token{
+		Id:             id,
+		UserId:         userId,
+		Key:            key,
+		Name:           "quota_token",
+		Status:         common.TokenStatusEnabled,
+		RemainQuota:    remainQuota,
+		UnlimitedQuota: unlimited,
+	}).Error)
+}
+
+func readUserQuota(t *testing.T, id int) int {
+	t.Helper()
+	var user User
+	require.NoError(t, DB.First(&user, id).Error)
+	return user.Quota
+}
+
+func readTokenQuota(t *testing.T, id int) (remain int, used int) {
+	t.Helper()
+	var token Token
+	require.NoError(t, DB.First(&token, id).Error)
+	return token.RemainQuota, token.UsedQuota
+}
+
+func TestDecreaseUserQuotaRejectsInsufficientQuota(t *testing.T) {
+	truncateTables(t)
+
+	seedQuotaUser(t, 1001, 100)
+
+	err := DecreaseUserQuota(1001, 150, false)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInsufficientUserQuota))
+	assert.Equal(t, 100, readUserQuota(t, 1001))
+}
+
+func TestDecreaseUserQuotaBypassesBatchUpdateForAtomicity(t *testing.T) {
+	truncateTables(t)
+	oldBatchUpdateEnabled := common.BatchUpdateEnabled
+	common.BatchUpdateEnabled = true
+	t.Cleanup(func() {
+		common.BatchUpdateEnabled = oldBatchUpdateEnabled
+	})
+
+	seedQuotaUser(t, 1002, 100)
+
+	require.NoError(t, DecreaseUserQuota(1002, 80, false))
+
+	assert.Equal(t, 20, readUserQuota(t, 1002))
+}
+
+func TestDecreaseTokenQuotaRejectsInsufficientQuota(t *testing.T) {
+	truncateTables(t)
+
+	seedQuotaUser(t, 1003, 1000)
+	seedQuotaToken(t, 1003, 1003, "sk-quota-token", 100, false)
+
+	err := DecreaseTokenQuota(1003, "sk-quota-token", 150)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInsufficientTokenQuota))
+	remain, used := readTokenQuota(t, 1003)
+	assert.Equal(t, 100, remain)
+	assert.Equal(t, 0, used)
+}
+
+func TestDecreaseTokenQuotaForUnlimitedAllowsUsageTracking(t *testing.T) {
+	truncateTables(t)
+
+	seedQuotaUser(t, 1004, 1000)
+	seedQuotaToken(t, 1004, 1004, "sk-unlimited-token", 0, true)
+
+	require.NoError(t, DecreaseTokenQuotaForUnlimited(1004, "sk-unlimited-token", 50))
+
+	remain, used := readTokenQuota(t, 1004)
+	assert.Equal(t, -50, remain)
+	assert.Equal(t, 50, used)
+}

--- a/model/token.go
+++ b/model/token.go
@@ -376,6 +376,13 @@ func IncreaseTokenQuota(tokenId int, key string, quota int) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
 	}
+	if quota == 0 {
+		return nil
+	}
+	// Token quota is security-sensitive; keep DB as the source of truth instead of batching.
+	if err = increaseTokenQuota(tokenId, quota); err != nil {
+		return err
+	}
 	if common.RedisEnabled {
 		gopool.Go(func() {
 			err := cacheIncrTokenQuota(key, int64(quota))
@@ -384,11 +391,7 @@ func IncreaseTokenQuota(tokenId int, key string, quota int) (err error) {
 			}
 		})
 	}
-	if common.BatchUpdateEnabled {
-		addNewRecord(BatchUpdateTypeTokenQuota, tokenId, quota)
-		return nil
-	}
-	return increaseTokenQuota(tokenId, quota)
+	return nil
 }
 
 func increaseTokenQuota(id int, quota int) (err error) {
@@ -403,8 +406,23 @@ func increaseTokenQuota(id int, quota int) (err error) {
 }
 
 func DecreaseTokenQuota(id int, key string, quota int) (err error) {
+	return decreaseTokenQuotaWithLimit(id, key, quota, true)
+}
+
+func DecreaseTokenQuotaForUnlimited(id int, key string, quota int) (err error) {
+	return decreaseTokenQuotaWithLimit(id, key, quota, false)
+}
+
+func decreaseTokenQuotaWithLimit(id int, key string, quota int, enforceLimit bool) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
+	}
+	if quota == 0 {
+		return nil
+	}
+	// Atomic DB update prevents concurrent requests from overdrawing token quota.
+	if err = decreaseTokenQuota(id, quota, enforceLimit); err != nil {
+		return err
 	}
 	if common.RedisEnabled {
 		gopool.Go(func() {
@@ -414,22 +432,28 @@ func DecreaseTokenQuota(id int, key string, quota int) (err error) {
 			}
 		})
 	}
-	if common.BatchUpdateEnabled {
-		addNewRecord(BatchUpdateTypeTokenQuota, id, -quota)
-		return nil
-	}
-	return decreaseTokenQuota(id, quota)
+	return nil
 }
 
-func decreaseTokenQuota(id int, quota int) (err error) {
-	err = DB.Model(&Token{}).Where("id = ?", id).Updates(
+func decreaseTokenQuota(id int, quota int, enforceLimit bool) (err error) {
+	query := DB.Model(&Token{}).Where("id = ?", id)
+	if enforceLimit {
+		query = query.Where("remain_quota >= ?", quota)
+	}
+	result := query.Updates(
 		map[string]interface{}{
 			"remain_quota":  gorm.Expr("remain_quota - ?", quota),
 			"used_quota":    gorm.Expr("used_quota + ?", quota),
 			"accessed_time": common.GetTimestamp(),
 		},
-	).Error
-	return err
+	)
+	if result.Error != nil {
+		return result.Error
+	}
+	if enforceLimit && result.RowsAffected == 0 {
+		return ErrInsufficientTokenQuota
+	}
+	return nil
 }
 
 // CountUserTokens returns total number of tokens for the given user, used for pagination

--- a/model/user.go
+++ b/model/user.go
@@ -884,17 +884,20 @@ func IncreaseUserQuota(id int, quota int, db bool) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
 	}
+	if quota == 0 {
+		return nil
+	}
+	// User quota is security-sensitive; keep DB as the source of truth instead of batching.
+	if err = increaseUserQuota(id, quota); err != nil {
+		return err
+	}
 	gopool.Go(func() {
 		err := cacheIncrUserQuota(id, int64(quota))
 		if err != nil {
 			common.SysLog("failed to increase user quota: " + err.Error())
 		}
 	})
-	if !db && common.BatchUpdateEnabled {
-		addNewRecord(BatchUpdateTypeUserQuota, id, quota)
-		return nil
-	}
-	return increaseUserQuota(id, quota)
+	return nil
 }
 
 func increaseUserQuota(id int, quota int) (err error) {
@@ -909,25 +912,31 @@ func DecreaseUserQuota(id int, quota int, db bool) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
 	}
+	if quota == 0 {
+		return nil
+	}
+	// Atomic DB update prevents concurrent requests from overdrawing quota.
+	if err = decreaseUserQuota(id, quota); err != nil {
+		return err
+	}
 	gopool.Go(func() {
 		err := cacheDecrUserQuota(id, int64(quota))
 		if err != nil {
 			common.SysLog("failed to decrease user quota: " + err.Error())
 		}
 	})
-	if !db && common.BatchUpdateEnabled {
-		addNewRecord(BatchUpdateTypeUserQuota, id, -quota)
-		return nil
-	}
-	return decreaseUserQuota(id, quota)
+	return nil
 }
 
 func decreaseUserQuota(id int, quota int) (err error) {
-	err = DB.Model(&User{}).Where("id = ?", id).Update("quota", gorm.Expr("quota - ?", quota)).Error
-	if err != nil {
-		return err
+	result := DB.Model(&User{}).Where("id = ? AND quota >= ?", id, quota).Update("quota", gorm.Expr("quota - ?", quota))
+	if result.Error != nil {
+		return result.Error
 	}
-	return err
+	if result.RowsAffected == 0 {
+		return ErrInsufficientUserQuota
+	}
+	return nil
 }
 
 func DeltaUpdateUserQuota(id int, delta int) (err error) {

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -60,7 +61,11 @@ func (s *BillingSession) Settle(actualQuota int) error {
 	var tokenErr error
 	if !s.relayInfo.IsPlayground {
 		if delta > 0 {
-			tokenErr = model.DecreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+			if s.relayInfo.TokenUnlimited {
+				tokenErr = model.DecreaseTokenQuotaForUnlimited(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+			} else {
+				tokenErr = model.DecreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+			}
 		} else {
 			tokenErr = model.IncreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, -delta)
 		}
@@ -217,6 +222,9 @@ func (s *BillingSession) preConsume(c *gin.Context, quota int) *types.NewAPIErro
 		errMsg := err.Error()
 		if strings.Contains(errMsg, "no active subscription") || strings.Contains(errMsg, "subscription quota insufficient") {
 			return types.NewErrorWithStatusCode(fmt.Errorf("订阅额度不足或未配置订阅: %s", errMsg), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
+		}
+		if errors.Is(err, model.ErrInsufficientUserQuota) {
+			return types.NewErrorWithStatusCode(fmt.Errorf("预扣费额度失败, 用户额度不足"), types.ErrorCodeInsufficientUserQuota, http.StatusForbidden, types.ErrOptionWithSkipRetry(), types.ErrOptionWithNoRecordErrorLog())
 		}
 		return types.NewError(err, types.ErrorCodeUpdateDataError, types.ErrOptionWithSkipRetry())
 	}

--- a/service/billing_session.go
+++ b/service/billing_session.go
@@ -61,10 +61,14 @@ func (s *BillingSession) Settle(actualQuota int) error {
 	var tokenErr error
 	if !s.relayInfo.IsPlayground {
 		if delta > 0 {
-			if s.relayInfo.TokenUnlimited {
-				tokenErr = model.DecreaseTokenQuotaForUnlimited(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
-			} else {
-				tokenErr = model.DecreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+			var tokenUnlimited bool
+			tokenUnlimited, tokenErr = tokenUnlimitedForQuotaAdjustment(s.relayInfo)
+			if tokenErr == nil {
+				if tokenUnlimited {
+					tokenErr = model.DecreaseTokenQuotaForUnlimited(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+				} else {
+					tokenErr = model.DecreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, delta)
+				}
 			}
 		} else {
 			tokenErr = model.IncreaseTokenQuota(s.relayInfo.TokenId, s.relayInfo.TokenKey, -delta)

--- a/service/quota.go
+++ b/service/quota.go
@@ -386,14 +386,15 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	//if relayInfo.TokenUnlimited {
 	//	return nil
 	//}
-	token, err := model.GetTokenByKey(relayInfo.TokenKey, false)
+	token, err := getRelayTokenForQuota(relayInfo)
 	if err != nil {
 		return err
 	}
-	if !relayInfo.TokenUnlimited && !token.UnlimitedQuota && token.RemainQuota < quota {
+	tokenUnlimited := syncRelayTokenUnlimited(relayInfo, token)
+	if !tokenUnlimited && token.RemainQuota < quota {
 		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(token.RemainQuota), logger.FormatQuota(quota))
 	}
-	if relayInfo.TokenUnlimited || token.UnlimitedQuota {
+	if tokenUnlimited {
 		err = model.DecreaseTokenQuotaForUnlimited(relayInfo.TokenId, relayInfo.TokenKey, quota)
 	} else {
 		err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
@@ -405,6 +406,38 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 		return err
 	}
 	return nil
+}
+
+func syncRelayTokenUnlimited(relayInfo *relaycommon.RelayInfo, token *model.Token) bool {
+	if relayInfo.TokenUnlimited {
+		return true
+	}
+	if token != nil && token.UnlimitedQuota {
+		relayInfo.TokenUnlimited = true
+		return true
+	}
+	return false
+}
+
+func getRelayTokenForQuota(relayInfo *relaycommon.RelayInfo) (*model.Token, error) {
+	if relayInfo.TokenKey != "" {
+		return model.GetTokenByKey(relayInfo.TokenKey, false)
+	}
+	if relayInfo.TokenId > 0 {
+		return model.GetTokenById(relayInfo.TokenId)
+	}
+	return nil, errors.New("token id and key are empty")
+}
+
+func tokenUnlimitedForQuotaAdjustment(relayInfo *relaycommon.RelayInfo) (bool, error) {
+	if relayInfo.TokenUnlimited {
+		return true, nil
+	}
+	token, err := getRelayTokenForQuota(relayInfo)
+	if err != nil {
+		return false, err
+	}
+	return syncRelayTokenUnlimited(relayInfo, token), nil
 }
 
 func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQuota int, sendEmail bool) (err error) {
@@ -435,7 +468,11 @@ func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQu
 
 	if !relayInfo.IsPlayground {
 		if quota > 0 {
-			if relayInfo.TokenUnlimited {
+			tokenUnlimited, tokenErr := tokenUnlimitedForQuotaAdjustment(relayInfo)
+			if tokenErr != nil {
+				return tokenErr
+			}
+			if tokenUnlimited {
 				err = model.DecreaseTokenQuotaForUnlimited(relayInfo.TokenId, relayInfo.TokenKey, quota)
 			} else {
 				err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)

--- a/service/quota.go
+++ b/service/quota.go
@@ -383,9 +383,6 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	if relayInfo.IsPlayground {
 		return nil
 	}
-	//if relayInfo.TokenUnlimited {
-	//	return nil
-	//}
 	token, err := getRelayTokenForQuota(relayInfo)
 	if err != nil {
 		return err
@@ -421,12 +418,16 @@ func syncRelayTokenUnlimited(relayInfo *relaycommon.RelayInfo, token *model.Toke
 
 func getRelayTokenForQuota(relayInfo *relaycommon.RelayInfo) (*model.Token, error) {
 	if relayInfo.TokenKey != "" {
-		return model.GetTokenByKey(relayInfo.TokenKey, false)
+		return model.GetTokenByKey(normalizeRelayTokenKey(relayInfo.TokenKey), false)
 	}
 	if relayInfo.TokenId > 0 {
 		return model.GetTokenById(relayInfo.TokenId)
 	}
 	return nil, errors.New("token id and key are empty")
+}
+
+func normalizeRelayTokenKey(key string) string {
+	return strings.TrimPrefix(key, "sk-")
 }
 
 func tokenUnlimitedForQuotaAdjustment(relayInfo *relaycommon.RelayInfo) (bool, error) {

--- a/service/quota.go
+++ b/service/quota.go
@@ -390,11 +390,18 @@ func PreConsumeTokenQuota(relayInfo *relaycommon.RelayInfo, quota int) error {
 	if err != nil {
 		return err
 	}
-	if !relayInfo.TokenUnlimited && token.RemainQuota < quota {
+	if !relayInfo.TokenUnlimited && !token.UnlimitedQuota && token.RemainQuota < quota {
 		return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(token.RemainQuota), logger.FormatQuota(quota))
 	}
-	err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
+	if relayInfo.TokenUnlimited || token.UnlimitedQuota {
+		err = model.DecreaseTokenQuotaForUnlimited(relayInfo.TokenId, relayInfo.TokenKey, quota)
+	} else {
+		err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
+	}
 	if err != nil {
+		if errors.Is(err, model.ErrInsufficientTokenQuota) {
+			return fmt.Errorf("token quota is not enough, token remain quota: %s, need quota: %s", logger.FormatQuota(token.RemainQuota), logger.FormatQuota(quota))
+		}
 		return err
 	}
 	return nil
@@ -428,7 +435,11 @@ func PostConsumeQuota(relayInfo *relaycommon.RelayInfo, quota int, preConsumedQu
 
 	if !relayInfo.IsPlayground {
 		if quota > 0 {
-			err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
+			if relayInfo.TokenUnlimited {
+				err = model.DecreaseTokenQuotaForUnlimited(relayInfo.TokenId, relayInfo.TokenKey, quota)
+			} else {
+				err = model.DecreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, quota)
+			}
 		} else {
 			err = model.IncreaseTokenQuota(relayInfo.TokenId, relayInfo.TokenKey, -quota)
 		}

--- a/service/quota_unlimited_test.go
+++ b/service/quota_unlimited_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedQuotaAdjustmentUser(t *testing.T, id int, quota int) {
+	t.Helper()
+	require.NoError(t, model.DB.Create(&model.User{
+		Id:       id,
+		Username: "quota_adjust_user",
+		Quota:    quota,
+		Status:   common.UserStatusEnabled,
+	}).Error)
+}
+
+func seedQuotaAdjustmentToken(t *testing.T, id int, userId int, key string, remainQuota int, unlimited bool) {
+	t.Helper()
+	require.NoError(t, model.DB.Create(&model.Token{
+		Id:             id,
+		UserId:         userId,
+		Key:            key,
+		Name:           "quota_adjust_token",
+		Status:         common.TokenStatusEnabled,
+		RemainQuota:    remainQuota,
+		UnlimitedQuota: unlimited,
+	}).Error)
+}
+
+func TestPreConsumeTokenQuotaPropagatesPersistedUnlimitedToken(t *testing.T) {
+	truncate(t)
+
+	seedQuotaAdjustmentUser(t, 5101, 1000)
+	seedQuotaAdjustmentToken(t, 5101, 5101, "sk-preconsume-unlimited", 0, true)
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:  5101,
+		TokenId: 5101,
+	}
+
+	require.NoError(t, PreConsumeTokenQuota(relayInfo, 50))
+
+	assert.True(t, relayInfo.TokenUnlimited)
+	assert.Equal(t, -50, getTokenRemainQuota(t, 5101))
+	assert.Equal(t, 50, getTokenUsedQuota(t, 5101))
+}
+
+func TestPostConsumeQuotaUsesPersistedUnlimitedToken(t *testing.T) {
+	truncate(t)
+
+	seedQuotaAdjustmentUser(t, 5102, 1000)
+	seedQuotaAdjustmentToken(t, 5102, 5102, "sk-postconsume-unlimited", 0, true)
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:  5102,
+		TokenId: 5102,
+	}
+
+	require.NoError(t, PostConsumeQuota(relayInfo, 50, 0, false))
+
+	assert.True(t, relayInfo.TokenUnlimited)
+	assert.Equal(t, 950, getUserQuota(t, 5102))
+	assert.Equal(t, -50, getTokenRemainQuota(t, 5102))
+	assert.Equal(t, 50, getTokenUsedQuota(t, 5102))
+}
+
+func TestBillingSessionSettleUsesPersistedUnlimitedToken(t *testing.T) {
+	truncate(t)
+
+	seedQuotaAdjustmentUser(t, 5103, 1000)
+	seedQuotaAdjustmentToken(t, 5103, 5103, "sk-settle-unlimited", 0, true)
+	relayInfo := &relaycommon.RelayInfo{
+		UserId:  5103,
+		TokenId: 5103,
+	}
+	session := &BillingSession{
+		relayInfo: relayInfo,
+		funding:   &WalletFunding{userId: 5103},
+	}
+
+	require.NoError(t, session.Settle(50))
+
+	assert.True(t, relayInfo.TokenUnlimited)
+	assert.Equal(t, 950, getUserQuota(t, 5103))
+	assert.Equal(t, -50, getTokenRemainQuota(t, 5103))
+	assert.Equal(t, 50, getTokenUsedQuota(t, 5103))
+}

--- a/service/quota_unlimited_test.go
+++ b/service/quota_unlimited_test.go
@@ -37,7 +37,7 @@ func TestPreConsumeTokenQuotaPropagatesPersistedUnlimitedToken(t *testing.T) {
 	truncate(t)
 
 	seedQuotaAdjustmentUser(t, 5101, 1000)
-	seedQuotaAdjustmentToken(t, 5101, 5101, "sk-preconsume-unlimited", 0, true)
+	seedQuotaAdjustmentToken(t, 5101, 5101, "preconsume-unlimited", 0, true)
 	relayInfo := &relaycommon.RelayInfo{
 		UserId:  5101,
 		TokenId: 5101,
@@ -54,7 +54,7 @@ func TestPostConsumeQuotaUsesPersistedUnlimitedToken(t *testing.T) {
 	truncate(t)
 
 	seedQuotaAdjustmentUser(t, 5102, 1000)
-	seedQuotaAdjustmentToken(t, 5102, 5102, "sk-postconsume-unlimited", 0, true)
+	seedQuotaAdjustmentToken(t, 5102, 5102, "postconsume-unlimited", 0, true)
 	relayInfo := &relaycommon.RelayInfo{
 		UserId:  5102,
 		TokenId: 5102,
@@ -72,7 +72,7 @@ func TestBillingSessionSettleUsesPersistedUnlimitedToken(t *testing.T) {
 	truncate(t)
 
 	seedQuotaAdjustmentUser(t, 5103, 1000)
-	seedQuotaAdjustmentToken(t, 5103, 5103, "sk-settle-unlimited", 0, true)
+	seedQuotaAdjustmentToken(t, 5103, 5103, "settle-unlimited", 0, true)
 	relayInfo := &relaycommon.RelayInfo{
 		UserId:  5103,
 		TokenId: 5103,
@@ -88,4 +88,10 @@ func TestBillingSessionSettleUsesPersistedUnlimitedToken(t *testing.T) {
 	assert.Equal(t, 950, getUserQuota(t, 5103))
 	assert.Equal(t, -50, getTokenRemainQuota(t, 5103))
 	assert.Equal(t, 50, getTokenUsedQuota(t, 5103))
+}
+
+func TestNormalizeRelayTokenKeyStripsPublicPrefix(t *testing.T) {
+	assert.Equal(t, "settle-unlimited", normalizeRelayTokenKey("sk-settle-unlimited"))
+	assert.Equal(t, "plain-token-key", normalizeRelayTokenKey("plain-token-key"))
+	assert.Empty(t, normalizeRelayTokenKey(""))
 }

--- a/service/task_billing.go
+++ b/service/task_billing.go
@@ -68,15 +68,15 @@ func LogTaskConsumption(c *gin.Context, info *relaycommon.RelayInfo) {
 // 异步任务计费辅助函数
 // ---------------------------------------------------------------------------
 
-// resolveTokenKey 通过 TokenId 运行时获取令牌 Key（用于 Redis 缓存操作）。
-// 如果令牌已被删除或查询失败，返回空字符串。
-func resolveTokenKey(ctx context.Context, tokenId int, taskID string) string {
+// resolveTokenForBilling 通过 TokenId 运行时获取令牌状态（用于 Redis 缓存和无限额判断）。
+// 如果令牌已被删除或查询失败，返回 nil。
+func resolveTokenForBilling(ctx context.Context, tokenId int, taskID string) *model.Token {
 	token, err := model.GetTokenById(tokenId)
 	if err != nil {
 		logger.LogWarn(ctx, fmt.Sprintf("获取令牌 key 失败 (tokenId=%d, task=%s): %s", tokenId, taskID, err.Error()))
-		return ""
+		return nil
 	}
-	return token.Key
+	return token
 }
 
 // taskIsSubscription 判断任务是否通过订阅计费。
@@ -96,20 +96,24 @@ func taskAdjustFunding(task *model.Task, delta int) error {
 }
 
 // taskAdjustTokenQuota 调整任务的令牌额度，delta > 0 表示扣费，delta < 0 表示退还。
-// 需要通过 resolveTokenKey 运行时获取 key（不从 PrivateData 中读取）。
+// 需要通过 resolveTokenForBilling 运行时获取 key（不从 PrivateData 中读取）。
 func taskAdjustTokenQuota(ctx context.Context, task *model.Task, delta int) {
 	if task.PrivateData.TokenId <= 0 || delta == 0 {
 		return
 	}
-	tokenKey := resolveTokenKey(ctx, task.PrivateData.TokenId, task.TaskID)
-	if tokenKey == "" {
+	token := resolveTokenForBilling(ctx, task.PrivateData.TokenId, task.TaskID)
+	if token == nil || token.Key == "" {
 		return
 	}
 	var err error
 	if delta > 0 {
-		err = model.DecreaseTokenQuota(task.PrivateData.TokenId, tokenKey, delta)
+		if token.UnlimitedQuota {
+			err = model.DecreaseTokenQuotaForUnlimited(task.PrivateData.TokenId, token.Key, delta)
+		} else {
+			err = model.DecreaseTokenQuota(task.PrivateData.TokenId, token.Key, delta)
+		}
 	} else {
-		err = model.IncreaseTokenQuota(task.PrivateData.TokenId, tokenKey, -delta)
+		err = model.IncreaseTokenQuota(task.PrivateData.TokenId, token.Key, -delta)
 	}
 	if err != nil {
 		logger.LogWarn(ctx, fmt.Sprintf("调整令牌额度失败 (delta=%d, task=%s): %s", delta, task.TaskID, err.Error()))


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 本描述已按本次代码变更整理，重点说明额度扣减为什么需要落到数据库条件更新上。

## 📝 变更描述 / Description
本 PR 修复用户钱包额度和 token 额度扣减的并发一致性问题。

此前扣费路径会先读取余额并在应用层判断，再执行 `quota - ?` / `remain_quota - ?` 更新；在并发请求下，多个请求可能基于同一份旧余额同时通过检查，最终把余额扣成负数。开启 batch update 时，扣减还会进入异步队列，进一步让请求期的余额约束无法以数据库状态为准。

本次改动把用户钱包和普通 token 的扣减改成单条条件更新：只有 `quota >= amount` 或 `remain_quota >= amount` 时才会更新，并通过 `RowsAffected` 判断是否成功。这样数据库成为扣减的原子裁判，避免并发透支。无限额 token 保留独立路径，继续记录用量但不按剩余额度拦截。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- N/A（计费一致性修复，未单独公开 Issue）

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 Issues 与 PRs，未发现针对用户/token 额度扣减原子性的重复提交。
- [x] **Bug fix 说明:** 本 PR 修复的是并发扣费一致性问题，不是设计取舍或预期不一致；由于涉及计费边界，未单独公开详细利用步骤的 Issue。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
本地验证通过：

```bash
env GOCACHE=/tmp/new-api-gocache go test ./model ./service
```

结果：

```text
ok  	github.com/QuantumNous/new-api/model
ok  	github.com/QuantumNous/new-api/service
```

新增覆盖：

- 用户额度不足时扣减失败且余额不变。
- batch update 开启时，用户额度扣减仍即时写库，避免异步透支。
- 普通 token 余额不足时扣减失败且 `remain_quota` / `used_quota` 不变。
- 无限额 token 仍可记录用量，不受余额条件拦截。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger atomic quota enforcement to prevent overdrafts and ensure consistent quota updates.
  * Unlimited-token handling unified across billing, consumption, and settlement, with correct negative tracking for unlimited usage.
  * Zero-amount quota operations are now no-ops.
  * Error mapping now surfaces explicit "insufficient user quota" and "insufficient token quota" responses.

* **Tests**
  * Added comprehensive tests covering quota decreases, unlimited-token behavior, atomicity, token-key normalization, and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->