### PR TITLE
fix(wallet): read topup gateway flags from topupInfo instead of status

### DIFF
--- a/web/default/src/features/wallet/components/subscription-plans-card.tsx
+++ b/web/default/src/features/wallet/components/subscription-plans-card.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { formatQuota } from '@/lib/format'
 import { cn } from '@/lib/utils'
-import { useStatus } from '@/hooks/use-status'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -61,7 +60,6 @@ export function SubscriptionPlansCard({
   onAvailabilityChange,
 }: SubscriptionPlansCardProps) {
   const { t } = useTranslation()
-  const { status } = useStatus()
 
   const [plans, setPlans] = useState<PlanRecord[]>([])
   const [activeSubscriptions, setActiveSubscriptions] = useState<
@@ -78,9 +76,9 @@ export function SubscriptionPlansCard({
   const [purchaseOpen, setPurchaseOpen] = useState(false)
   const [selectedPlan, setSelectedPlan] = useState<PlanRecord | null>(null)
 
-  const enableStripe = !!status?.enable_stripe_topup
+  const enableStripe = !!topupInfo?.enable_stripe_topup
   const enableCreem = !!topupInfo?.enable_creem_topup
-  const enableOnlineTopUp = !!status?.enable_online_topup
+  const enableOnlineTopUp = !!topupInfo?.enable_online_topup
   const epayMethods = useMemo(
     () => getEpayMethods(topupInfo?.pay_methods),
     [topupInfo?.pay_methods]


### PR DESCRIPTION
## 📝 变更描述 / Description

修复新前端（default frontend）订阅卡片中支付网关判断错误的 bug。

**问题表现**

管理员已正确配置在线支付（如易支付 EPay）后，余额充值正常工作，但点击订阅套餐"立即订阅"时，购买弹窗仍提示：

> 管理员未开启在线支付功能，请联系管理员配置。

经典前端（`web/classic`）和同一页面的余额充值卡片均不受影响，仅新前端的订阅卡片有此问题。

**根因**

`web/default/src/features/wallet/components/subscription-plans-card.tsx` 中 `enableStripe` 与 `enableOnlineTopUp` 错误地从 `status?.`（`/api/status` 接口）读取，但这两个开关 **仅存在于 `/api/user/topup/info`**（即组件已通过 props 传入的 `topupInfo`）；`/api/status` 根本不暴露这两个字段。

```tsx
// before
const enableStripe      = !!status?.enable_stripe_topup    // 永远 undefined
const enableCreem       = !!topupInfo?.enable_creem_topup  // 已正确
const enableOnlineTopUp = !!status?.enable_online_topup    // 永远 undefined
```

因此 `hasStripe` 与 `hasEpay` 永远为 `false`，购买弹窗判定 `hasAnyPayment === false`，展示"未开启"横幅，唯独 Creem（已正确从 `topupInfo` 读取）能用。

**修复**

将这两行的来源从 `status?.` 改为 `topupInfo?.`，与同文件内 `enableCreem`、同页面的 `recharge-form-card.tsx`（`topupInfo?.enable_online_topup || topupInfo?.enable_stripe_topup`）以及经典前端 `web/classic` 的 `SubscriptionPlansCard` / `SubscriptionPurchaseModal` 行为完全一致。同时移除随之不再使用的 `useStatus` 导入。

```diff
- const enableStripe      = !!status?.enable_stripe_topup
+ const enableStripe      = !!topupInfo?.enable_stripe_topup
  const enableCreem       = !!topupInfo?.enable_creem_topup
- const enableOnlineTopUp = !!status?.enable_online_topup
+ const enableOnlineTopUp = !!topupInfo?.enable_online_topup
```

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix)
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

无

## ✅ 提交前检查项 / Checklist

- [x] **人工确认**: 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **变更理解**: 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦**: 本 PR 未包含任何与当前任务无关的代码改动（仅 1 个文件 +2/-4）。
- [x] **本地验证**: 已基于 `v1.0.0-rc.2` 在生产环境构建镜像并部署，复现 bug → 应用修复 → 订阅购买弹窗的易支付选择框与"支付"按钮正常出现，已验证通过。
- [x] **安全合规**: 代码中无敏感凭据，符合项目代码规范，无类型与 lint 问题引入。

## 📸 运行证明 / Proof of Work

**复现步骤**

1. 在管理员后台仅启用易支付（EPay），不启用 Stripe / Creem。
2. 创建任一订阅套餐（无需配置 `stripe_price_id` / `creem_product_id`）。
3. 用普通用户登录 → 钱包页 → 订阅 Tab → 点击"立即订阅"。
4. **修复前**：弹窗显示"管理员未开启在线支付功能，请联系管理员配置"。
5. **修复后**：弹窗正常显示"选择支付方式"下拉框 + "支付"按钮，可发起易支付。

**对照参考（证明修复方向正确）**

- 同一页面 `web/default/src/features/wallet/components/recharge-form-card.tsx:113-117` 已正确从 `topupInfo` 读取相同两个字段。
- 经典前端 `web/classic/src/components/topup/index.jsx:636-637` 同样从 `data.enable_*_topup`（即 topup-info 接口）读取。
- 后端 `controller/user/topup.go` 的 `GetUserTopUpInfo` 返回 `enable_online_topup` / `enable_stripe_topup` / `enable_creem_topup`；`/api/status` 接口不暴露这些字段。

**Diff 大小**

仅一个文件，+2/-4 行：`web/default/src/features/wallet/components/subscription-plans-card.tsx`。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the subscription plans component to streamline how feature availability flags are determined, with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->