### PR TITLE
fix: sync theme to runtime when loaded from database

### DIFF
--- a/model/option.go
+++ b/model/option.go
@@ -581,6 +581,8 @@ func handleConfigUpdate(key, value string) bool {
 	} else if configName == "billing_setting" {
 		InvalidatePricingCache()
 		ratio_setting.InvalidateExposedDataCache()
+	} else if configName == "theme" {
+		system_setting.UpdateAndSyncTheme()
 	}
 
 	return true // 已处理


### PR DESCRIPTION
## Problem

When the theme setting (`theme.frontend`) is loaded from the database, `handleConfigUpdate` in `model/option.go` correctly updates `themeSettings.Frontend` via the config system, but never calls `syncThemeToCommon()`. This means `common.GetTheme()` always returns the hardcoded init value `"classic"`, regardless of what's stored in the database.

As a result, the web router (`router/web-router.go`) always serves the classic frontend, even when a user has explicitly set `theme.frontend=default` in the system settings.

## Fix

Add a post-processing hook for the `"theme"` config name in `handleConfigUpdate`, calling `system_setting.UpdateAndSyncTheme()` — consistent with how `performance_setting`, `tool_price_setting`, and `billing_setting` already handle their runtime sync.

## Changes

- `model/option.go`: Added `else if configName == "theme"` branch to call `system_setting.UpdateAndSyncTheme()`

This is a 2-line fix. `UpdateAndSyncTheme()` already exists and was clearly intended for this purpose but was never wired up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme configuration synchronization to ensure theme updates are properly applied across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->