### PR TITLE
bug fix: 新版前端email绑定错误

### DIFF
--- a/web/default/src/features/auth/api.ts
+++ b/web/default/src/features/auth/api.ts
@@ -109,8 +109,9 @@ export async function bindEmail(
   email: string,
   code: string
 ): Promise<ApiResponse> {
-  const res = await api.get('/api/oauth/email/bind', {
-    params: { email, code },
+  const res = await api.post('/api/oauth/email/bind', {
+    email,
+    code,
   })
   return res.data
 }

--- a/web/default/src/features/profile/api.ts
+++ b/web/default/src/features/profile/api.ts
@@ -85,7 +85,10 @@ export async function bindEmail(
   email: string,
   code: string
 ): Promise<ApiResponse> {
-  const res = await api.get(`/api/oauth/email/bind?email=${email}&code=${code}`)
+  const res = await api.post('/api/oauth/email/bind', {
+    email,
+    code,
+  })
   return res.data
 }
 


### PR DESCRIPTION

## 📝 变更描述 / Description

修复默认前端绑定邮箱时请求方法与后端接口不一致的问题。

后端 `/api/oauth/email/bind` 路由只注册了 `POST`，并且 `EmailBind` 会从 JSON request body 中读取 `email` 和 `code`。但 default 前端此前使用 `GET` 请求，并把参数放在 query 中，导致请求无法命中后端路由，返回 `Invalid URL (GET /api/oauth/email/bind)`。

本次将 default 前端中两处绑定邮箱调用统一改为 `POST /api/oauth/email/bind`，并通过 JSON body 传递：

```json
{
  "email": "...",
  "code": "..."
}
```

这样与后端路由和参数解析逻辑保持一致。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #4549

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
```
{"message":"","success":true}
```
<img width="810" height="178" alt="CleanShot 2026-04-30 at 10 03 40@2x" src="https://github.com/user-attachments/assets/e8ff09ac-7fcb-41bc-b109-f12ce8999d99" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated email binding operations to improve data handling in authentication workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->