### PR TITLE
fix: improve tiered pricing number input editing

### DIFF
--- a/web/default/src/components/ui/label.tsx
+++ b/web/default/src/components/ui/label.tsx
@@ -4,8 +4,48 @@ import * as React from 'react'
 import * as LabelPrimitive from '@radix-ui/react-label'
 import { cn } from '@/lib/utils'
 
+const requiredMarkerPattern = /\s\*$/
+
+function renderRequiredMarker(text: string, key?: React.Key) {
+  if (!requiredMarkerPattern.test(text)) {
+    return text
+  }
+
+  return (
+    <span key={key}>
+      {text.slice(0, -1)}
+      <span className='text-destructive'>*</span>
+    </span>
+  )
+}
+
+function renderLabelChildren(children: React.ReactNode) {
+  const childArray = React.Children.toArray(children)
+
+  if (childArray.length === 0) {
+    return children
+  }
+
+  if (
+    childArray.every(
+      (child) => typeof child === 'string' || typeof child === 'number'
+    )
+  ) {
+    return renderRequiredMarker(childArray.join(''))
+  }
+
+  return childArray.map((child, index) => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      return renderRequiredMarker(String(child), index)
+    }
+
+    return child
+  })
+}
+
 function Label({
   className,
+  children,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root>) {
   return (
@@ -16,7 +56,9 @@ function Label({
         className
       )}
       {...props}
-    />
+    >
+      {renderLabelChildren(children)}
+    </LabelPrimitive.Root>
   )
 }
 

--- a/web/default/src/features/system-settings/models/tiered-pricing-editor.tsx
+++ b/web/default/src/features/system-settings/models/tiered-pricing-editor.tsx
@@ -1,4 +1,15 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+  type InputHTMLAttributes,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
 import { Copy, Plus, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -285,6 +296,93 @@ function formatTokenHint(n: number | string | null | undefined): string {
   return `= ${v.toLocaleString()} tokens`
 }
 
+function formatNumberDraft(value: number | string): string {
+  if (value === '') return ''
+  if (typeof value === 'number')
+    return Number.isFinite(value) ? String(value) : '0'
+  return value
+}
+
+function parseNumberDraft(value: string): number {
+  if (value.trim() === '') return 0
+  const next = Number(value)
+  return Number.isFinite(next) ? next : 0
+}
+
+function isZeroDraft(value: string): boolean {
+  return value.trim() !== '' && parseNumberDraft(value) === 0
+}
+
+type DraftNumberInputProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'value' | 'onChange'
+> & {
+  value: number | string
+  onValueChange: (next: number) => void
+  selectZeroOnFocus?: boolean
+}
+
+function DraftNumberInput({
+  value,
+  onValueChange,
+  selectZeroOnFocus = true,
+  onBlur,
+  onFocus,
+  onMouseUp,
+  ...props
+}: DraftNumberInputProps) {
+  const [draft, setDraft] = useState(() => formatNumberDraft(value))
+  const [focused, setFocused] = useState(false)
+
+  useEffect(() => {
+    if (!focused) {
+      setDraft(formatNumberDraft(value))
+    }
+  }, [focused, value])
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextDraft = event.target.value
+    setDraft(nextDraft)
+    onValueChange(parseNumberDraft(nextDraft))
+  }
+
+  const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+    setFocused(true)
+    onFocus?.(event)
+    if (selectZeroOnFocus && isZeroDraft(event.currentTarget.value)) {
+      event.currentTarget.select()
+    }
+  }
+
+  const handleMouseUp = (event: ReactMouseEvent<HTMLInputElement>) => {
+    onMouseUp?.(event)
+    if (selectZeroOnFocus && isZeroDraft(event.currentTarget.value)) {
+      event.preventDefault()
+      event.currentTarget.select()
+    }
+  }
+
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    const normalized = parseNumberDraft(event.currentTarget.value)
+    setFocused(false)
+    setDraft(String(normalized))
+    onValueChange(normalized)
+    onBlur?.(event)
+  }
+
+  return (
+    <Input
+      {...props}
+      type='number'
+      value={draft}
+      onChange={handleChange}
+      onFocus={handleFocus}
+      onMouseUp={handleMouseUp}
+      onBlur={handleBlur}
+    />
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Tier condition row
 // ---------------------------------------------------------------------------
@@ -332,13 +430,10 @@ function ConditionRow({ condition, onChange, onRemove }: ConditionRowProps) {
           ))}
         </SelectContent>
       </Select>
-      <Input
-        type='number'
+      <DraftNumberInput
         min={0}
-        value={condition.value === '' ? '' : Number(condition.value)}
-        onChange={(event) =>
-          onChange({ ...condition, value: event.target.value })
-        }
+        value={condition.value}
+        onValueChange={(value) => onChange({ ...condition, value })}
         placeholder='tokens'
         className='w-32'
       />
