### PR TITLE
feat(relay): preserve original model name in mapped responses

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -44,6 +44,37 @@ func maybeMarkClaudeRefusal(c *gin.Context, stopReason string) {
 	}
 }
 
+func applyClientResponseModelToClaudeResponse(info *relaycommon.RelayInfo, response *dto.ClaudeResponse) {
+	rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info)
+	if !rewriteModel || response == nil {
+		return
+	}
+	if response.Model != "" || response.Type == "message" {
+		response.Model = responseModel
+	}
+	if response.Message != nil && response.Message.Model != "" {
+		response.Message.Model = responseModel
+	}
+}
+
+func patchClaudeResponseModelData(info *relaycommon.RelayInfo, data string) string {
+	rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info)
+	if !rewriteModel || data == "" {
+		return data
+	}
+	if gjson.Get(data, "model").Exists() {
+		if patched, err := sjson.Set(data, "model", responseModel); err == nil {
+			data = patched
+		}
+	}
+	if gjson.Get(data, "message.model").Exists() {
+		if patched, err := sjson.Set(data, "message.model", responseModel); err == nil {
+			data = patched
+		}
+	}
+	return data
+}
+
 func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRequest) (*dto.ClaudeRequest, error) {
 	claudeTools := make([]any, 0, len(textRequest.Tools))
 
@@ -709,7 +740,7 @@ func setMessageDeltaUsageInt(data string, path string, localValue int) string {
 	return patchedData
 }
 
-func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *dto.ChatCompletionsStreamResponse, claudeInfo *ClaudeResponseInfo) bool {
+func FormatClaudeResponseInfo(info *relaycommon.RelayInfo, claudeResponse *dto.ClaudeResponse, oaiResponse *dto.ChatCompletionsStreamResponse, claudeInfo *ClaudeResponseInfo) bool {
 	if claudeInfo == nil {
 		return false
 	}
@@ -777,6 +808,9 @@ func FormatClaudeResponseInfo(claudeResponse *dto.ClaudeResponse, oaiResponse *d
 		oaiResponse.Id = claudeInfo.ResponseId
 		oaiResponse.Created = claudeInfo.Created
 		oaiResponse.Model = claudeInfo.Model
+		if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+			oaiResponse.Model = responseModel
+		}
 	}
 	return true
 }
@@ -798,7 +832,7 @@ func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 		maybeMarkClaudeRefusal(c, *claudeResponse.Delta.StopReason)
 	}
 	if info.RelayFormat == types.RelayFormatClaude {
-		FormatClaudeResponseInfo(&claudeResponse, nil, claudeInfo)
+		FormatClaudeResponseInfo(info, &claudeResponse, nil, claudeInfo)
 
 		if claudeResponse.Type == "message_start" {
 			// message_start, 获取usage
@@ -812,11 +846,12 @@ func HandleStreamResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 				data = patchClaudeMessageDeltaUsageData(data, buildMessageDeltaPatchUsage(&claudeResponse, claudeInfo))
 			}
 		}
