### PR TITLE
fix(web/default): guard playground messages against legacy classic shape

### DIFF
--- a/web/default/src/features/playground/lib/storage.ts
+++ b/web/default/src/features/playground/lib/storage.ts
@@ -70,8 +70,12 @@ export function loadMessages(): Message[] | null {
   try {
     const saved = localStorage.getItem(STORAGE_KEYS.MESSAGES)
     if (saved) {
-      const parsed: Message[] = JSON.parse(saved)
-      const sanitized = sanitizeMessagesOnLoad(parsed)
+      const parsed: unknown = JSON.parse(saved)
+      if (!Array.isArray(parsed)) {
+        localStorage.removeItem(STORAGE_KEYS.MESSAGES)
+        return null
+      }
+      const sanitized = sanitizeMessagesOnLoad(parsed as Message[])
       // Persist sanitized result to avoid re-sanitizing on subsequent loads
       if (sanitized !== parsed) {
         saveMessages(sanitized)


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
修复新版UI, playground 获取playground_messages时
由于浏览器localstorage与旧版 结构不一致 导致报错问题

## 📸 运行证明 / Proof of Work
修复前: 
<img width="1420" height="1050" alt="image" src="https://github.com/user-attachments/assets/3f196fac-bcc5-48fc-843c-34801a4b91b6" />
<img width="1036" height="328" alt="image" src="https://github.com/user-attachments/assets/403634a8-f187-4121-a974-f8cba0b14b5f" />


修复后:
<img width="2162" height="1284" alt="image" src="https://github.com/user-attachments/assets/e10f9bc5-a7ca-4da4-a6cb-26e53ec77b23" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of stored messages by adding enhanced validation and data integrity checks to prevent crashes or errors from corrupted data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->