### PR TITLE
fix: 修复默认主题 API 密钥分组行为

### DIFF
--- a/web/default/src/features/keys/components/api-key-group-combobox.tsx
+++ b/web/default/src/features/keys/components/api-key-group-combobox.tsx
@@ -128,7 +128,12 @@ export function ApiKeyGroupCombobox({
           <ChevronsUpDown className='h-4 w-4 shrink-0 opacity-50' />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className='data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 data-[side=bottom]:slide-in-from-top-0 data-[side=left]:slide-in-from-right-0 data-[side=right]:slide-in-from-left-0 data-[side=top]:slide-in-from-bottom-0 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl p-0 shadow-lg data-[state=closed]:duration-75 data-[state=open]:duration-100'>
+      <PopoverContent
+        className='data-[state=closed]:zoom-out-100 data-[state=open]:zoom-in-100 data-[side=bottom]:slide-in-from-top-0 data-[side=left]:slide-in-from-right-0 data-[side=right]:slide-in-from-left-0 data-[side=top]:slide-in-from-bottom-0 w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl p-0 shadow-lg data-[state=closed]:duration-75 data-[state=open]:duration-100'
+        onWheel={(event) => event.stopPropagation()}
+        onTouchMove={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
         <Command shouldFilter={false}>
           <CommandInput
             placeholder={t('Search...')}

--- a/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
+++ b/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner'
 import { getUserModels, getUserGroups } from '@/lib/api'
 import { getCurrencyDisplay, getCurrencyLabel } from '@/lib/currency'
 import { cn } from '@/lib/utils'
+import { useStatus } from '@/hooks/use-status'
 import { Button } from '@/components/ui/button'
 import {
   Collapsible,
@@ -48,7 +49,7 @@ import { ERROR_MESSAGES, SUCCESS_MESSAGES } from '../constants'
 import {
   apiKeyFormSchema,
   type ApiKeyFormValues,
-  API_KEY_FORM_DEFAULT_VALUES,
+  getApiKeyFormDefaultValues,
   transformFormDataToPayload,
   transformApiKeyToFormDefaults,
 } from '../lib'
@@ -103,8 +104,10 @@ export function ApiKeysMutateDrawer({
   const { t } = useTranslation()
   const isUpdate = !!currentRow
   const { triggerRefresh } = useApiKeys()
+  const { status } = useStatus()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [advancedOpen, setAdvancedOpen] = useState(false)
+  const defaultUseAutoGroup = status?.default_use_auto_group === true
 
   // Fetch models
   const { data: modelsData } = useQuery({
@@ -142,7 +145,7 @@ export function ApiKeysMutateDrawer({
 
   const form = useForm<ApiKeyFormValues>({
     resolver: zodResolver(apiKeyFormSchema),
-    defaultValues: API_KEY_FORM_DEFAULT_VALUES,
+    defaultValues: getApiKeyFormDefaultValues(defaultUseAutoGroup),
   })
 
   // Load existing data when updating
@@ -156,9 +159,9 @@ export function ApiKeysMutateDrawer({
       })
     } else if (open && !isUpdate) {
       // For create, reset to defaults
-      form.reset(API_KEY_FORM_DEFAULT_VALUES)
+      form.reset(getApiKeyFormDefaultValues(defaultUseAutoGroup))
     }
-  }, [open, isUpdate, currentRow, form])
+  }, [open, isUpdate, currentRow, form, defaultUseAutoGroup])
 
   const onSubmit = async (data: ApiKeyFormValues) => {
     setIsSubmitting(true)

--- a/web/default/src/features/keys/constants.ts
+++ b/web/default/src/features/keys/constants.ts
@@ -56,7 +56,7 @@ export const API_KEY_STATUS_OPTIONS = Object.values(API_KEY_STATUSES).map(
 // Default Values
 // ============================================================================
 
-export const DEFAULT_GROUP = 'auto' as const
+export const DEFAULT_GROUP = '' as const
 
 // ============================================================================
 // Error Messages (i18n keys: use t(ERROR_MESSAGES.xxx) when displaying)

--- a/web/default/src/features/keys/lib/api-key-form.ts
+++ b/web/default/src/features/keys/lib/api-key-form.ts
@@ -37,6 +37,16 @@ export const API_KEY_FORM_DEFAULT_VALUES: ApiKeyFormValues = {
   tokenCount: 1,
 }
 
+export function getApiKeyFormDefaultValues(
+  defaultUseAutoGroup: boolean
+): ApiKeyFormValues {
+  return {
+    ...API_KEY_FORM_DEFAULT_VALUES,
+    group: defaultUseAutoGroup ? 'auto' : DEFAULT_GROUP,
+    cross_group_retry: defaultUseAutoGroup,
+  }
+}
+
 // ============================================================================
 // Form Data Transformation
 // ============================================================================

--- a/web/default/src/features/keys/lib/index.ts
+++ b/web/default/src/features/keys/lib/index.ts
@@ -5,6 +5,7 @@ export {
   apiKeyFormSchema,
   type ApiKeyFormValues,
   API_KEY_FORM_DEFAULT_VALUES,
+  getApiKeyFormDefaultValues,
   transformFormDataToPayload,
   transformApiKeyToFormDefaults,
 } from './api-key-form'


### PR DESCRIPTION
## 修复内容

- 修复 default 主题创建 API 密钥时忽略 `default_use_auto_group`，总是默认选择 `auto` 分组的问题。
- 修复 default 主题 API 密钥创建/编辑抽屉中分组下拉列表滚动事件被外层 Sheet 滚动容器抢占的问题。

## 行为说明

- `default_use_auto_group=false` 时，新建 API 密钥默认分组为空，表示使用用户默认分组。
- `default_use_auto_group=true` 时，新建 API 密钥默认选择 `auto`。
- 编辑已有 API 密钥时继续保留已有分组值。
- `auto` 仍可作为可用分组被用户手动选择。

## 验证

- `cd web/default && bun run typecheck`
- `cd web/default && bun run build`

## 签名

- Commit 已使用 GPG 签名，并包含 Signed-off-by。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Form initialization now dynamically adapts to system configuration for consistent default behavior
  * Enhanced event handling in UI components for improved interaction stability and responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->