+		data = patchClaudeResponseModelData(info, data)
 		helper.ClaudeChunkData(c, claudeResponse, data)
 	} else if info.RelayFormat == types.RelayFormatOpenAI {
 		response := StreamResponseClaude2OpenAI(&claudeResponse)
 
-		if !FormatClaudeResponseInfo(&claudeResponse, response, claudeInfo) {
+		if !FormatClaudeResponseInfo(info, &claudeResponse, response, claudeInfo) {
 			return nil
 		}
 
@@ -856,7 +891,11 @@ func HandleStreamFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, clau
 	} else if info.RelayFormat == types.RelayFormatOpenAI {
 		if info.ShouldIncludeUsage {
 			openAIUsage := buildOpenAIStyleUsageFromClaudeUsage(claudeInfo.Usage)
-			response := helper.GenerateFinalUsageResponse(claudeInfo.ResponseId, claudeInfo.Created, info.UpstreamModelName, openAIUsage)
+			responseModel := info.UpstreamModelName
+			if rewriteModel, modelName := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+				responseModel = modelName
+			}
+			response := helper.GenerateFinalUsageResponse(claudeInfo.ResponseId, claudeInfo.Created, responseModel, openAIUsage)
 			err := helper.ObjectData(c, response)
 			if err != nil {
 				common.SysLog("send final response failed: " + err.Error())
@@ -915,14 +954,15 @@ func HandleClaudeResponseData(c *gin.Context, info *relaycommon.RelayInfo, claud
 	var responseData []byte
 	switch info.RelayFormat {
 	case types.RelayFormatOpenAI:
+		applyClientResponseModelToClaudeResponse(info, &claudeResponse)
 		openaiResponse := ResponseClaude2OpenAI(&claudeResponse)
 		openaiResponse.Usage = buildOpenAIStyleUsageFromClaudeUsage(claudeInfo.Usage)
-		responseData, err = json.Marshal(openaiResponse)
+		responseData, err = common.Marshal(openaiResponse)
 		if err != nil {
 			return types.NewError(err, types.ErrorCodeBadResponseBody)
 		}
 	case types.RelayFormatClaude:
-		responseData = data
+		responseData = []byte(patchClaudeResponseModelData(info, string(data)))
 	}
 
 	if claudeResponse.Usage != nil && claudeResponse.Usage.ServerToolUse != nil && claudeResponse.Usage.ServerToolUse.WebSearchRequests > 0 {

--- a/relay/channel/claude/relay_claude_test.go
+++ b/relay/channel/claude/relay_claude_test.go
@@ -27,7 +27,7 @@ func TestFormatClaudeResponseInfo_MessageStart(t *testing.T) {
 		},
 	}
 
-	ok := FormatClaudeResponseInfo(claudeResponse, nil, claudeInfo)
+	ok := FormatClaudeResponseInfo(nil, claudeResponse, nil, claudeInfo)
 	if !ok {
 		t.Fatal("expected true")
 	}
@@ -72,7 +72,7 @@ func TestFormatClaudeResponseInfo_MessageDelta_FullUsage(t *testing.T) {
 		},
 	}
 
-	ok := FormatClaudeResponseInfo(claudeResponse, nil, claudeInfo)
+	ok := FormatClaudeResponseInfo(nil, claudeResponse, nil, claudeInfo)
 	if !ok {
 		t.Fatal("expected true")
 	}
@@ -114,7 +114,7 @@ func TestFormatClaudeResponseInfo_MessageDelta_OnlyOutputTokens(t *testing.T) {
 		},
 	}
 
-	ok := FormatClaudeResponseInfo(claudeResponse, nil, claudeInfo)
+	ok := FormatClaudeResponseInfo(nil, claudeResponse, nil, claudeInfo)
 	if !ok {
 		t.Fatal("expected true")
 	}
@@ -148,7 +148,7 @@ func TestFormatClaudeResponseInfo_MessageDelta_OnlyOutputTokens(t *testing.T) {
 
 func TestFormatClaudeResponseInfo_NilClaudeInfo(t *testing.T) {
 	claudeResponse := &dto.ClaudeResponse{Type: "message_start"}
-	ok := FormatClaudeResponseInfo(claudeResponse, nil, nil)
+	ok := FormatClaudeResponseInfo(nil, claudeResponse, nil, nil)
 	if ok {
 		t.Error("expected false for nil claudeInfo")
 	}
@@ -167,7 +167,7 @@ func TestFormatClaudeResponseInfo_ContentBlockDelta(t *testing.T) {
 		},
 	}
 
-	ok := FormatClaudeResponseInfo(claudeResponse, nil, claudeInfo)
+	ok := FormatClaudeResponseInfo(nil, claudeResponse, nil, claudeInfo)
 	if !ok {
 		t.Fatal("expected true")
 	}

--- a/relay/channel/gemini/relay-gemini.go
+++ b/relay/channel/gemini/relay-gemini.go
@@ -1330,6 +1330,10 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 	id := helper.GetResponseID(c)
 	createAt := common.GetTimestamp()
 	finishReason := constant.FinishReasonStop
+	responseModel := info.UpstreamModelName
+	if rewriteModel, modelName := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		responseModel = modelName
+	}
 	toolCallIndexByChoice := make(map[int]map[string]int)
 	nextToolCallIndexByChoice := make(map[int]int)
 
@@ -1338,7 +1342,7 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 
 		response.Id = id
 		response.Created = createAt
-		response.Model = info.UpstreamModelName
+		response.Model = responseModel
 		for choiceIdx := range response.Choices {
 			choiceKey := response.Choices[choiceIdx].Index
 			for toolIdx := range response.Choices[choiceIdx].Delta.ToolCalls {
@@ -1365,7 +1369,7 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 		logger.LogDebug(c, fmt.Sprintf("info.SendResponseCount = %d", info.SendResponseCount))
 		if info.SendResponseCount == 0 {
 			// send first response
-			emptyResponse := helper.GenerateStartEmptyResponse(id, createAt, info.UpstreamModelName, nil)
+			emptyResponse := helper.GenerateStartEmptyResponse(id, createAt, responseModel, nil)
 			if response.IsToolCall() {
 				if len(emptyResponse.Choices) > 0 && len(response.Choices) > 0 {
 					toolCalls := response.Choices[0].Delta.ToolCalls
@@ -1399,7 +1403,7 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 			logger.LogError(c, err.Error())
 		}
 		if isStop {
-			_ = handleStream(c, info, helper.GenerateStopResponse(id, createAt, info.UpstreamModelName, finishReason))
+			_ = handleStream(c, info, helper.GenerateStopResponse(id, createAt, responseModel, finishReason))
 		}
 		return true
 	})
@@ -1408,7 +1412,7 @@ func GeminiChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *
 		return usage, err
 	}
 
-	response := helper.GenerateFinalUsageResponse(id, createAt, info.UpstreamModelName, *usage)
+	response := helper.GenerateFinalUsageResponse(id, createAt, responseModel, *usage)
 	handleErr := handleFinalStream(c, info, response)
 	if handleErr != nil {
 		common.SysLog("send final response failed: " + handleErr.Error())
@@ -1467,6 +1471,9 @@ func GeminiChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 	}
 	fullTextResponse := responseGeminiChat2OpenAI(c, &geminiResponse)
 	fullTextResponse.Model = info.UpstreamModelName
+	if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		fullTextResponse.Model = responseModel
+	}
 	usage := buildUsageFromGeminiMetadata(geminiResponse.UsageMetadata, info.GetEstimatePromptTokens())
 
 	fullTextResponse.Usage = usage
@@ -1511,6 +1518,9 @@ func GeminiEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *h
 		Object: "list",
 		Data:   make([]dto.OpenAIEmbeddingResponseItem, 0, len(geminiResponse.Embeddings)),
 		Model:  info.UpstreamModelName,
+	}
+	if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		openAIResponse.Model = responseModel
 	}
 
 	for i, embedding := range geminiResponse.Embeddings {

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -64,6 +64,9 @@ func OaiResponsesToChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp
 	if err != nil {
 		return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 	}
+	if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		chatResp.Model = responseModel
+	}
 
 	if usage == nil || usage.TotalTokens == 0 {
 		text := service.ExtractOutputTextFromResponses(&responsesResp)
@@ -100,6 +103,10 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 	responseId := helper.GetResponseID(c)
 	createAt := time.Now().Unix()
 	model := info.UpstreamModelName
+	rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info)
+	if rewriteModel {
+		model = responseModel
+	}
 
 	var (
 		usage       = &dto.Usage{}
@@ -312,7 +319,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 		switch streamResp.Type {
 		case "response.created":
 			if streamResp.Response != nil {
-				if streamResp.Response.Model != "" {
+				if streamResp.Response.Model != "" && !rewriteModel {
 					model = streamResp.Response.Model
 				}
 				if streamResp.Response.CreatedAt != 0 {
@@ -444,7 +451,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 
 		case "response.completed":
 			if streamResp.Response != nil {
-				if streamResp.Response.Model != "" {
+				if streamResp.Response.Model != "" && !rewriteModel {
 					model = streamResp.Response.Model
 				}
 				if streamResp.Response.CreatedAt != 0 {

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -38,6 +38,9 @@ func handleClaudeFormat(c *gin.Context, data string, info *relaycommon.RelayInfo
 	if err := common.Unmarshal(common.StringToByteSlice(data), &streamResponse); err != nil {
 		return err
 	}
+	if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		streamResponse.Model = responseModel
+	}
 
 	if streamResponse.Usage != nil {
 		info.ClaudeConvertInfo.Usage = streamResponse.Usage
@@ -180,6 +183,9 @@ func handleLastResponse(lastStreamData string, responseId *string, createAt *int
 	*createAt = lastStreamResponse.Created
 	*systemFingerprint = lastStreamResponse.GetSystemFingerprint()
 	*model = lastStreamResponse.Model
+	if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+		*model = responseModel
+	}
 
 	if service.ValidUsage(lastStreamResponse.Usage) {
 		*containStreamUsage = true
@@ -212,6 +218,9 @@ func HandleFinalResponse(c *gin.Context, info *relaycommon.RelayInfo, lastStream
 		if err := common.Unmarshal(common.StringToByteSlice(lastStreamData), &streamResponse); err != nil {
 			common.SysLog("error unmarshalling stream response: " + err.Error())
 			return
+		}
+		if rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info); rewriteModel {
+			streamResponse.Model = responseModel
 		}
 
 		info.ClaudeConvertInfo.Usage = usage

--- a/relay/channel/openai/relay-openai.go
+++ b/relay/channel/openai/relay-openai.go
@@ -27,13 +27,17 @@ func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, fo
 		return nil
 	}
 
-	if !forceFormat && !thinkToContent {
+	rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info)
+	if !forceFormat && !thinkToContent && !rewriteModel {
 		return helper.StringData(c, data)
 	}
 
 	var lastStreamResponse dto.ChatCompletionsStreamResponse
 	if err := common.UnmarshalJsonStr(data, &lastStreamResponse); err != nil {
 		return err
+	}
+	if rewriteModel {
+		lastStreamResponse.Model = responseModel
 	}
 
 	if !thinkToContent {
@@ -259,15 +263,25 @@ func OpenaiHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respo
 
 	applyUsagePostProcessing(info, &simpleResponse.Usage, responseBody)
 
+	rewriteModel, responseModel := relaycommon.ResponseModelNameForClient(info)
+	if rewriteModel {
+		simpleResponse.Model = responseModel
+	}
+
 	switch info.RelayFormat {
 	case types.RelayFormatOpenAI:
-		if usageModified {
+		if usageModified || rewriteModel {
 			var bodyMap map[string]interface{}
 			err = common.Unmarshal(responseBody, &bodyMap)
 			if err != nil {
 				return nil, types.NewOpenAIError(err, types.ErrorCodeBadResponseBody, http.StatusInternalServerError)
 			}
-			bodyMap["usage"] = simpleResponse.Usage
+			if usageModified {
+				bodyMap["usage"] = simpleResponse.Usage
+			}
+			if rewriteModel {
+				bodyMap["model"] = responseModel
+			}
 			responseBody, _ = common.Marshal(bodyMap)
 		}
 		if forceFormat {

--- a/relay/common/response_model.go
+++ b/relay/common/response_model.go
@@ -1,0 +1,13 @@
+package common
+
+import "github.com/QuantumNous/new-api/setting/model_setting"
+
+func ResponseModelNameForClient(info *RelayInfo) (bool, string) {
+	if info == nil || !info.IsModelMapped || info.OriginModelName == "" {
+		return false, ""
+	}
+	if !model_setting.GetGlobalSettings().ResponseModelOriginalEnabled {
+		return false, ""
+	}
+	return true, info.OriginModelName
+}

--- a/setting/model_setting/global.go
+++ b/setting/model_setting/global.go
@@ -34,6 +34,7 @@ func (p ChatCompletionsToResponsesPolicy) IsChannelEnabled(channelID int, channe
 
 type GlobalSettings struct {
 	PassThroughRequestEnabled        bool                             `json:"pass_through_request_enabled"`
+	ResponseModelOriginalEnabled     bool                             `json:"response_model_original_enabled"`
 	ThinkingModelBlacklist           []string                         `json:"thinking_model_blacklist"`
 	ChatCompletionsToResponsesPolicy ChatCompletionsToResponsesPolicy `json:"chat_completions_to_responses_policy"`
 }
@@ -41,6 +42,7 @@ type GlobalSettings struct {
 // 默认配置
 var defaultOpenaiSettings = GlobalSettings{
 	PassThroughRequestEnabled: false,
+	ResponseModelOriginalEnabled: true,
 	ThinkingModelBlacklist: []string{
 		"moonshotai/kimi-k2-thinking",
 		"kimi-k2-thinking",

--- a/web/src/components/settings/ModelSetting.jsx
+++ b/web/src/components/settings/ModelSetting.jsx
@@ -40,6 +40,7 @@ const ModelSetting = () => {
     'claude.default_max_tokens': '',
     'claude.thinking_adapter_budget_tokens_percentage': 0.8,
     'global.pass_through_request_enabled': false,
+    'global.response_model_original_enabled': true,
     'global.thinking_model_blacklist': '[]',
     'global.chat_completions_to_responses_policy': '{}',
     'general_setting.ping_interval_enabled': false,

--- a/web/src/pages/Setting/Model/SettingGlobalModel.jsx
+++ b/web/src/pages/Setting/Model/SettingGlobalModel.jsx
@@ -68,6 +68,7 @@ const chatCompletionsToResponsesPolicyAllChannelsExample = JSON.stringify(
 
 const defaultGlobalSettingInputs = {
   'global.pass_through_request_enabled': false,
+  'global.response_model_original_enabled': true,
   'global.thinking_model_blacklist': '[]',
   'global.chat_completions_to_responses_policy': '{}',
   'general_setting.ping_interval_enabled': false,
@@ -201,6 +202,23 @@ export default function SettingGlobalModel(props) {
                   }
                   extraText={t(
                     '开启后，所有请求将直接透传给上游，不会进行任何处理（重定向和渠道适配也将失效）,请谨慎开启',
+                  )}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={24} sm={12} md={8} lg={8} xl={8}>
+                <Form.Switch
+                  label={t('响应模型名使用请求模型名')}
+                  field={'global.response_model_original_enabled'}
+                  onChange={(value) =>
+                    setInputs({
+                      ...inputs,
+                      'global.response_model_original_enabled': value,
+                    })
+                  }
+                  extraText={t(
+                    '开启后，当渠道模型映射生效时，响应中的 model 字段返回客户端请求的模型名；关闭后返回上游实际模型名',
                   )}
                 />
               </Col>


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
新增全局设置 `global.response_model_original_enabled`，用于控制模型映射生效时响应中的 `model` 字段是否返回客户端请求的原始模型名。

该设置开启后，OpenAI / Claude / Gemini 相关兼容响应会在返回前将客户端可见的 `model` 字段改回请求模型名，避免暴露映射后的上游模型名。计费、token 统计和上游请求仍继续使用真实上游模型名，不影响路由和结算逻辑。

## 🚀 变更类型 / Type of change
- [ ] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
- 已执行 `git diff --check`，无 whitespace/error 输出。
- 当前环境缺少 `go`、`gofmt`、`bun`，未能运行 Go 测试和前端构建。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added response model name rewriting for different AI providers (Claude, Gemini, OpenAI) based on client configuration.
  * New global setting `response_model_original_enabled` to control whether original model names are used in responses.
  * Updated settings UI to expose the new response model configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->