### PR TITLE
fix(dockerignore): exclude all node_modules + build outputs from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,13 @@ Makefile
 docs
 .eslintcache
 .gocache
-/web/node_modules
+# Exclude all node_modules. The Dockerfile builder stages run `bun install`
+# themselves; bundling the host's local node_modules into the build context
+# is pure waste — adds ~2GB to every `COPY . .` for nothing.
+# (The legacy `/web/node_modules` line below no longer matches anything —
+# after the web/default + web/classic split, the actual dirs are nested.)
+**/node_modules
+# Build outputs — same reasoning; the Dockerfile rebuilds these in-image.
+/web/default/dist
+/web/classic/dist
 !THIRD-PARTY-LICENSES.md


### PR DESCRIPTION
## Problem

The existing `.dockerignore` rule:

\`\`\`
/web/node_modules
\`\`\`

was correct for the **pre-2026 frontend layout** when the React app lived directly under \`web/\`. After PR #4265 split the frontend into \`web/default/\` and \`web/classic/\`, this rule no longer matches any directory — it silently became a no-op.

## Effect

Every \`docker build\` host that previously ran \`bun install\` for local dev iteration (i.e. anyone touching frontend code before building) carries their local \`web/default/node_modules\` (~1.5GB) and optionally \`web/classic/node_modules\` (~700MB) into the build context.

The Dockerfile has three builder stages (\`builder-classic\`, \`builder\`, \`builder2\`), and each issues a \`COPY . .\` that snapshots the entire context into a fresh BuildKit layer blob. Net result on a Mac mini I measured today:

\`\`\`
before this fix:  ~4GB cache written per build (mostly bundled node_modules)
after this fix:   ~1GB cache written per build (only actual compile outputs)
\`\`\`

The in-image \`bun install\` re-installs node_modules anyway, so the bundled junk is pure waste — wasted disk, wasted network if anyone uses remote BuildKit, wasted COPY time.

## Fix

\`\`\`diff
- /web/node_modules
+ **/node_modules
+ /web/default/dist
+ /web/classic/dist
\`\`\`

- \`**/node_modules\` handles all nested locations regardless of future frontend reorganization (no more "silently breaks if path changes")
- Added \`dist/\` exclusions for the same reason (the Dockerfile rebuilds these in-image; bundling stale local builds is the same kind of waste)

## Verification

After this change, on the same Mac mini, a release-mode \`docker buildx build --platform linux/amd64 --push\` writes ~1GB of new BuildKit cache per build instead of ~4GB. Final image content is unchanged (the in-image \`bun install\` produces the same node_modules either way).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration to exclude unnecessary dependencies and build artifacts, improving build performance and efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4803)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->