### PR TITLE
feat: add DeepChat deeplink support

### DIFF
--- a/setting/chat.go
+++ b/setting/chat.go
@@ -23,6 +23,9 @@ var Chats = []map[string]string{
 		"CC Switch": "ccswitch",
 	},
 	{
+		"DeepChat": "deepchat://provider/install?v=1&data={deepchatConfig}",
+	},
+	{
 		"Lobe Chat 官方示例": "https://chat-preview.lobehub.com/?settings={\"keyVaults\":{\"openai\":{\"apiKey\":\"{key}\",\"baseURL\":\"{address}/v1\"}}}",
 	},
 	{

--- a/web/classic/src/components/layout/SiderBar.jsx
+++ b/web/classic/src/components/layout/SiderBar.jsx
@@ -251,7 +251,11 @@ const SiderBar = ({ onNavigate = () => {} }) => {
             for (let key in chats[i]) {
               let link = chats[i][key];
               if (typeof link !== 'string') continue; // 确保链接是字符串
-              if (link.startsWith('fluent') || link.startsWith('ccswitch')) {
+              if (
+                link.startsWith('fluent') ||
+                link.startsWith('ccswitch') ||
+                link.startsWith('deepchat')
+              ) {
                 shouldSkip = true;
                 break;
               }

--- a/web/classic/src/hooks/tokens/useTokensData.jsx
+++ b/web/classic/src/hooks/tokens/useTokensData.jsx
@@ -251,6 +251,16 @@ export const useTokensData = (openFluentNotification, openCCSwitchModal) => {
         encodeToBase64(JSON.stringify(aionuiConfig)),
       );
       url = url.replaceAll('{aionuiConfig}', encodedConfig);
+    } else if (url.includes('{deepchatConfig}') === true) {
+      let deepchatConfig = {
+        id: 'new-api',
+        baseUrl: serverAddress,
+        apiKey: `sk-${fullKey}`,
+      };
+      let encodedConfig = encodeURIComponent(
+        encodeToBase64(JSON.stringify(deepchatConfig)),
+      );
+      url = url.replaceAll('{deepchatConfig}', encodedConfig);
     } else {
       let encodedServerAddress = encodeURIComponent(serverAddress);
       url = url.replaceAll('{address}', encodedServerAddress);

--- a/web/classic/src/pages/Setting/Chat/SettingsChats.jsx
+++ b/web/classic/src/pages/Setting/Chat/SettingsChats.jsx
@@ -71,6 +71,7 @@ export default function SettingsChats(props) {
     { name: 'AionUI', url: 'aionui://provider/add?v=1&data={aionuiConfig}' },
     { name: '流畅阅读', url: 'fluentread' },
     { name: 'CC Switch', url: 'ccswitch' },
+    { name: 'DeepChat', url: 'deepchat://provider/install?v=1&data={deepchatConfig}' },
     { name: 'Lobe Chat', url: 'https://chat-preview.lobehub.com/?settings={"keyVaults":{"openai":{"apiKey":"{key}","baseURL":"{address}/v1"}}}' },
     { name: 'AI as Workspace', url: 'https://aiaw.app/set-provider?provider={"type":"openai","settings":{"apiKey":"{key}","baseURL":"{address}/v1","compatibility":"strict"}}' },
     { name: 'AMA 问天', url: 'ama://set-api-key?server={address}&key={key}' },

--- a/web/default/src/components/layout/components/chat-presets-item.tsx
+++ b/web/default/src/components/layout/components/chat-presets-item.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useRef, useState } from 'react'
 import { Link, useLocation } from '@tanstack/react-router'
 import { ExternalLink, Loader2, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -12,7 +12,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import {
@@ -23,18 +22,15 @@ import {
   SidebarMenuSubItem,
   useSidebar,
 } from '@/components/ui/sidebar'
-import { useActiveChatKey } from '@/features/chat/hooks/use-active-chat-key'
+import { fetchActiveChatKey } from '@/features/chat/hooks/use-active-chat-key'
 import { useChatPresets } from '@/features/chat/hooks/use-chat-presets'
-import { resolveChatUrl, type ChatPreset } from '@/features/chat/lib/chat-links'
+import {
+  chatLinkRequiresApiKey,
+  resolveChatUrl,
+  type ChatPreset,
+} from '@/features/chat/lib/chat-links'
 import { normalizeHref } from '../lib/url-utils'
 import type { NavChatPresets } from '../types'
-
-/**
- * Check if a preset requires an API key
- */
-function requiresApiKey(preset: ChatPreset): boolean {
-  return preset.url.includes('{key}') || preset.url.includes('{cherryConfig}')
-}
 
 /**
  * Sub-menu item for a single chat preset
@@ -42,12 +38,14 @@ function requiresApiKey(preset: ChatPreset): boolean {
 function ChatMenuItem({
   preset,
   active,
+  loading,
   onOpen,
   onNavigate,
 }: {
   preset: ChatPreset
   active: boolean
-  onOpen: (preset: ChatPreset) => void
+  loading: boolean
+  onOpen: (preset: ChatPreset) => void | Promise<void>
   onNavigate: () => void
 }) {
   if (preset.type === 'web') {
@@ -72,12 +70,19 @@ function ChatMenuItem({
   return (
     <SidebarMenuSubItem>
       <SidebarMenuSubButton
-        onClick={() => onOpen(preset)}
+        onClick={() => {
+          if (!loading) void onOpen(preset)
+        }}
+        aria-disabled={loading ? 'true' : undefined}
         isActive={false}
         className='justify-between'
       >
         <span>{preset.name}</span>
-        <ExternalLink className='h-4 w-4' />
+        {loading ? (
+          <Loader2 className='h-4 w-4 animate-spin' />
+        ) : (
+          <ExternalLink className='h-4 w-4' />
+        )}
       </SidebarMenuSubButton>
     </SidebarMenuSubItem>
   )
@@ -88,10 +93,12 @@ function ChatMenuItem({
  */
 function DropdownPresetItem({
   preset,
+  loading,
   onOpen,
 }: {
   preset: ChatPreset
-  onOpen: (preset: ChatPreset) => void
+  loading: boolean
+  onOpen: (preset: ChatPreset) => void | Promise<void>
 }) {
   if (preset.type === 'web') {
     return (
@@ -104,9 +111,18 @@ function DropdownPresetItem({
   }
 
   return (
-    <DropdownMenuItem onClick={() => onOpen(preset)}>
+    <DropdownMenuItem
+      disabled={loading}
+      onClick={() => {
+        if (!loading) void onOpen(preset)
+      }}
+    >
       {preset.name}
-      <ExternalLink className='ml-auto h-4 w-4 opacity-70' />
+      {loading ? (
+        <Loader2 className='ml-auto h-4 w-4 animate-spin opacity-70' />
+      ) : (
+        <ExternalLink className='ml-auto h-4 w-4 opacity-70' />
+      )}
     </DropdownMenuItem>
   )
 }
@@ -119,44 +135,44 @@ export function ChatPresetsItem({ item }: { item: NavChatPresets }) {
   const { chatPresets, serverAddress } = useChatPresets()
   const { state, isMobile, setOpenMobile } = useSidebar()
   const href = useLocation({ select: (location) => location.href })
-  const loadingMessage = t('Preparing chat keys…')
+  const [loadingPresetId, setLoadingPresetId] = useState<string | null>(null)
+  const loadingPresetIdRef = useRef<string | null>(null)
 
   const visiblePresets = useMemo(
     () => chatPresets.filter((preset) => preset.type !== 'fluent'),
     [chatPresets]
   )
 
-  const hasKeyDependentPresets = useMemo(
-    () => visiblePresets.some(requiresApiKey),
-    [visiblePresets]
-  )
-
-  const {
-    data: activeKey,
-    isPending: isKeyPending,
-    error: keyError,
-  } = useActiveChatKey(hasKeyDependentPresets)
-
   const handleOpenExternal = useCallback(
-    (preset: ChatPreset) => {
+    async (preset: ChatPreset) => {
       if (preset.type === 'web') return
 
-      const needsKey = requiresApiKey(preset)
+      const needsKey = chatLinkRequiresApiKey(preset.url)
+      let activeKey: string | undefined
 
-      if (needsKey && isKeyPending) {
+      if (needsKey && loadingPresetIdRef.current) {
         toast.info(t('Preparing your chat link, please try again in a moment.'))
         return
       }
 
-      if (needsKey && !activeKey) {
-        const message =
-          keyError instanceof Error
-            ? keyError.message
-            : t(
-                'Unable to prepare chat link. Please ensure you have an enabled API key.'
-              )
-        toast.error(message)
-        return
+      if (needsKey) {
+        loadingPresetIdRef.current = preset.id
+        setLoadingPresetId(preset.id)
+        try {
+          activeKey = await fetchActiveChatKey()
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : t(
+                  'Unable to prepare chat link. Please ensure you have an enabled API key.'
+                )
+          toast.error(message)
+          return
+        } finally {
+          loadingPresetIdRef.current = null
+          setLoadingPresetId(null)
+        }
       }
 
       const url = resolveChatUrl({
@@ -175,7 +191,7 @@ export function ChatPresetsItem({ item }: { item: NavChatPresets }) {
       window.open(url, '_blank', 'noopener')
       setOpenMobile(false)
     },
-    [activeKey, isKeyPending, keyError, serverAddress, setOpenMobile, t]
+    [serverAddress, setOpenMobile, t]
   )
 
   const normalizedHref = normalizeHref(href)
@@ -202,16 +218,10 @@ export function ChatPresetsItem({ item }: { item: NavChatPresets }) {
               <DropdownPresetItem
                 key={preset.id}
                 preset={preset}
+                loading={loadingPresetId === preset.id}
                 onOpen={handleOpenExternal}
               />
             ))}
-            {hasKeyDependentPresets && <DropdownMenuSeparator />}
-            {hasKeyDependentPresets && isKeyPending && (
-              <DropdownMenuItem disabled>
-                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                {loadingMessage}
-              </DropdownMenuItem>
-            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>
@@ -240,18 +250,11 @@ export function ChatPresetsItem({ item }: { item: NavChatPresets }) {
               key={preset.id}
               preset={preset}
               active={normalizedHref === `/chat/${preset.id}`}
+              loading={loadingPresetId === preset.id}
               onOpen={handleOpenExternal}
               onNavigate={() => setOpenMobile(false)}
             />
           ))}
-          {hasKeyDependentPresets && isKeyPending && (
-            <SidebarMenuSubItem>
-              <SidebarMenuSubButton aria-disabled='true' tabIndex={-1}>
-                <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                {loadingMessage}
-              </SidebarMenuSubButton>
-            </SidebarMenuSubItem>
-          )}
         </SidebarMenuSub>
       </CollapsibleContent>
     </Collapsible>

--- a/web/default/src/features/chat/hooks/use-active-chat-key.ts
+++ b/web/default/src/features/chat/hooks/use-active-chat-key.ts
@@ -1,30 +1,38 @@
 import { useQuery } from '@tanstack/react-query'
-import { getApiKeys } from '@/features/keys/api'
+import { fetchTokenKey, getApiKeys } from '@/features/keys/api'
 import { API_KEY_STATUS } from '@/features/keys/constants'
+import { useAuthStore } from '@/stores/auth-store'
+
+export async function fetchActiveChatKey() {
+  const result = await getApiKeys({ p: 1, size: 50 })
+  if (!result.success) {
+    throw new Error(result.message || 'Failed to load API keys')
+  }
+
+  const items = result.data?.items ?? []
+  const active = items.find((item) => item.status === API_KEY_STATUS.ENABLED)
+  if (!active) {
+    throw new Error('No enabled API keys found. Create or enable one first.')
+  }
+
+  const keyResult = await fetchTokenKey(active.id)
+  if (!keyResult.success || !keyResult.data?.key) {
+    throw new Error(keyResult.message || 'Failed to load API key')
+  }
+
+  return `sk-${keyResult.data.key}`
+}
 
 /**
  * Get the currently active API key for chat links
  */
 export function useActiveChatKey(enabled: boolean) {
+  const userId = useAuthStore((state) => state.auth.user?.id)
+
   return useQuery({
-    queryKey: ['chat-active-key'],
-    queryFn: async () => {
-      const result = await getApiKeys({ p: 1, size: 50 })
-      if (!result.success) {
-        throw new Error(result.message || 'Failed to load API keys')
-      }
-      const items = result.data?.items ?? []
-      const active = items.find(
-        (item) => item.status === API_KEY_STATUS.ENABLED
-      )
-      if (!active) {
-        throw new Error(
-          'No enabled API keys found. Create or enable one first.'
-        )
-      }
-      return active.key
-    },
-    enabled,
+    queryKey: ['chat-active-key', userId],
+    queryFn: fetchActiveChatKey,
+    enabled: enabled && Boolean(userId),
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
   })

--- a/web/default/src/features/chat/lib/chat-links.ts
+++ b/web/default/src/features/chat/lib/chat-links.ts
@@ -66,6 +66,15 @@ export function detectChatLinkType(url: string): ChatLinkType {
   return 'custom-protocol'
 }
 
+export function chatLinkRequiresApiKey(url: string): boolean {
+  return (
+    url.includes('{key}') ||
+    url.includes('{cherryConfig}') ||
+    url.includes('{aionuiConfig}') ||
+    url.includes('{deepchatConfig}')
+  )
+}
+
 export function parseChatConfig(raw: RawChatConfig): ChatPreset[] {
   let parsed: unknown = raw
 
@@ -144,6 +153,16 @@ export function resolveChatUrl({
     }
     const encoded = encodeURIComponent(toBase64(JSON.stringify(payload)))
     return replaceToken(url, '{aionuiConfig}', encoded)
+  }
+
+  if (url.includes('{deepchatConfig}')) {
+    const payload = {
+      id: 'new-api',
+      baseUrl: safeServerAddress,
+      apiKey: safeApiKey,
+    }
+    const encoded = encodeURIComponent(toBase64(JSON.stringify(payload)))
+    return replaceToken(url, '{deepchatConfig}', encoded)
   }
 
   if (safeServerAddress) {

--- a/web/default/src/routes/_authenticated/chat/$chatId.tsx
+++ b/web/default/src/routes/_authenticated/chat/$chatId.tsx
@@ -1,14 +1,15 @@
 import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { Link, createFileRoute, redirect } from '@tanstack/react-router'
 import { Loader2, MessageCircleWarning } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { useActiveChatKey } from '@/features/chat/hooks/use-active-chat-key'
 import { useChatPresets } from '@/features/chat/hooks/use-chat-presets'
-import { resolveChatUrl } from '@/features/chat/lib/chat-links'
-import { getApiKeys } from '@/features/keys/api'
-import { API_KEY_STATUS } from '@/features/keys/constants'
+import {
+  chatLinkRequiresApiKey,
+  resolveChatUrl,
+} from '@/features/chat/lib/chat-links'
 
 export const Route = createFileRoute('/_authenticated/chat/$chatId')({
   loader: async ({ params }) => {
@@ -33,8 +34,7 @@ function ChatRouteComponent() {
 
   const requiresActiveKey = useMemo(() => {
     if (!preset || !isWebLink) return false
-    const url = preset.url ?? ''
-    return url.includes('{key}') || url.includes('{cherryConfig}')
+    return chatLinkRequiresApiKey(preset.url ?? '')
   }, [isWebLink, preset])
 
   const {
@@ -42,28 +42,7 @@ function ChatRouteComponent() {
     isPending,
     isError,
     error,
-  } = useQuery({
-    queryKey: ['chat-active-key'],
-    queryFn: async () => {
-      const result = await getApiKeys({ p: 1, size: 50 })
-      if (!result.success) {
-        throw new Error(result.message || 'Failed to load API keys')
-      }
-      const items = result.data?.items ?? []
-      const active = items.find(
-        (item) => item.status === API_KEY_STATUS.ENABLED
-      )
-      if (!active) {
-        throw new Error(
-          'No enabled API key available. Please enable an API key first.'
-        )
-      }
-      return active.key
-    },
-    enabled: Boolean(preset && requiresActiveKey),
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-  })
+  } = useActiveChatKey(Boolean(preset && requiresActiveKey))
 
   const iframeSrc = useMemo(() => {
     if (!preset || !isWebLink) return ''

--- a/web/default/src/routes/_authenticated/chat2link.tsx
+++ b/web/default/src/routes/_authenticated/chat2link.tsx
@@ -1,13 +1,11 @@
 import { useEffect, useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
+import { useActiveChatKey } from '@/features/chat/hooks/use-active-chat-key'
 import { useChatPresets } from '@/features/chat/hooks/use-chat-presets'
 import { resolveChatUrl } from '@/features/chat/lib/chat-links'
-import { getApiKeys } from '@/features/keys/api'
-import { API_KEY_STATUS } from '@/features/keys/constants'
 
 export const Route = createFileRoute('/_authenticated/chat2link')({
   component: Chat2LinkPage,
@@ -23,19 +21,9 @@ function Chat2LinkPage() {
     [chatPresets]
   )
 
-  const { data: activeKey } = useQuery({
-    queryKey: ['chat2link-active-key'],
-    queryFn: async () => {
-      const result = await getApiKeys({ p: 1, size: 50 })
-      if (!result.success) throw new Error(result.message)
-      const items = result.data?.items ?? []
-      const active = items.find(
-        (item) => item.status === API_KEY_STATUS.ENABLED
-      )
-      return active?.key ?? null
-    },
-    staleTime: 5 * 60 * 1000,
-  })
+  const { data: activeKey, error: keyError } = useActiveChatKey(
+    Boolean(firstWebPreset)
+  )
 
   useEffect(() => {
     if (!firstWebPreset) {
@@ -45,10 +33,14 @@ function Chat2LinkPage() {
       return
     }
 
-    if (activeKey === undefined) return
+    if (activeKey === undefined && !keyError) return
 
-    if (!activeKey) {
-      toast.error(t('No enabled tokens available'))
+    if (keyError || !activeKey) {
+      const message =
+        keyError instanceof Error
+          ? keyError.message
+          : t('No enabled tokens available')
+      toast.error(message)
       navigate({ to: '/keys' })
       return
     }
@@ -65,6 +57,7 @@ function Chat2LinkPage() {
   }, [
     firstWebPreset,
     activeKey,
+    keyError,
     serverAddress,
     chatPresets.length,
     navigate,


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice
> [!IMPORTANT]
>
> - 请提供**人工撰写**的简洁摘要，避免直接粘贴未经整理的 AI 输出。

## 📝 变更描述 / Description
(简述：做了什么？为什么这样改能生效？请基于你对代码逻辑的理解来写，避免粘贴未经整理的内容)
- 添加 [DeepChat](https://github.com/thinkinaixyz/deepchat) deeplink 支持
- 修复 `default` UI 聊天入口生成 deeplink 时误使用脱敏 API Key 的问题：现在会先定位启用中的 token，再通过真实 key 接口获取完整 `sk-...`，确保 Cherry Studio、AionUI、DeepChat 等客户端导入时拿到可用密钥。
- 收敛 `default` UI 侧边栏的真实 key 获取逻辑，改为点击外部客户端入口时按需获取，并按当前用户隔离缓存，避免跨会话复用旧用户的真实 key。

## 🚀 变更类型 / Type of change
- [x] 🐛 Bug 修复 (Bug fix) - *请关联对应 Issue，避免将设计取舍、理解偏差或预期不一致直接归类为 bug*
- [x] ✨ 新功能 (New feature) - *重大特性建议先通过 Issue 沟通*
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue
- Closes # (如有)

## ✅ 提交前检查项 / Checklist
- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有的 [Issues](https://github.com/QuantumNous/new-api/issues) 与 [PRs](https://github.com/QuantumNous/new-api/pulls)，确认不是重复提交。
- [x] **Bug fix 说明:** 若此 PR 标记为 `Bug fix`，我已提交或关联对应 Issue，且不会将设计取舍、预期不一致或理解偏差直接归类为 bug。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 未包含任何与当前任务无关的代码改动。
- [x] **本地验证:** 已在本地运行并通过测试或手动验证，维护者可以据此复核结果。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work
(请在此粘贴截图、关键日志或测试报告，以证明变更生效)
<img width="559" height="482" alt="image" src="https://github.com/user-attachments/assets/0ef24b76-3e1a-4d01-ac47-e496c2f8e8ba" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DeepChat as a new supported chat provider for enhanced integration options.

* **Improvements**
  * Enhanced loading state tracking when opening external chat presets for a smoother user experience.
  * Refactored API key handling for more reliable chat provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->