### PR TITLE
feat(channel): add dual endpoint support for ali and minimax token plans

### DIFF
--- a/constant/channel.go
+++ b/constant/channel.go
@@ -206,4 +206,12 @@ var ChannelSpecialBases = map[string]ChannelSpecialBase{
 		ClaudeBaseURL: "https://ark.cn-beijing.volces.com/api/coding",
 		OpenAIBaseURL: "https://ark.cn-beijing.volces.com/api/coding/v3",
 	},
+	"ali-token-plan": {
+		ClaudeBaseURL: "https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic",
+		OpenAIBaseURL: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+	},
+	"minimax-token-plan": {
+		ClaudeBaseURL: "https://api.minimaxi.com/anthropic",
+		OpenAIBaseURL: "https://api.minimaxi.com/v1",
+	},
 }

--- a/relay/channel/ali/adaptor.go
+++ b/relay/channel/ali/adaptor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
+	channelconstant "github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/relay/channel"
 	"github.com/QuantumNous/new-api/relay/channel/claude"
@@ -90,6 +91,17 @@ func (a *Adaptor) Init(info *relaycommon.RelayInfo) {
 
 func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	var fullRequestURL string
+
+	baseURL := info.ChannelBaseUrl
+	if specialPlan, ok := channelconstant.ChannelSpecialBases[baseURL]; ok {
+		switch info.RelayFormat {
+		case types.RelayFormatClaude:
+			return fmt.Sprintf("%s/v1/messages", specialPlan.ClaudeBaseURL), nil
+		default:
+			return fmt.Sprintf("%s/chat/completions", specialPlan.OpenAIBaseURL), nil
+		}
+	}
+
 	switch info.RelayFormat {
 	case types.RelayFormatClaude:
 		if supportsAliAnthropicMessages(info.UpstreamModelName) {

--- a/relay/channel/minimax/relay-minimax.go
+++ b/relay/channel/minimax/relay-minimax.go
@@ -14,9 +14,19 @@ func GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
 	if baseUrl == "" {
 		baseUrl = channelconstant.ChannelBaseURLs[channelconstant.ChannelTypeMiniMax]
 	}
+
+	if specialPlan, ok := channelconstant.ChannelSpecialBases[baseUrl]; ok {
+		switch info.RelayFormat {
+		case types.RelayFormatClaude:
+			return fmt.Sprintf("%s/v1/messages", specialPlan.ClaudeBaseURL), nil
+		default:
+			return fmt.Sprintf("%s/chat/completions", specialPlan.OpenAIBaseURL), nil
+		}
+	}
+
 	switch info.RelayFormat {
 	case types.RelayFormatClaude:
-		return fmt.Sprintf("%s/anthropic/v1/messages", info.ChannelBaseUrl), nil
+		return fmt.Sprintf("%s/anthropic/v1/messages", baseUrl), nil
 	default:
 		switch info.RelayMode {
 		case constant.RelayModeChatCompletions:


### PR DESCRIPTION
Add ali-token-plan and minimax-token-plan to ChannelSpecialBases, enabling direct routing to provider-specific endpoints based on RelayFormat
(Claude vs OpenAI) without format conversion.

# ⚠️ 提交说明 / PR Notice

## 📝 变更描述 / Description
为 `ChannelTypeAli` 和 `ChannelTypeMiniMax` 新增双端点支持。当渠道的 `base_url` 设置为特定标识字符串时（如
`ali-token-plan`、`minimax-token-plan`），系统可根据请求的 `RelayFormat`（Claude 格式 vs OpenAI 格式）自动路由到对应的 provider
原生端点，无需进行请求格式转换。

实现方式：
- 在 `ChannelSpecialBases` 映射中新增 `ali-token-plan` 和 `minimax-token-plan` 条目
- 在 Ali 和 MiniMax 的 `GetRequestURL()` 方法中优先检查 `ChannelSpecialBases`，匹配时按格式路由到对应端点

路由规则：
- `ali-token-plan`: Claude 格式 → `https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic/v1/messages`；其他格式 →
`https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions`
- `minimax-token-plan`: Claude 格式 → `https://api.minimaxi.com/anthropic/v1/messages`；其他格式 → `https://api.minimaxi.com/v1/chat/completions`

## 🚀 变更类型 / Type of change
- [x] ✨ 新功能 (New feature)

## 🔗 关联任务 / Related Issue
  - 关联 PR: [#4571](https://github.com/QuantumNous/new-api/pull/4571) (扩展阿里云订阅计划支持) — 已添加 `ali-token-plan`，本次补充
  `minimax-token-plan`
  - 关联 PR: [#2960](https://github.com/QuantumNous/new-api/pull/2960) (minimax native /v1/messages)

## ✅ 提交前检查项 / Checklist
  - [x] **人工确认:** 已亲自整理并撰写此描述
  - [x] **非重复提交:** 已检索 Issues 和 PRs（#4571、#2960），确认本次为 Ali + MiniMax 双端点支持的补充完善
  - [ ] **Bug fix 说明:** 不适用
  - [x] **变更理解:** 已理解双端点路由逻辑及影响范围
  - [x] **范围聚焦:** 仅涉及 Ali 和 MiniMax 两个 channel adaptor
  - [x] **本地验证:** `go build` 编译通过，`gopls check` 无错误

## 📸 运行证明 / Proof of Work
$ go build ./relay/channel/minimax/... ./relay/channel/ali/... ./constant/...
✅ Build passed

$ gopls check relay/channel/minimax/relay-minimax.go relay/channel/ali/adaptor.go constant/channel.go
✅ gopls check passed1

$ go vet ./relay/channel/minimax/... ./relay/channel/ali/... ./constant/...
✅ go vet passed

$ go test ./relay/channel/minimax/... -v
=== RUN   TestGetRequestURLForImageGeneration
--- PASS: TestGetRequestURLForImageGeneration (0.00s)
=== RUN   TestConvertImageRequest
--- PASS: TestConvertImageRequest (0.00s)
=== RUN   TestDoResponseForImageGeneration
--- PASS: TestDoResponseForImageGeneration (0.00s)
PASS
ok    github.com/QuantumNous/new-api/relay/channel/minimax    0.008s

## 📚 参考文档 / Reference Documentation

  MiniMax 文档：
  - [MiniMax 开放平台 - 文本编码工具](https://platform.minimaxi.com/docs/guides/text-ai-coding-tools)
    - Claude 兼容接口（Anthropic 协议）：https://api.minimaxi.com/anthropic
    - OpenAI 兼容接口：https://api.minimaxi.com/v1

  阿里云百炼文档：
  - [百炼平台 API 文档](https://bailian.console.aliyun.com/cn-beijing/?spm=a2ty02.43680508.d_my-plan.10.28fd74a1u5sKyf&tab=doc#/doc/?type=model&url=3029264)
    - Anthropic 兼容接口：https://token-plan.cn-beijing.maas.aliyuncs.com/apps/anthropic
    - OpenAI 兼容接口：https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ali token plan and Minimax token plan channels
  * Implemented specialized request routing for token plan configurations to optimize URL handling across different relay formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->