### PR TITLE
fix(web/default): use getUserGroups for ratio display to respect GroupGroupRatio

### DIFF
--- a/web/default/src/features/keys/components/api-keys-columns.tsx
+++ b/web/default/src/features/keys/components/api-keys-columns.tsx
@@ -16,11 +16,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { type ColumnDef } from '@tanstack/react-table'
 import { useTranslation } from 'react-i18next'
-import { useAuthStore } from '@/stores/auth-store'
 import { getUserGroups } from '@/lib/api'
 import { formatQuota, formatTimestampToDate } from '@/lib/format'
 import { cn } from '@/lib/utils'
@@ -34,7 +32,6 @@ import {
 import { DataTableColumnHeader } from '@/components/data-table'
 import { GroupBadge } from '@/components/group-badge'
 import { StatusBadge } from '@/components/status-badge'
-import { getSystemOptions } from '@/features/system-settings/api'
 import { API_KEY_STATUSES } from '../constants'
 import { type ApiKey } from '../types'
 import {
@@ -51,31 +48,9 @@ function getQuotaProgressColor(percentage: number): string {
 }
 
 function useGroupRatios(): Record<string, number> {
-  const isAdmin = useAuthStore((s) =>
-    Boolean(s.auth.user?.role && s.auth.user.role >= 10)
-  )
-
-  const { data: adminData } = useQuery({
-    queryKey: ['system-options-group-ratio'],
-    queryFn: getSystemOptions,
-    enabled: isAdmin,
-    staleTime: 5 * 60 * 1000,
-    select: (res) => {
-      if (!res.success || !res.data) return {}
-      const option = res.data.find((o) => o.key === 'GroupRatio')
-      if (!option?.value) return {}
-      try {
-        return JSON.parse(option.value) as Record<string, number>
-      } catch {
-        return {}
-      }
-    },
-  })
-
-  const { data: userGroupsData } = useQuery({
+  const { data } = useQuery({
     queryKey: ['user-self-groups'],
     queryFn: getUserGroups,
-    enabled: !isAdmin,
     staleTime: 5 * 60 * 1000,
     select: (res) => {
       if (!res.success || !res.data) return {}
@@ -89,10 +64,7 @@ function useGroupRatios(): Record<string, number> {
     },
   })
 
-  return useMemo(
-    () => (isAdmin ? adminData : userGroupsData) ?? {},
-    [isAdmin, adminData, userGroupsData]
-  )
+  return data ?? {}
 }
 
 export function useApiKeysColumns(): ColumnDef<ApiKey>[] {


### PR DESCRIPTION
## 问题描述

在 API 密钥列表页，管理员（role >= 10）看到的分组倍率与实际计费不一致。

**复现步骤：**
1. 配置 GroupGroupRatio，例如 VIP 用户使用 default 分组的特殊倍率为 1（全局 default 倍率为 2）
2. 以管理员身份登录（同时属于 VIP 分组）
3. 创建 API 密钥时选择 default 分组，弹窗显示倍率 1x（正确）
4. 创建成功后，密钥列表页显示倍率 2x（错误）

## 根本原因

`api-keys-columns.tsx` 中的 `useGroupRatios` hook 对管理员和普通用户走了不同的数据源：

- **管理员**：调用 `getSystemOptions`，直接读取全局 `GroupRatio` 配置，**不考虑** `GroupGroupRatio`（用户分组对特定分组的特殊倍率）
- **普通用户**：调用 `getUserGroups`，后端已经根据当前用户分组计算出实际倍率（考虑了 `GroupGroupRatio`）

而创建/编辑弹窗始终调用 `getUserGroups`，所以两处显示不一致。

## 修复方案

统一使用 `getUserGroups` 获取倍率，管理员和普通用户走相同路径。`getUserGroups` 后端已经正确处理了 `GroupGroupRatio` 逻辑，返回的是当前用户视角下各分组的实际倍率。

## 影响范围

- 仅影响前端显示，不影响实际计费逻辑
- 修复后管理员在密钥列表页看到的倍率与创建弹窗、实际计费一致

## 测试

- [ ] 配置 GroupGroupRatio 后，管理员密钥列表页倍率显示与创建弹窗一致
- [ ] 普通用户倍率显示不受影响

Signed-off-by: Micah-Zheng <102610064+Micah-Zheng@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the group ratio data retrieval logic in API key management, reducing code complexity and removing unnecessary role-based conditionals for improved maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4772)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->