### PR TITLE
fix: model pricing use correct display type

### DIFF
--- a/web/src/components/table/model-pricing/modal/components/DynamicPricingBreakdown.jsx
+++ b/web/src/components/table/model-pricing/modal/components/DynamicPricingBreakdown.jsx
@@ -20,7 +20,7 @@ For commercial licensing, please contact support@quantumnous.com
 import React from 'react';
 import { Avatar, Tag, Table, Typography } from '@douyinfe/semi-ui';
 import { IconPriceTag } from '@douyinfe/semi-icons';
-import { parseTiersFromExpr } from '../../../../../helpers';
+import { parseTiersFromExpr, getCurrencyConfig } from '../../../../../helpers';
 import { BILLING_VARS } from '../../../../../constants';
 import {
   splitBillingExprAndRequestRules,
@@ -35,8 +35,6 @@ import {
 } from '../../../../../pages/Setting/Ratio/components/requestRuleExpr';
 
 const { Text } = Typography;
-
-const PRICE_SUFFIX = '$/1M tokens';
 
 const VAR_LABELS = { p: '输入', c: '输出' };
 const OP_LABELS = { '<': '<', '<=': '≤', '>': '>', '>=': '≥' };
@@ -89,6 +87,7 @@ function describeGroup(group, t) {
 }
 
 export default function DynamicPricingBreakdown({ billingExpr, t }) {
+  const { symbol, rate } = getCurrencyConfig();
   const { billingExpr: baseExpr, requestRuleExpr: ruleExpr } =
     splitBillingExprAndRequestRules(billingExpr || '');
 
@@ -132,9 +131,9 @@ export default function DynamicPricingBreakdown({ billingExpr, t }) {
     ...priceFields
       .filter(([field]) => hasTiers && tiers.some((tier) => tier[field] > 0))
       .map(([field, label]) => ({
-        title: `${t(label)} (${PRICE_SUFFIX})`,
+        title: `${t(label)} (${symbol}/1M tokens)`,
         dataIndex: field,
-        render: (v) => v > 0 ? <Text strong>${v.toFixed(4)}</Text> : '-',
+        render: (v) => v > 0 ? <Text strong>{`${symbol}${(v * rate).toFixed(4)}`}</Text> : '-',
       })),
   ];
 

--- a/web/src/helpers/utils.jsx
+++ b/web/src/helpers/utils.jsx
@@ -900,6 +900,20 @@ export const getModelPriceItems = (
 export const formatDynamicPriceSummary = (billingExpr, t, groupRatio = 1) => {
   if (!billingExpr) return <span style={{ color: 'var(--semi-color-text-1)' }}>{t('动态计费')}</span>;
 
+  const quotaDisplayType = localStorage.getItem('quota_display_type') || 'USD';
+  let symbol = '$';
+  let rate = 1;
+  try {
+    const s = JSON.parse(localStorage.getItem('status') || '{}');
+    if (quotaDisplayType === 'CNY') {
+      symbol = '¥';
+      rate = s?.usd_exchange_rate || 7;
+    } else if (quotaDisplayType === 'CUSTOM') {
+      symbol = s?.custom_currency_symbol || '¤';
+      rate = s?.custom_currency_exchange_rate || 1;
+    }
+  } catch (e) {}
+
   const gr = groupRatio || 1;
   const exprBody = billingExpr.replace(/^v\d+:/, '');
   const tierMatches = exprBody.match(/tier\(/g) || [];
@@ -933,7 +947,7 @@ export const formatDynamicPriceSummary = (billingExpr, t, groupRatio = 1) => {
           {varLabels.map(([key, label]) =>
             key in varCoeffs ? (
               <span key={key} style={lineStyle}>
-                {t(label)} ${(varCoeffs[key] * gr).toFixed(4)}{unitSuffix}
+                {`${t(label)} ${symbol}${(varCoeffs[key] * gr * rate).toFixed(4)}${unitSuffix}`}
               </span>
             ) : null,
           )}


### PR DESCRIPTION
# 提交说明 / PR Notice
修复模型广场 动态计费未按设置的展示单位显示的问题

## 变更描述 / Description
获取后台设置的展示单位进行正确的显示

## 运行证明 / Proof of Work
修改前:
<img width="2564" height="608" alt="image" src="https://github.com/user-attachments/assets/d5ea9786-399d-4143-9943-57ea7fb534ed" />

修改后:
<img width="2580" height="514" alt="image" src="https://github.com/user-attachments/assets/b7372b61-6224-492c-abc7-5bb50a9b511d" />

<img width="1620" height="1004" alt="image" src="https://github.com/user-attachments/assets/74222a0e-2f10-4fb1-8c8f-f70e6c9f0326" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing displays now support multiple currencies with dynamic exchange rate conversion based on configuration.
  * Pricing values are properly formatted and converted according to the selected currency and exchange rate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->