### PR TITLE
fix: remove codex cli trace affinity rule causing permanent channel lock

### DIFF
--- a/setting/operation_setting/channel_affinity_setting.go
+++ b/setting/operation_setting/channel_affinity_setting.go
@@ -79,21 +79,21 @@ var channelAffinitySetting = ChannelAffinitySetting{
 	MaxEntries:        100_000,
 	DefaultTTLSeconds: 3600,
 	Rules: []ChannelAffinityRule{
-		{
-			Name:       "codex cli trace",
-			ModelRegex: []string{"^gpt-.*$"},
-			PathRegex:  []string{"/v1/responses"},
-			KeySources: []ChannelAffinityKeySource{
-				{Type: "gjson", Path: "prompt_cache_key"},
-			},
-			ValueRegex:            "",
-			TTLSeconds:            0,
-			ParamOverrideTemplate: buildPassHeaderTemplate(codexCliPassThroughHeaders),
-			SkipRetryOnFailure:    true,
-			IncludeUsingGroup:     true,
-			IncludeRuleName:       true,
-			UserAgentInclude:      nil,
-		},
+		// [DEBUG] codex cli trace rule removed - prompt_cache_key caused permanent channel lock
+		// {
+		// 	Name:       "codex cli trace",
+		// 	ModelRegex: []string{"^gpt-.*$"},
+		// 	PathRegex:  []string{"/v1/responses"},
+		// 	KeySources: []ChannelAffinityKeySource{
+		// 		{Type: "gjson", Path: "prompt_cache_key"},
+		// 	},
+		// 	ValueRegex:            "",
+		// 	TTLSeconds:            0,
+		// 	ParamOverrideTemplate: buildPassHeaderTemplate(codexCliPassThroughHeaders),
+		// 	SkipRetryOnFailure:    true,
+		// 	IncludeUsingGroup:     true,
+		// 	IncludeRuleName:       true,
+		// },
 		{
 			Name:       "claude cli trace",
 			ModelRegex: []string{"^claude-.*$"},


### PR DESCRIPTION
## Summary
- Remove the 'codex cli trace' rule that used prompt_cache_key as affinity key
- This rule locked users to a single channel for 1 hour (TTL=3600)
- When the locked channel failed, SkipRetryOnFailure=true prevented retry
- Now users will be randomly assigned across available channels

## Testing
- [ ] Service restarts without error
- [ ] Channel affinity cache cleared (container restart)
- [ ] Users can use any available channel randomly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted channel affinity rule configuration with updated debug annotations and notes for improved troubleshooting support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->