### PR TITLE
增加用户创建时间和最后登录时间

### DIFF
--- a/controller/user.go
+++ b/controller/user.go
@@ -91,6 +91,7 @@ func Login(c *gin.Context) {
 
 // setup session & cookies and then return user info
 func setupLogin(user *model.User, c *gin.Context) {
+	model.UpdateUserLastLoginAt(user.Id)
 	session := sessions.Default(c)
 	session.Set("id", user.Id)
 	session.Set("username", user.Username)

--- a/model/user.go
+++ b/model/user.go
@@ -50,6 +50,8 @@ type User struct {
 	Setting          string         `json:"setting" gorm:"type:text;column:setting"`
 	Remark           string         `json:"remark,omitempty" gorm:"type:varchar(255)" validate:"max=255"`
 	StripeCustomer   string         `json:"stripe_customer" gorm:"type:varchar(64);column:stripe_customer;index"`
+	CreatedAt        int64          `json:"created_at" gorm:"autoCreateTime;column:created_at"`
+	LastLoginAt      int64          `json:"last_login_at" gorm:"default:0;column:last_login_at"`
 }
 
 func (user *User) ToBaseUser() *UserBase {
@@ -949,6 +951,12 @@ func DeltaUpdateUserQuota(id int, delta int) (err error) {
 func GetRootUser() (user *User) {
 	DB.Where("role = ?", common.RoleRootUser).First(&user)
 	return user
+}
+
+func UpdateUserLastLoginAt(id int) {
+	if err := DB.Model(&User{}).Where("id = ?", id).Update("last_login_at", common.GetTimestamp()).Error; err != nil {
+		common.SysLog("failed to update user last_login_at: " + err.Error())
+	}
 }
 
 func UpdateUserUsedQuotaAndRequestCount(id int, quota int) {

--- a/web/src/components/table/users/UsersColumnDefs.jsx
+++ b/web/src/components/table/users/UsersColumnDefs.jsx
@@ -29,7 +29,14 @@ import {
   Dropdown,
 } from '@douyinfe/semi-ui';
 import { IconMore } from '@douyinfe/semi-icons';
-import { renderGroup, renderNumber, renderQuota } from '../../../helpers';
+import {
+  renderGroup,
+  renderNumber,
+  renderQuota,
+  timestamp2string,
+} from '../../../helpers';
+
+const renderTimestamp = (text) => (text ? timestamp2string(text) : '-');
 
 /**
  * Render user role
@@ -349,6 +356,16 @@ export const getUsersColumns = ({
       title: t('邀请信息'),
       dataIndex: 'invite',
       render: (text, record, index) => renderInviteInfo(text, record, t),
+    },
+    {
+      title: t('创建时间'),
+      dataIndex: 'created_at',
+      render: renderTimestamp,
+    },
+    {
+      title: t('最后登录'),
+      dataIndex: 'last_login_at',
+      render: renderTimestamp,
     },
     {
       title: '',


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
增加用户创建时间和最后登录时间
增强排查问题和事后审计数据

## 📝 变更描述 / Description
增加创建时间和最后登录时间字段和前端显示

## 🚀 变更类型 / Type of change
改动较小, 增加字段可以自迁移
业务代码只在登录时 增加登录时间的记录 


## 📸 运行证明 / Proof of Work
<img width="2970" height="360" alt="image" src="https://github.com/user-attachments/assets/bdc07f1e-38b5-45db-ab63-8e6e0251e67b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- User accounts now automatically track account creation time and the timestamp of last login activity
- Last login timestamp updates each time a user successfully completes the login process
- User management interface displays these timestamps in human-readable format for all accounts, providing administrators visibility into account activity history and user engagement patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->