### PR TITLE
fix(codex): 修复 Responses API tool_call arguments 字段双向类型兼容

### DIFF
--- a/dto/flexible_arguments.go
+++ b/dto/flexible_arguments.go
@@ -1,0 +1,206 @@
+package dto
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+// ObjectArgumentItemTypes lists Responses-API item types whose `arguments`
+// field must be carried as a JSON object/array (not a JSON string) when sent
+// to or received from the upstream. Items not listed here (notably
+// `function_call`) keep `arguments` as a JSON string per OpenAI Responses spec.
+//
+// The list is intentionally non-exhaustive: it enumerates the built-in tool
+// call item types that are known today to use object-shaped `arguments`.
+// Unknown / future item types fall through the default branch in
+// normalizeArgumentField and are coerced to string. This is fail-closed for
+// types whose shape is unknown (better to over-stringify and let downstream
+// parse than to drop data).
+//
+// Add a new entry here whenever the upstream introduces another structured
+// built-in tool whose `arguments` is delivered as an object.
+var ObjectArgumentItemTypes = map[string]bool{
+	"tool_search_call":      true,
+	"web_search_call":       true,
+	"file_search_call":      true,
+	"local_shell_call":      true,
+	"computer_call":         true,
+	"image_generation_call": true,
+	"code_interpreter_call": true,
+	"mcp_call":              true,
+}
+
+// FlexibleArguments holds the raw JSON bytes of the `arguments` field of a
+// Responses API output item. The Responses API uses different JSON shapes for
+// different item types: function_call carries a JSON-encoded string, while
+// tool_search_call / web_search_call / etc. carry a JSON object.
+//
+// The string representation stores the verbatim JSON token received from the
+// wire (e.g. `"{\"k\":\"v\"}"` for a string-shaped value, or `{"k":"v"}` for
+// an object-shaped value), so that re-marshaling reproduces the original
+// shape and the upstream / downstream observe the protocol they expect.
+//
+// Empty FlexibleArguments ("") is treated as absent: it survives `omitempty`
+// elision and `MarshalJSON` falls back to an empty JSON string for callers
+// that do force-serialize the field.
+//
+// The underlying string holds raw JSON bytes, not a plain Go string. Do not
+// cast a plain Go string into FlexibleArguments directly (e.g.
+// `FlexibleArguments("hello")` would marshal as invalid JSON). All callers
+// in this codebase populate FlexibleArguments only via JSON unmarshal.
+type FlexibleArguments string
+
+// UnmarshalJSON stores the raw JSON bytes verbatim (with their surrounding
+// quotes for string payloads) so the original shape can be re-emitted later.
+func (a *FlexibleArguments) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*a = ""
+		return nil
+	}
+	*a = FlexibleArguments(trimmed)
+	return nil
+}
+
+// MarshalJSON re-emits the arguments using the original shape received from
+// the wire. An empty FlexibleArguments serializes as an empty JSON string so
+// that surrounding `omitempty` tags continue to elide the field.
+func (a FlexibleArguments) MarshalJSON() ([]byte, error) {
+	if a == "" {
+		return []byte(`""`), nil
+	}
+	return []byte(a), nil
+}
+
+// String returns a string representation of the arguments suitable for places
+// that expect the OpenAI Chat Completions `tool_calls[].function.arguments`
+// shape (always a JSON-encoded string).
+//
+//   - JSON-string raw payload  -> the unquoted contents.
+//   - empty / null raw payload -> "".
+//   - object/array/etc.        -> compact JSON encoding.
+func (a FlexibleArguments) String() string {
+	raw := strings.TrimSpace(string(a))
+	if raw == "" || raw == "null" {
+		return ""
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := common.UnmarshalJsonStr(raw, &s); err == nil {
+			return s
+		}
+	}
+	return raw
+}
+
+// NormalizeResponsesStreamArgumentsJSON walks a single SSE event payload and
+// makes the `arguments` field of any function_call / tool_*_call items match
+// the shape required by the OpenAI Responses spec:
+//
+//   - function_call (and any item type not listed in ObjectArgumentItemTypes):
+//     arguments must be a JSON string.
+//   - tool_search_call / web_search_call / file_search_call / local_shell_call /
+//     computer_call / image_generation_call: arguments must be a JSON object
+//     or array.
+//
+// It returns the (possibly rewritten) JSON, a flag indicating whether the
+// payload was modified, and any error encountered while parsing.
+func NormalizeResponsesStreamArgumentsJSON(data string) (string, bool, error) {
+	if data == "" || !strings.Contains(data, `"arguments"`) {
+		return data, false, nil
+	}
+
+	var event map[string]any
+	if err := common.UnmarshalJsonStr(data, &event); err != nil {
+		return data, false, err
+	}
+
+	changed, err := normalizeResponsesArgumentsInEvent(event)
+	if err != nil || !changed {
+		return data, changed, err
+	}
+
+	normalized, err := common.Marshal(event)
+	if err != nil {
+		return data, false, err
+	}
+	return string(normalized), true, nil
+}
+
+func normalizeResponsesArgumentsInEvent(event map[string]any) (bool, error) {
+	changed := false
+
+	if item, ok := event["item"].(map[string]any); ok {
+		itemChanged, err := normalizeArgumentField(item)
+		if err != nil {
+			return false, err
+		}
+		changed = changed || itemChanged
+	}
+
+	if response, ok := event["response"].(map[string]any); ok {
+		if output, ok := response["output"].([]any); ok {
+			for _, outputItem := range output {
+				item, ok := outputItem.(map[string]any)
+				if !ok {
+					continue
+				}
+				itemChanged, err := normalizeArgumentField(item)
+				if err != nil {
+					return false, err
+				}
+				changed = changed || itemChanged
+			}
+		}
+	}
+
+	return changed, nil
+}
+
+// normalizeArgumentField makes the arguments field of one item match its
+// expected shape based on the item's `type`.
+func normalizeArgumentField(item map[string]any) (bool, error) {
+	typ, _ := item["type"].(string)
+	value, ok := item["arguments"]
+	if !ok {
+		return false, nil
+	}
+
+	if ObjectArgumentItemTypes[typ] {
+		// Wants object/array. Convert string -> object only.
+		str, isString := value.(string)
+		if !isString {
+			return false, nil
+		}
+		trimmed := strings.TrimSpace(str)
+		if trimmed == "" {
+			item["arguments"] = map[string]any{}
+			return true, nil
+		}
+		var parsed any
+		if err := common.UnmarshalJsonStr(trimmed, &parsed); err != nil {
+			// Leave the original string in place rather than failing the
+			// whole event; downstream may still recover.
+			return false, nil
+		}
+		item["arguments"] = parsed
+		return true, nil
+	}
+
+	// Default (function_call etc.): wants string.
+	if _, isString := value.(string); isString {
+		return false, nil
+	}
+	if value == nil {
+		item["arguments"] = ""
+		return true, nil
+	}
+	compact, err := common.Marshal(value)
+	if err != nil {
+		return false, err
+	}
+	item["arguments"] = string(compact)
+	return true, nil
+}