@@ -381,12 +476,11 @@ function PriceField({
     <div className='space-y-1'>
       <Label className='text-xs'>{label}</Label>
       <div className='flex items-center gap-2'>
-        <Input
-          type='number'
+        <DraftNumberInput
           min={0}
           step={0.01}
           value={Number.isFinite(value) ? value : 0}
-          onChange={(event) => onChange(Number(event.target.value) || 0)}
+          onValueChange={onChange}
           className='w-32'
         />
         {showSuffix && (
@@ -802,32 +896,29 @@ function RuleConditionRow({
       </Select>
       {timeCond.mode === MATCH_RANGE ? (
         <>
-          <Input
-            type='number'
+          <DraftNumberInput
             value={timeCond.rangeStart}
-            onChange={(event) =>
-              onChange({ ...timeCond, rangeStart: event.target.value })
+            onValueChange={(value) =>
+              onChange({ ...timeCond, rangeStart: String(value) })
             }
             placeholder='start'
             className='w-20'
           />
           <span className='text-muted-foreground text-xs'>~</span>
-          <Input
-            type='number'
+          <DraftNumberInput
             value={timeCond.rangeEnd}
-            onChange={(event) =>
-              onChange({ ...timeCond, rangeEnd: event.target.value })
+            onValueChange={(value) =>
+              onChange({ ...timeCond, rangeEnd: String(value) })
             }
             placeholder='end'
             className='w-20'
           />
         </>
       ) : (
-        <Input
-          type='number'
+        <DraftNumberInput
           value={timeCond.value}
-          onChange={(event) =>
-            onChange({ ...timeCond, value: event.target.value })
+          onValueChange={(value) =>
+            onChange({ ...timeCond, value: String(value) })
           }
           placeholder='value'
           className='w-24'
@@ -991,13 +1082,12 @@ function RuleGroupCard({
 
       <div className='flex items-center gap-2'>
         <Label className='text-xs'>{t('Multiplier')}</Label>
-        <Input
-          type='number'
+        <DraftNumberInput
           min={0}
           step={0.01}
           value={group.multiplier}
-          onChange={(event) =>
-            onChange({ ...group, multiplier: event.target.value })
+          onValueChange={(value) =>
+            onChange({ ...group, multiplier: String(value) })
           }
           className='w-32'
           placeholder='1.0'
@@ -1114,24 +1204,18 @@ function CostEstimator({ effectiveExpr }: EstimatorProps) {
       <div className='grid grid-cols-2 gap-3'>
         <div className='space-y-1'>
           <Label className='text-xs'>{t('Input tokens')} (p)</Label>
-          <Input
-            type='number'
+          <DraftNumberInput
             min={0}
             value={promptTokens}
-            onChange={(event) =>
-              setPromptTokens(Number(event.target.value) || 0)
-            }
+            onValueChange={setPromptTokens}
           />
         </div>
         <div className='space-y-1'>
           <Label className='text-xs'>{t('Output tokens')} (c)</Label>
-          <Input
-            type='number'
+          <DraftNumberInput
             min={0}
             value={completionTokens}
-            onChange={(event) =>
-              setCompletionTokens(Number(event.target.value) || 0)
-            }
+            onValueChange={setCompletionTokens}
           />
         </div>
       </div>
@@ -1151,14 +1235,13 @@ function CostEstimator({ effectiveExpr }: EstimatorProps) {
                 <Label className='text-xs'>
                   {variable.shortLabel} ({variable.key})
                 </Label>
-                <Input
-                  type='number'
+                <DraftNumberInput
                   min={0}
                   value={extras[stateKey]}
-                  onChange={(event) =>
+                  onValueChange={(value) =>
                     setExtras((prev) => ({
                       ...prev,
-                      [stateKey]: Number(event.target.value) || 0,
+                      [stateKey]: value,
                     }))
                   }
                 />


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
修复新版 `default` UI 中阶梯定价数字输入框的编辑体验问题。
此前价格字段直接把输入值转换成 number 保存，导致输入框清空时空字符串会立刻被转换回 0，所以无法删除默认的 0。同时在默认值为 0 时直接输入数字，会变成类似 0111 的追加效果。
本次改动为阶梯定价编辑器的数字输入增加编辑态处理：输入过程中保留用户正在编辑的文本，允许临时清空；当字段为 0 且获得焦点时自动选中原值，使新输入可以直接替换默认 0。最终生成表达式时仍按原有逻辑把空值归一为 0，不改变计费语义。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)

https://github.com/user-attachments/assets/9f4ee28c-f38c-4fa1-8957-e995ff6be363



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Label components now display styled asterisks to clearly mark required form fields
  * Tiered pricing editor features improved numeric input handling via new draft-based input component, ensuring consistent and reliable data entry across pricing fields, tier conditions, time values, multipliers, and token-related configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->