### PR TITLE
fix(web/default/keys): remove unconditional 'auto' group injection in API key form

### DIFF
--- a/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
+++ b/web/default/src/features/keys/components/api-keys-mutate-drawer.tsx
@@ -152,15 +152,6 @@ export function ApiKeysMutateDrawer({
     })
   )
 
-  // Add auto group if configured
-  if (!groups.some((g) => g.value === 'auto')) {
-    groups.unshift({
-      value: 'auto',
-      label: 'auto',
-      desc: t('Auto (Circuit Breaker)'),
-    })
-  }
-
   const form = useForm<ApiKeyFormValues>({
     resolver: zodResolver(apiKeyFormSchema),
     defaultValues: getApiKeyFormDefaultValues(defaultUseAutoGroup),


### PR DESCRIPTION
## Problem

The API key form's group dropdown (`api-keys-mutate-drawer.tsx`) unconditionally prepends an `auto` option to the groups list, overriding the backend's gating logic.

`controller/group.go` (`GetUserGroups`) only includes `auto` in its response when it's present in the operator's `UserUsableGroups` setting:

```go
if _, ok := userUsableGroups["auto"]; ok {
    usableGroups["auto"] = map[string]interface{}{
        "ratio": "自动",
        "desc":  setting.GetUsableGroupDescription("auto"),
    }
}
```

But the frontend ignored that gating and always added `auto`:

```tsx
// Add auto group if configured       ← comment says "if configured"
if (!groups.some((g) => g.value === 'auto')) {  // ← but code only checks "not already present"
  groups.unshift({ value: 'auto', label: 'auto', desc: t('Auto (Circuit Breaker)') })
}
```

## Effect

Every install showed `auto` in the API-key group dropdown even when the operator hadn't configured it in `UserUsableGroups`, which led to:

- User confusion (what is this option?)
- Tokens accidentally bound to a `group` value that has no upstream `auto_groups` configured (silently broken routing)

## Fix

Delete the unconditional injection. Trust the backend response — if an operator wants `auto`, they add it to `UserUsableGroups`; the backend then includes it and the frontend's normal `Object.entries(groupsRaw).map(...)` renders it.

Verified locally: in an instance without `auto` configured, the dropdown no longer shows `auto`. In an instance with `auto` configured (manually inserted into options), it still shows as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated group dropdown options in API key management to only display user groups without automatic inclusion of a default option.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4796)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->