### PR TITLE
fix(web): keep dashboard model chart type stable

### DIFF
--- a/web/default/src/features/dashboard/lib/charts.ts
+++ b/web/default/src/features/dashboard/lib/charts.ts
@@ -20,6 +20,10 @@ type TooltipLineItem = {
   shapeSize?: number
 }
 
+const DISABLE_POINT_UPDATE_ANIMATION = {
+  animationUpdate: false,
+} as const
+
 function getVChartDefaultColors(domainLength: number) {
   const scheme =
     vchartDefaultDataScheme.find(
@@ -159,14 +163,17 @@ export function processChartData(
         yField: 'Usage',
         seriesField: 'Model',
         stack: true,
+        ...DISABLE_POINT_UPDATE_ANIMATION,
         legends: { visible: true, selectMode: 'single' },
       },
       spec_model_line: {
-        type: 'line',
+        type: 'area',
         data: [{ id: 'lineData', values: [] }],
         xField: 'Time',
         yField: 'Count',
         seriesField: 'Model',
+        stack: false,
+        ...DISABLE_POINT_UPDATE_ANIMATION,
         legends: { visible: true, selectMode: 'single' },
         title: {
           visible: true,
@@ -510,6 +517,7 @@ export function processChartData(
       yField: 'Usage',
       seriesField: 'Model',
       stack: false,
+      ...DISABLE_POINT_UPDATE_ANIMATION,
       legends: { visible: true, selectMode: 'single' },
       color: modelColor,
       tooltip: {
@@ -558,6 +566,7 @@ export function processChartData(
       yField: 'Count',
       seriesField: 'Model',
       stack: false,
+      ...DISABLE_POINT_UPDATE_ANIMATION,
       legends: { visible: true, selectMode: 'single' },
       color: modelColor,
       title: {
@@ -713,6 +722,7 @@ export function processUserChartData(
       xField: 'Time',
       yField: 'rawQuota',
       seriesField: 'User',
+      ...DISABLE_POINT_UPDATE_ANIMATION,
       title: {
         visible: true,
         text: tt('User Consumption Trend'),
@@ -853,6 +863,7 @@ export function processUserChartData(
       yField: 'rawQuota',
       seriesField: 'User',
       stack: false,
+      ...DISABLE_POINT_UPDATE_ANIMATION,
       title: {
         visible: true,
         text: tt('User Consumption Trend'),

--- a/web/default/tests/dashboard-charts.test.ts
+++ b/web/default/tests/dashboard-charts.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  processChartData,
+  processUserChartData,
+} from '../src/features/dashboard/lib/charts'
+import type { QuotaDataItem } from '../src/features/dashboard/types'
+
+const sampleModelUsage: QuotaDataItem[] = [
+  {
+    created_at: 1_735_689_600,
+    model_name: 'gpt-4o-mini',
+    count: 3,
+    quota: 1200,
+    token_used: 800,
+  },
+]
+
+describe('processChartData', () => {
+  test('keeps the model trend chart type stable across loading and populated states', () => {
+    const emptySpec = processChartData([], 'day').spec_model_line
+    const populatedSpec = processChartData(sampleModelUsage, 'day').spec_model_line
+
+    expect(emptySpec.type).toBe(populatedSpec.type)
+  })
+
+  test('disables point update animation for dashboard area charts', () => {
+    const chartData = processChartData(sampleModelUsage, 'hour')
+    const emptyChartData = processChartData([], 'hour')
+    const userChartData = processUserChartData(sampleModelUsage, 'hour')
+    const emptyUserChartData = processUserChartData([], 'hour')
+
+    expect(chartData.spec_area.animationUpdate).toBe(false)
+    expect(chartData.spec_model_line.animationUpdate).toBe(false)
+    expect(emptyChartData.spec_area.animationUpdate).toBe(false)
+    expect(emptyChartData.spec_model_line.animationUpdate).toBe(false)
+    expect(userChartData.spec_user_trend.animationUpdate).toBe(false)
+    expect(emptyUserChartData.spec_user_trend.animationUpdate).toBe(false)
+  })
+})


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description

修复了 `/dashboard/models` 页面在设置筛选条件并点击 应用筛选器 后崩溃的问题。根本原因是 VChart 的 spec 在空数据加载态与填充态之间发生了图表类型切换（从 `line` 变为 `area`），导致已复用的 VChart 实例在更新不兼容的序列类型时抛出 `TypeError: can't access property "y", i is undefined`，并重定向至 500 页面。

本次修复：
- 将空/加载状态的 `spec_model_line` 图表类型改为 `area`，并设置 `stack: false`，使其与填充数据的模型趋势图表 spec 类型保持一致。
- 新增回归测试，确保空状态与填充状态的模型趋势 spec 始终使用相同的图表类型，避免将来再次出现类似类型突变。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [ ] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes #4618 

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Call Trend" chart to render as an area chart when data is empty and disabled point-update animations for smoother visuals across dashboard charts.

* **Tests**
  * Added tests to verify chart type and animation behavior remain consistent across empty and populated data states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->