### PR TITLE
fix(relay): restore Claude file and stream status handling

### DIFF
--- a/relay/channel/claude/relay-claude.go
+++ b/relay/channel/claude/relay-claude.go
@@ -1,11 +1,15 @@
 package claude
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
+	"path/filepath"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
@@ -376,6 +380,14 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 								Text: common.GetPointer[string](mediaMessage.Text),
 							})
 						}
+					case dto.ContentTypeFile:
+						claudeFileMessage, err := buildClaudeFileMessage(c, mediaMessage.GetFile())
+						if err != nil {
+							return nil, err
+						}
+						if claudeFileMessage != nil {
+							claudeMediaMessages = append(claudeMediaMessages, *claudeFileMessage)
+						}
 					default:
 						source := mediaMessage.ToFileSource()
 						if source == nil {
@@ -432,6 +444,74 @@ func RequestOpenAI2ClaudeMessage(c *gin.Context, textRequest dto.GeneralOpenAIRe
 	claudeRequest.Prompt = ""
 	claudeRequest.Messages = claudeMessages
 	return &claudeRequest, nil
+}
+
+func buildClaudeFileMessage(c *gin.Context, file *dto.MessageFile) (*dto.ClaudeMediaMessage, error) {
+	if file == nil || file.FileData == "" {
+		return nil, nil
+	}
+
+	mimeType := mimeTypeFromFileName(file.FileName)
+	source := types.NewFileSourceFromData(file.FileData, mimeType)
+	base64Data, resolvedMimeType, err := service.GetBase64Data(c, source, "formatting file for Claude")
+	if err != nil {
+		return nil, fmt.Errorf("get file data failed: %s", err.Error())
+	}
+	resolvedMimeType = normalizeMimeType(resolvedMimeType)
+	if resolvedMimeType == "" {
+		resolvedMimeType = normalizeMimeType(mimeType)
+	}
+
+	switch {
+	case strings.HasPrefix(resolvedMimeType, "application/pdf"):
+		return &dto.ClaudeMediaMessage{
+			Type: "document",
+			Source: &dto.ClaudeMessageSource{
+				Type:      "base64",
+				MediaType: "application/pdf",
+				Data:      base64Data,
+			},
+		}, nil
+	case strings.HasPrefix(resolvedMimeType, "image/"):
+		return &dto.ClaudeMediaMessage{
+			Type: "image",
+			Source: &dto.ClaudeMessageSource{
+				Type:      "base64",
+				MediaType: resolvedMimeType,
+				Data:      base64Data,
+			},
+		}, nil
+	case strings.HasPrefix(resolvedMimeType, "text/"):
+		decoded, err := base64.StdEncoding.DecodeString(base64Data)
+		if err != nil || !utf8.Valid(decoded) {
+			return nil, nil
+		}
+		text := string(decoded)
+		if text == "" {
+			return nil, nil
+		}
+		return &dto.ClaudeMediaMessage{
+			Type: "text",
+			Text: common.GetPointer[string](text),
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func mimeTypeFromFileName(fileName string) string {
+	ext := strings.ToLower(filepath.Ext(fileName))
+	if ext == "" {
+		return ""
+	}
+	return normalizeMimeType(mime.TypeByExtension(ext))
+}
+
+func normalizeMimeType(mimeType string) string {
+	if idx := strings.Index(mimeType, ";"); idx >= 0 {
+		mimeType = mimeType[:idx]
+	}
+	return strings.ToLower(strings.TrimSpace(mimeType))
 }
 
 func StreamResponseClaude2OpenAI(claudeResponse *dto.ClaudeResponse) *dto.ChatCompletionsStreamResponse {

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -40,8 +40,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		return
 	}
 
-	// 无条件新建 StreamStatus
-	info.StreamStatus = relaycommon.NewStreamStatus()
+	if info.StreamStatus == nil {
+		info.StreamStatus = relaycommon.NewStreamStatus()
+	}
 
 	// 确保响应体总是被关闭
 	defer func() {


### PR DESCRIPTION
## Background

While establishing the local backend baseline, `go test ./...` exposed two regressions in existing tests after the frontend `dist` directories were built for Go embed.

## Problem

The current relay behavior does not match the existing test expectations in two areas:

- OpenAI `file` content converted for Claude is treated through the generic media path, so PDFs and text files can be misclassified as images, while unsupported files are not skipped.
- `StreamScannerHandler` always replaces `RelayInfo.StreamStatus`, which drops any status data that was initialized by the caller before stream handling starts.

- Issue:
- Discussion:
- Related PR:

## Root Cause

The file-source refactor unified media loading but removed the explicit Claude file-content handling path. As a result, filename-derived MIME information was no longer used to distinguish PDFs, text files, images, and unsupported file payloads.

For stream handling, `StreamScannerHandler` unconditionally assigned a new `StreamStatus` instead of only initializing it when the caller had not already provided one.

## Changes

- Restore explicit Claude handling for OpenAI `file` content.
- Convert PDF files to Claude `document` blocks.
- Convert UTF-8 text files to Claude `text` blocks.
- Preserve image file support and skip unsupported file types.
- Preserve preinitialized `RelayInfo.StreamStatus` and only create a new status when it is nil.

## Impact

Affected:

- OpenAI-compatible requests that include `file` content and are relayed to Claude.
- Stream scanner callers that prepopulate `RelayInfo.StreamStatus`.

Not affected:

- Existing text and image URL conversion paths.
- Existing stream status initialization when no status is provided.
- Database schema, billing, authentication, and frontend behavior.

## Testing

- `go test ./relay/channel/claude`
- `go test ./relay/helper`
- `go test ./...`

## Notes

The change is intentionally narrow and keeps the existing test cases as the regression coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for file attachments in messages to Claude, including PDFs, images, and text files.

* **Bug Fixes**
  * Fixed stream status handling to preserve existing status information instead of overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->