### PR TITLE
fix(web/default/playground): remove hardcoded 'auto' group default and injection

### DIFF
--- a/web/default/src/features/playground/constants.ts
+++ b/web/default/src/features/playground/constants.ts
@@ -39,8 +39,11 @@ export const API_ENDPOINTS = {
   USER_GROUPS: '/api/user/self/groups',
 } as const
 
-// Default group
-export const DEFAULT_GROUP = 'auto' as const
+// Default group — the standard user group that every install ships with.
+// Don't hardcode 'auto' here: 'auto' is only available when the operator has
+// configured AutoGroups in the system options. For installs without that
+// setup, picking 'auto' silently fails to route any request.
+export const DEFAULT_GROUP = 'default' as const
 
 // Default configuration
 export const DEFAULT_CONFIG: PlaygroundConfig = {

--- a/web/default/src/features/playground/index.tsx
+++ b/web/default/src/features/playground/index.tsx
@@ -79,22 +79,23 @@ export function Playground() {
   useEffect(() => {
     if (!groupsData) return
 
-    // Add auto group if not present
-    const hasAutoGroup = groupsData.some((g) => g.value === DEFAULT_GROUP)
-    const processedGroups = hasAutoGroup
-      ? groupsData
-      : [
-          {
-            value: DEFAULT_GROUP,
-            label: 'Auto',
-            ratio: 1,
-            desc: 'Circuit Breaker',
-          },
-          ...groupsData,
-        ]
+    setGroups(groupsData)
 
-    setGroups(processedGroups)
-  }, [groupsData, setGroups])
+    // If the persisted config.group isn't in the available groups, switch to
+    // the first valid one. Handles two cases: (1) localStorage retained an
+    // 'auto' value from a prior version that hardcoded it as default, and the
+    // operator never configured 'auto'; (2) the operator removed the group
+    // the user previously had selected.
+    const isCurrentGroupValid = groupsData.some(
+      (g) => g.value === config.group
+    )
+    if (groupsData.length > 0 && !isCurrentGroupValid) {
+      const fallback =
+        groupsData.find((g) => g.value === DEFAULT_GROUP)?.value ??
+        groupsData[0].value
+      updateConfig('group', fallback)
+    }
+  }, [groupsData, config.group, setGroups, updateConfig])
 
   const handleSendMessage = (text: string) => {
     const userMessage = createUserMessage(text)


### PR DESCRIPTION
## Context

This is the same class of bug as #4796 (auto group injection in API key form), but in the Playground feature. Found while testing #4796 — the API key dropdown was fixed but the Playground still showed 'auto' as the default selected group and users couldn't chat.

## Problem

The Playground hardcodes 'auto' as the group at **two layers**:

### 1. `constants.ts` — initial config

```ts
export const DEFAULT_GROUP = 'auto' as const

export const DEFAULT_CONFIG: PlaygroundConfig = {
  model: 'gpt-4o',
  group: DEFAULT_GROUP,  // <- every new visit starts here
  ...
}
```

Every new visitor opens the Playground with `config.group = 'auto'` selected.

### 2. `index.tsx` — group dropdown population

```ts
useEffect(() => {
  if (!groupsData) return
  const hasAutoGroup = groupsData.some((g) => g.value === DEFAULT_GROUP)
  const processedGroups = hasAutoGroup
    ? groupsData
    : [
        { value: DEFAULT_GROUP, label: 'Auto', ratio: 1, desc: 'Circuit Breaker' },
        ...groupsData,
      ]
  setGroups(processedGroups)
}, [groupsData, setGroups])
```

If the backend doesn't return 'auto' (because the operator didn't configure `AutoGroups` in system options — `setting/auto_group.go`), the frontend forcibly injects it.

## Effect

For operators who never configured AutoGroups (the default state), users see 'auto' as the default selected option in the Playground group dropdown. Clicking **Send** routes to the 'auto' group, which has no upstream channels mapped, so the request silently fails to route. From the user's perspective the Playground is broken — typing a message and hitting send does nothing.

## Fix

1. Change `DEFAULT_GROUP` from `'auto'` to `'default'` — the standard user group that every install ships with via `setting/user_usable_group.go`'s defaults.
2. Remove the unconditional auto-injection. The dropdown should show exactly what `GET /api/user/self/groups` returns, no more.
3. Add a migration fallback: if `config.group` (loaded from localStorage) isn't in the backend-returned groups, switch to `DEFAULT_GROUP` or the first available group. Mirrors the existing pattern in the same `useEffect` block for `config.model` validation. This handles returning users whose localStorage retained 'auto' from before this fix.

## Verification

- New visitor (no localStorage): lands on 'default' group, chat works immediately
- Returning visitor with `config.group = 'auto'` in localStorage: on next visit, fallback kicks in, group migrates to 'default' (or whatever the user's actual default is), chat works
- Returning visitor with `config.group = 'somegroup'` that's still configured: no change, keeps using that group
- Operator who DOES configure 'auto' via UserUsableGroups + AutoGroups: 'auto' shows up in the dropdown normally via the backend response, selectable and functional

No backend changes required. Pure frontend bugfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Updated the default group selection in the playground to use 'default' instead of 'auto'
* Improved group fallback mechanism to gracefully handle cases where previously saved group configurations are no longer available, automatically selecting the default or first available group

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4799)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->