--- a/dto/flexible_arguments_test.go
+++ b/dto/flexible_arguments_test.go
@@ -1,0 +1,327 @@
+package dto
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+func TestFlexibleArguments_UnmarshalPreservesShape(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		// expectedRaw is the verbatim JSON we expect FlexibleArguments to remember.
+		expectedRaw string
+		// expectedString is what String() should yield.
+		expectedString string
+	}{
+		{
+			name:           "string payload",
+			in:             `"{\"foo\":\"bar\"}"`,
+			expectedRaw:    `"{\"foo\":\"bar\"}"`,
+			expectedString: `{"foo":"bar"}`,
+		},
+		{
+			name:           "object payload",
+			in:             `{"foo":"bar"}`,
+			expectedRaw:    `{"foo":"bar"}`,
+			expectedString: `{"foo":"bar"}`,
+		},
+		{
+			name:           "array payload",
+			in:             `[1,2,3]`,
+			expectedRaw:    `[1,2,3]`,
+			expectedString: `[1,2,3]`,
+		},
+		{
+			name:           "null payload",
+			in:             `null`,
+			expectedRaw:    ``,
+			expectedString: ``,
+		},
+		{
+			name:           "empty string payload",
+			in:             `""`,
+			expectedRaw:    `""`,
+			expectedString: ``,
+		},
+		{
+			name:           "number payload",
+			in:             `42`,
+			expectedRaw:    `42`,
+			expectedString: `42`,
+		},
+		{
+			name:           "boolean true payload",
+			in:             `true`,
+			expectedRaw:    `true`,
+			expectedString: `true`,
+		},
+		{
+			name:           "boolean false payload",
+			in:             `false`,
+			expectedRaw:    `false`,
+			expectedString: `false`,
+		},
+		{
+			name:           "leading and trailing whitespace stripped on unmarshal",
+			in:             "   {\"foo\":\"bar\"}   ",
+			expectedRaw:    `{"foo":"bar"}`,
+			expectedString: `{"foo":"bar"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var fa FlexibleArguments
+			if err := fa.UnmarshalJSON([]byte(tc.in)); err != nil {
+				t.Fatalf("UnmarshalJSON: %v", err)
+			}
+			if string(fa) != tc.expectedRaw {
+				t.Fatalf("raw mismatch: want %q got %q", tc.expectedRaw, string(fa))
+			}
+			if got := fa.String(); got != tc.expectedString {
+				t.Fatalf("String() mismatch: want %q got %q", tc.expectedString, got)
+			}
+		})
+	}
+}
+
+func TestFlexibleArguments_MarshalRoundTripPreservesShape(t *testing.T) {
+	type wrap struct {
+		Arguments FlexibleArguments `json:"arguments,omitempty"`
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		// expectedField is what we expect the re-marshaled JSON to contain
+		// for the `arguments` key (or empty string if the key should be elided).
+		expectedField string
+	}{
+		{
+			name:          "object preserved as object",
+			in:            `{"arguments":{"foo":"bar"}}`,
+			expectedField: `"arguments":{"foo":"bar"}`,
+		},
+		{
+			name:          "string preserved as string",
+			in:            `{"arguments":"abc"}`,
+			expectedField: `"arguments":"abc"`,
+		},
+		{
+			name:          "array preserved as array",
+			in:            `{"arguments":[1,2]}`,
+			expectedField: `"arguments":[1,2]`,
+		},
+		{
+			name:          "null elided by omitempty",
+			in:            `{"arguments":null}`,
+			expectedField: ``,
+		},
+		{
+			name:          "absent field stays absent",
+			in:            `{}`,
+			expectedField: ``,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var w wrap
+			if err := common.UnmarshalJsonStr(tc.in, &w); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			out, err := common.Marshal(w)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			outStr := string(out)
+			if tc.expectedField == "" {
+				if strings.Contains(outStr, `"arguments"`) {
+					t.Fatalf("expected arguments to be elided, got %s", outStr)
+				}
+				return
+			}
+			if !strings.Contains(outStr, tc.expectedField) {
+				t.Fatalf("expected %q in %s", tc.expectedField, outStr)
+			}
+		})
+	}
+}
+
+func TestFlexibleArguments_MarshalIsIdempotent(t *testing.T) {
+	// The same FlexibleArguments value must marshal to identical bytes on
+	// every call; otherwise stream prefix-match logic in chat_via_responses.go
+	// could see spurious diffs across chunks.
+	type wrap struct {
+		Arguments FlexibleArguments `json:"arguments,omitempty"`
+	}
+	inputs := []string{
+		`{"arguments":"abc"}`,
+		`{"arguments":{"foo":"bar","baz":1}}`,
+		`{"arguments":[1,2,3]}`,
+		`{"arguments":42}`,
+		`{"arguments":true}`,
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			var w wrap
+			if err := common.UnmarshalJsonStr(in, &w); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			first, err := common.Marshal(w)
+			if err != nil {
+				t.Fatalf("Marshal #1: %v", err)
+			}
+			for i := 0; i < 4; i++ {
+				next, err := common.Marshal(w)
+				if err != nil {
+					t.Fatalf("Marshal #%d: %v", i+2, err)
+				}
+				if string(next) != string(first) {
+					t.Fatalf("non-idempotent marshal: first=%s later=%s", first, next)
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_FunctionCallObjectToString(t *testing.T) {
+	in := `{"type":"response.output_item.done","item":{"type":"function_call","arguments":{"path":"/etc"}}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if !strings.Contains(out, `"arguments":"{\"path\":\"/etc\"}"`) {
+		t.Fatalf("expected stringified arguments, got %s", out)
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_ToolSearchCallStringToObject(t *testing.T) {
+	in := `{"type":"response.output_item.done","item":{"type":"tool_search_call","arguments":"{\"query\":\"hello\"}"}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if !strings.Contains(out, `"arguments":{"query":"hello"}`) {
+		t.Fatalf("expected object-shaped arguments, got %s", out)
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_AlreadyCorrectShapesAreNoOp(t *testing.T) {
+	cases := []string{
+		// function_call already string - no change
+		`{"type":"response.output_item.done","item":{"type":"function_call","arguments":"{\"a\":1}"}}`,
+		// tool_search_call already object - no change
+		`{"type":"response.output_item.done","item":{"type":"tool_search_call","arguments":{"a":1}}}`,
+	}
+	for _, in := range cases {
+		out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+		if err != nil {
+			t.Fatalf("err: %v (input=%s)", err, in)
+		}
+		if changed {
+			t.Fatalf("expected no change for %s, got %s", in, out)
+		}
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_ExtendedObjectArgTypes(t *testing.T) {
+	// code_interpreter_call and mcp_call are also expected to carry object-shaped
+	// arguments. They should be normalized the same way as tool_search_call.
+	cases := []struct {
+		typ string
+	}{
+		{"code_interpreter_call"},
+		{"mcp_call"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			in := `{"type":"response.output_item.done","item":{"type":"` + tc.typ + `","arguments":"{\"k\":1}"}}`
+			out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !changed {
+				t.Fatalf("expected change for %s", tc.typ)
+			}
+			if !strings.Contains(out, `"arguments":{"k":1}`) {
+				t.Fatalf("expected object-shape for %s, got %s", tc.typ, out)
+			}
+		})
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_FunctionCallNullBecomesEmptyString(t *testing.T) {
+	in := `{"type":"response.output_item.done","item":{"type":"function_call","arguments":null}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected change")
+	}
+	if !strings.Contains(out, `"arguments":""`) {
+		t.Fatalf("expected empty-string arguments, got %s", out)
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_ObjectTypeWithMalformedStringIsLeftAlone(t *testing.T) {
+	// When a whitelisted type carries a string that is not valid JSON, the
+	// normalizer leaves the original string in place rather than failing the
+	// entire event. The downstream may still recover.
+	in := `{"type":"response.output_item.done","item":{"type":"tool_search_call","arguments":"not-json"}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected no change for malformed JSON string, got %s", out)
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_ResponseOutputArrayMixedTypes(t *testing.T) {
+	in := `{"type":"response.completed","response":{"output":[` +
+		`{"type":"function_call","arguments":{"path":"/etc"}},` +
+		`{"type":"tool_search_call","arguments":"{\"q\":1}"},` +
+		`{"type":"web_search_call","arguments":{"q":2}}` +
+		`]}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !changed {
+		t.Fatalf("expected changed=true")
+	}
+	if !strings.Contains(out, `"arguments":"{\"path\":\"/etc\"}"`) {
+		t.Fatalf("function_call should become string, got %s", out)
+	}
+	if !strings.Contains(out, `"arguments":{"q":1}`) {
+		t.Fatalf("tool_search_call should become object, got %s", out)
+	}
+	if !strings.Contains(out, `"arguments":{"q":2}`) {
+		t.Fatalf("web_search_call should stay object, got %s", out)
+	}
+}
+
+func TestNormalizeResponsesStreamArgumentsJSON_NoArgumentsField(t *testing.T) {
+	in := `{"type":"response.created","response":{"id":"abc"}}`
+	out, changed, err := NormalizeResponsesStreamArgumentsJSON(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if changed {
+		t.Fatalf("expected no change")
+	}
+	if out != in {
+		t.Fatalf("expected pass-through, got %s", out)
+	}
+}

--- a/dto/openai_response.go
+++ b/dto/openai_response.go
@@ -345,7 +345,7 @@ type ResponsesOutput struct {
 	Size      string                   `json:"size"`
 	CallId    string                   `json:"call_id,omitempty"`
 	Name      string                   `json:"name,omitempty"`
-	Arguments string                   `json:"arguments,omitempty"`
+	Arguments FlexibleArguments        `json:"arguments,omitempty"`
 }
 
 type ResponsesOutputContent struct {

--- a/relay/channel/codex/adaptor.go
+++ b/relay/channel/codex/adaptor.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -52,8 +53,132 @@ func (a *Adaptor) ConvertEmbeddingRequest(c *gin.Context, info *relaycommon.Rela
 	return nil, errors.New("codex channel: /v1/embeddings endpoint not supported")
 }
 
+// normalizeCodexResponsesInput rewrites the Responses-API `input` payload so the
+// Codex backend receives the per-item-type shapes it expects.
+//
+// Two shapes are observed in real Codex CLI / Codex Desktop sessions:
+//   - A bare JSON string: wrapped into a single user message so the upstream sees
+//     a list of message items (matching Codex CLI's behavior).
+//   - A JSON array of items: items whose `type` is listed in
+//     dto.ObjectArgumentItemTypes (tool_search_call / web_search_call / ...) must
+//     have `arguments` as a JSON object. function_call items keep `arguments`
+//     as a JSON string, per the OpenAI Responses spec. Items already in the
+//     correct shape are left untouched.
+//
+// Returns the original bytes unchanged when no rewrite is required.
+func normalizeCodexResponsesInput(raw json.RawMessage) (json.RawMessage, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return raw, nil
+	}
+
+	if raw[0] == '"' {
+		var strInput string
+		if err := common.Unmarshal(raw, &strInput); err != nil {
+			return raw, err
+		}
+		wrapped := []map[string]string{
+			{"role": "user", "content": strInput},
+		}
+		return common.Marshal(wrapped)
+	}
+
+	if raw[0] == '[' {
+		var items []any
+		if err := common.Unmarshal(raw, &items); err != nil {
+			return raw, err
+		}
+		if convertCodexObjectArgItems(items) {
+			return common.Marshal(items)
+		}
+		return raw, nil
+	}
+
+	return raw, nil
+}
+
+// convertCodexObjectArgItems walks the input array and converts string
+// `arguments` values to JSON objects for item types that require it. Returns
+// true if any item was modified.
+func convertCodexObjectArgItems(items []any) bool {
+	changed := false
+	for _, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		typ, _ := m["type"].(string)
+		if !dto.ObjectArgumentItemTypes[typ] {
+			continue
+		}
+		raw, has := m["arguments"]
+		if !has {
+			continue
+		}
+		switch v := raw.(type) {
+		case map[string]any, []any:
+			// already a JSON object/array
+			continue
+		case nil:
+			m["arguments"] = map[string]any{}
+			changed = true
+		case string:
+			m["arguments"] = parseStringArgsToObject(v)
+			changed = true
+		default:
+			m["arguments"] = map[string]any{"value": v}
+			changed = true
+		}
+	}
+	return changed
+}
+
+// parseStringArgsToObject parses a JSON-string arguments value into a map.
+//
+// Compliant clients (Codex Desktop, Codex CLI) always send object-shaped
+// arguments for the item types listed in dto.ObjectArgumentItemTypes, so this
+// function is only reached on misbehaving / legacy clients that wrap the
+// arguments into a string. Behavior:
+//
+//   - empty string                 -> {}
+//   - valid JSON object            -> the object itself
+//   - valid JSON null              -> {}
+//   - valid JSON of any other kind -> {"value": <parsed value>}
+//   - invalid JSON                 -> {"value": <original string>}
+//
+// The fallback wrapper (`{"value": ...}`) is best-effort: it preserves the
+// payload so the upstream can choose to accept or reject it, instead of
+// silently dropping data here. If the upstream's tool schema doesn't accept
+// the wrapped shape, the upstream will surface the error to the client,
+// which is the desired behavior for a relay.
+func parseStringArgsToObject(s string) map[string]any {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return map[string]any{}
+	}
+	var parsed any
+	if err := common.UnmarshalJsonStr(trimmed, &parsed); err != nil {
+		return map[string]any{"value": s}
+	}
+	if parsed == nil {
+		return map[string]any{}
+	}
+	if obj, ok := parsed.(map[string]any); ok {
+		return obj
+	}
+	return map[string]any{"value": parsed}
+}
+
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {
 	isCompact := info != nil && info.RelayMode == relayconstant.RelayModeResponsesCompact
+
+	if len(request.Input) > 0 {
+		normalizedInput, err := normalizeCodexResponsesInput(request.Input)
+		if err != nil {
+			return nil, err
+		}
+		request.Input = normalizedInput
+	}
 
 	if info != nil && info.ChannelSetting.SystemPrompt != "" {
 		systemPrompt := info.ChannelSetting.SystemPrompt

--- a/relay/channel/codex/adaptor_test.go
+++ b/relay/channel/codex/adaptor_test.go
@@ -1,0 +1,189 @@
+package codex
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+)
+
+func TestNormalizeCodexResponsesInput_BareStringWrapsAsUserMessage(t *testing.T) {
+	in := json.RawMessage(`"hello world"`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	var items []map[string]string
+	if err := common.Unmarshal(out, &items); err != nil {
+		t.Fatalf("expected JSON array, got %s (err=%v)", out, err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if items[0]["role"] != "user" || items[0]["content"] != "hello world" {
+		t.Fatalf("unexpected wrapped item: %+v", items[0])
+	}
+}
+
+func TestNormalizeCodexResponsesInput_FunctionCallStringStays(t *testing.T) {
+	in := json.RawMessage(`[{"type":"function_call","arguments":"{\"path\":\"/etc\"}"}]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), `"arguments":"{\"path\":\"/etc\"}"`) {
+		t.Fatalf("expected function_call.arguments to remain a string, got %s", out)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_ToolSearchCallStringToObject(t *testing.T) {
+	in := json.RawMessage(`[{"type":"tool_search_call","arguments":"{\"query\":\"hello\"}"}]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), `"arguments":{"query":"hello"}`) {
+		t.Fatalf("expected tool_search_call.arguments to become an object, got %s", out)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_ToolSearchCallObjectStays(t *testing.T) {
+	in := json.RawMessage(`[{"type":"tool_search_call","arguments":{"query":"hi"}}]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), `"arguments":{"query":"hi"}`) {
+		t.Fatalf("expected object to remain object, got %s", out)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_OtherObjectArgItemTypes(t *testing.T) {
+	cases := []struct {
+		typ string
+	}{
+		{"web_search_call"},
+		{"file_search_call"},
+		{"local_shell_call"},
+		{"computer_call"},
+		{"image_generation_call"},
+		{"code_interpreter_call"},
+		{"mcp_call"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			in := json.RawMessage(`[{"type":"` + tc.typ + `","arguments":"{\"a\":1}"}]`)
+			out, err := normalizeCodexResponsesInput(in)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !strings.Contains(string(out), `"arguments":{"a":1}`) {
+				t.Fatalf("expected %s.arguments to become object, got %s", tc.typ, out)
+			}
+		})
+	}
+}
+
+func TestNormalizeCodexResponsesInput_MixedArrayHandlesEachItemType(t *testing.T) {
+	in := json.RawMessage(`[` +
+		`{"type":"function_call","arguments":"{\"k\":1}"},` +
+		`{"type":"tool_search_call","arguments":"{\"k\":2}"},` +
+		`{"type":"message","role":"user","content":"hi"}` +
+		`]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, `"arguments":"{\"k\":1}"`) {
+		t.Fatalf("function_call.arguments should remain string, got %s", s)
+	}
+	if !strings.Contains(s, `"arguments":{"k":2}`) {
+		t.Fatalf("tool_search_call.arguments should become object, got %s", s)
+	}
+	if !strings.Contains(s, `"role":"user"`) {
+		t.Fatalf("message item should be preserved, got %s", s)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_EmptyOrNilStaysSame(t *testing.T) {
+	for _, in := range []json.RawMessage{nil, []byte(""), []byte("   ")} {
+		out, err := normalizeCodexResponsesInput(in)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(out) > 0 && strings.TrimSpace(string(out)) != "" {
+			t.Fatalf("expected empty pass-through, got %q", out)
+		}
+	}
+}
+
+func TestNormalizeCodexResponsesInput_ObjectInputPassesThrough(t *testing.T) {
+	// The Responses API spec allows `input` to be a string or an array of
+	// items. A bare object is non-conforming client input; the relay should
+	// not silently rewrite it. Pass it through verbatim and let the upstream
+	// surface the actual error.
+	in := json.RawMessage(`{"unexpected":"shape"}`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if string(out) != string(in) {
+		t.Fatalf("expected verbatim pass-through, got %s", out)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_NullArgumentsBecomesEmptyObject(t *testing.T) {
+	// Whitelisted item types should never carry a JSON `null` arguments
+	// upstream; turn it into an empty object so the upstream schema check
+	// always sees an object shape.
+	in := json.RawMessage(`[{"type":"tool_search_call","arguments":null}]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), `"arguments":{}`) {
+		t.Fatalf("expected null -> {}, got %s", out)
+	}
+}
+
+func TestNormalizeCodexResponsesInput_FunctionCallObjectPassesThrough(t *testing.T) {
+	// function_call with object-shaped arguments is non-conforming client
+	// input. The relay does not "fix" it because the spec is clear that
+	// function_call.arguments must be a string. Let the upstream reject it.
+	in := json.RawMessage(`[{"type":"function_call","arguments":{"k":1}}]`)
+	out, err := normalizeCodexResponsesInput(in)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !strings.Contains(string(out), `"arguments":{"k":1}`) {
+		t.Fatalf("expected verbatim object pass-through (no relay-side fix), got %s", out)
+	}
+}
+
+func TestParseStringArgsToObject(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: `{}`},
+		{name: "valid object", in: `{"a":1}`, want: `{"a":1}`},
+		{name: "valid array", in: `[1,2]`, want: `{"value":[1,2]}`},
+		{name: "valid scalar", in: `42`, want: `{"value":42}`},
+		{name: "invalid json wraps as value", in: `not-json`, want: `{"value":"not-json"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseStringArgsToObject(tc.in)
+			b, err := common.Marshal(got)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(b) != tc.want {
+				t.Fatalf("got %s want %s", b, tc.want)
+			}
+		})
+	}
+}

--- a/relay/channel/openai/chat_via_responses.go
+++ b/relay/channel/openai/chat_via_responses.go
@@ -408,7 +408,7 @@ func OaiResponsesToChatStreamHandler(c *gin.Context, info *relaycommon.RelayInfo
 				toolCallNameByID[callID] = name
 			}
 
-			newArgs := streamResp.Item.Arguments
+			newArgs := streamResp.Item.Arguments.String()
 			prevArgs := toolCallArgsByID[callID]
 			argsDelta := ""
 			if newArgs != "" {

--- a/relay/channel/openai/helper.go
+++ b/relay/channel/openai/helper.go
@@ -257,5 +257,19 @@ func sendResponsesStreamData(c *gin.Context, streamResponse dto.ResponsesStreamR
 	if data == "" {
 		return
 	}
+	// dto.NormalizeResponsesStreamArgumentsJSON is type-aware: it only rewrites
+	// items whose declared `type` disagrees with the shape required by the
+	// Responses spec. This handler is shared across all channels that produce
+	// Responses stream events (codex, plain OpenAI, etc.); the normalization
+	// is a no-op when upstream events already match the spec, so passing
+	// non-Codex traffic through it is safe and cheap.
+	if normalizedData, changed, err := dto.NormalizeResponsesStreamArgumentsJSON(data); err != nil {
+		// Fail open: a normalization error should not abort the stream.
+		// The original `data` is whatever the upstream sent and remains
+		// the most authoritative source of truth on parse failure.
+		common.SysLog("failed to normalize responses stream arguments: " + err.Error())
+	} else if changed {
+		data = normalizedData
+	}
 	helper.ResponseChunkData(c, streamResponse, data)
 }

--- a/service/openaicompat/responses_to_chat.go
+++ b/service/openaicompat/responses_to_chat.go
@@ -60,7 +60,7 @@ func ResponsesResponseToChatCompletionsResponse(resp *dto.OpenAIResponsesRespons
 				Type: "function",
 				Function: dto.FunctionResponse{
 					Name:      name,
-					Arguments: out.Arguments,
+					Arguments: out.Arguments.String(),
 				},
 			})
 		}


### PR DESCRIPTION
## 📝 变更描述 / Description

### 问题 / Problem

Codex 渠道走 `/v1/responses` 时，**请求和响应两个方向**都会因 `arguments` 字段类型期望不一致而失败：

- **响应方向 / Response side（issue #4432 报告的错误）**
  - 上游 chatgpt.com Codex 后端在 `tool_search_call` / `web_search_call` / `file_search_call` 等内置工具事件里，把 `arguments` 当作 **JSON object** 返回
  - NewAPI 的 `dto.OutputItem.Arguments` 之前声明为 `string`，于是流式转发链路抛错：
    `json: cannot unmarshal object into Go struct field ResponsesOutput.item.arguments of type string`
  - 后果：tool call 响应被丢弃，计费 `prompt_tokens=0`

- **请求方向 / Request side（同一根因，方向相反）**
  - 客户端（Codex CLI、Claude Code 等）按 OpenAI Responses API 规范，把 `function_call.arguments` 序列化为 **JSON string**
  - NewAPI 转发到上游 chatgpt.com Codex 时，未做任何 normalize，但上游 Codex 后端对自家内置工具调用的 `tool_search_call` 等 item 又**要求 object**
  - 一旦客户端把内置工具的 arguments 也写成 string 形式，上游会回 400：
    `Invalid type for 'input[N].arguments': expected an object, but got a string instead`

### 修复 / Fix

引入 type-aware 的双向 normalization：

1. **`dto.FlexibleArguments`** 字符串底层类型，在 `UnmarshalJSON` 阶段**保留原始 JSON 字节**（不做形状转换），下游想要哪种形态就由序列化端决定。
2. **`dto.ObjectArgumentItemTypes`** 共享白名单，列出所有 Codex 内置工具 item 类型（共 8 个），这些 item 的 `arguments` 必须保持 **object**：
   - `tool_search_call`, `web_search_call`, `file_search_call`, `local_shell_call`, `computer_call`, `image_generation_call`, `code_interpreter_call`, `mcp_call`
3. **请求方向**：在 `relay/channel/codex/adaptor.go` 里加 `normalizeCodexResponsesInput`，对 input 数组里的 item 按 type 走分支：
   - `function_call` → `arguments` 必须是 string（OpenAI Responses 协议）
   - 命中白名单 → `arguments` 必须是 object（Codex 内置工具协议）
4. **响应方向**：在 `relay/channel/openai/helper.go` 的流式 chunk 转发链路里，调用 `dto.NormalizeResponsesStreamArgumentsJSON` 做同样的 type-aware 修正（fail-open，不阻塞流）。
5. **下游 Chat Completions 路径**：`chat_via_responses.go` 与 `responses_to_chat.go` 把 `Arguments` 转成 OpenAI 标准的 string 时，统一走 `FlexibleArguments.String()`，自动处理 string / object 两种来源。

### 为什么这样改能生效 / Why this works

- `FlexibleArguments` **不在解析阶段做有损转换**，原始 wire 字节保留下来，再按 item.type 决定输出形态——这是单向类型 (`string`) 在双形态协议里失败的根因，对症下药。
- 共享 `ObjectArgumentItemTypes` 让请求/响应两个方向用**同一份白名单**，不会出现两边漂移；新增 Codex 内置工具时只改一处。
- 响应方向兜底是 fail-open（normalize 失败时透传原始字节），不会因为新出现的 item.type 把流打死。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) — 关联 Issue #4432

## 🔗 关联任务 / Related Issue

- Closes #4432

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 描述基于实际调试结果手工撰写，未粘贴 AI 原始输出。
- [x] **非重复提交:** 已搜索 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认无重复。
- [x] **Bug fix 说明:** 已关联 Issue #4432；本 PR 解决的是协议层类型不匹配导致的真实运行时错误，非设计取舍。
- [x] **变更理解:** 已理解请求/响应两个方向的协议要求差异，修复方案对称。
- [x] **范围聚焦:** 仅包含 `arguments` 字段类型双向 normalize 所需的最小改动；附带的"裸字符串 input → user message 包装"复用同一 normalize 入口函数，PR 描述已诚实标明。
- [x] **本地验证:** `go build ./...`、`go vet ./...`、`go test ./dto ./relay/channel/codex` 全部通过；新增单元测试覆盖请求/响应两向的核心分支与边界条件。
- [x] **安全合规:** 无凭据、密钥等敏感数据；遵循项目 `common.Marshal/Unmarshal` 等约定。

## 📸 运行证明 / Proof of Work

### 架构总览 / Architecture overview

<!-- 拖图区：把架构图拖到此处 / drag the cover image here -->

### 测试日志 / Test log

```
$ go test ./dto ./relay/channel/codex
ok  	github.com/QuantumNous/new-api/dto                       5.851s
ok  	github.com/QuantumNous/new-api/relay/channel/codex      11.255s
```

### 修复后实际跑通的场景 / Verified scenarios

- ✅ 客户端发送 `function_call.arguments` 为 string —— 透传上游、无 400
- ✅ 客户端发送 `tool_search_call.arguments` 为 object —— 透传上游、无 400
- ✅ 上游返回 `tool_search_call.arguments` 为 object —— 流式 chunk 不再抛 unmarshal error，tool call 完整下传，计费正常
- ✅ 既有 `function_call` 流式响应不受影响（向后兼容）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced handling of arguments in Responses API with improved JSON structure preservation during streaming operations.
  * Automatic normalization of tool and function call arguments to expected API formats.

* **Bug Fixes**
  * Improved argument shape transformations for tool-related calls to ensure correct format conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->