### PR TITLE
fix: follow required marker styling convention

### DIFF
--- a/web/default/src/components/ui/label.tsx
+++ b/web/default/src/components/ui/label.tsx
@@ -4,8 +4,48 @@ import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
 import { cn } from '@/lib/utils'
 
+const requiredMarkerPattern = /\s\*$/
+
+function renderRequiredMarker(text: string, key?: React.Key) {
+  if (!requiredMarkerPattern.test(text)) {
+    return text
+  }
+
+  return (
+    <span key={key}>
+      {text.slice(0, -1)}
+      <span className='text-destructive'>*</span>
+    </span>
+  )
+}
+
+function renderLabelChildren(children: React.ReactNode) {
+  const childArray = React.Children.toArray(children)
+
+  if (childArray.length === 0) {
+    return children
+  }
+
+  if (
+    childArray.every(
+      (child) => typeof child === 'string' || typeof child === 'number'
+    )
+  ) {
+    return renderRequiredMarker(childArray.join(''))
+  }
+
+  return childArray.map((child, index) => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      return renderRequiredMarker(String(child), index)
+    }
+
+    return child
+  })
+}
+
 function Label({
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
@@ -16,7 +56,9 @@ function Label({
         className
       )}
       {...props}
-    />
+    >
+      {renderLabelChildren(children)}
+    </LabelPrimitive.Root>
   )
 }
 


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
完善必填项`*`的显示效果

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Close #4532 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
未修改：
<img width="478" height="610" alt="image" src="https://github.com/user-attachments/assets/35ac0c3a-4052-4ff1-ac27-77285ce8874b" />
修改后：
<img width="387" height="420" alt="image" src="https://github.com/user-attachments/assets/d71ba77a-323f-4510-a915-adccb8aa8850" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Required field indicators in labels now render a styled asterisk for improved clarity and visibility.
  * Trailing asterisks (with optional preceding space) are automatically detected and transformed without altering surrounding text.
  * Labels with mixed content (plain text plus other elements) preserve structure while still showing the required marker correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->