### PR TITLE
fix: add timeout alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,11 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | Encryption secret (required for Redis) | - |
 | `SQL_DSN` | Database connection string | - |
 | `REDIS_CONN_STRING` | Redis connection string | - |
+| `RELAY_TIMEOUT` | Upstream HTTP request timeout (seconds). `0` disables the client timeout | `0` |
 | `STREAMING_TIMEOUT` | Streaming timeout (seconds) | `300` |
+| `TIMEOUT_ALERT_WEBHOOK_URL` | Feishu bot webhook for relay request, stream, and upstream 408/504/524 timeout alerts | - |
+| `TIMEOUT_ALERT_LABEL` | Timeout alert label | `ENV` or `NODE_NAME` |
+| `TIMEOUT_ALERT_TIMEOUT_MS` | Timeout alert webhook delivery timeout (milliseconds) | `3000` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | Max per-line buffer (MB) for the stream scanner; increase when upstream sends huge image/base64 payloads | `64` |
 | `MAX_REQUEST_BODY_MB` | Max request body size (MB, counted **after decompression**; prevents huge requests/zip bombs from exhausting memory). Exceeding it returns `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API version | `2025-04-01-preview` |

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -316,7 +316,11 @@ docker run --name new-api -d --restart always \
 | `CRYPTO_SECRET` | 加密密钥（Redis 必须）                                               | - |
 | `SQL_DSN` | 数据库连接字符串                                                     | - |
 | `REDIS_CONN_STRING` | Redis 连接字符串                                                  | - |
+| `RELAY_TIMEOUT` | 上游 HTTP 请求超时时间（秒），`0` 表示不启用 client timeout                    | `0` |
 | `STREAMING_TIMEOUT` | 流式超时时间（秒）                                                    | `300` |
+| `TIMEOUT_ALERT_WEBHOOK_URL` | relay 请求、流式请求、上游 408/504/524 超时告警的飞书机器人 Webhook          | - |
+| `TIMEOUT_ALERT_LABEL` | 超时告警标签                                                       | `ENV` 或 `NODE_NAME` |
+| `TIMEOUT_ALERT_TIMEOUT_MS` | 超时告警 Webhook 发送超时时间（毫秒）                                   | `3000` |
 | `STREAM_SCANNER_MAX_BUFFER_MB` | 流式扫描器单行最大缓冲（MB），图像生成等超大 `data:` 片段（如 4K 图片 base64）需适当调大 | `64` |
 | `MAX_REQUEST_BODY_MB` | 请求体最大大小（MB，**解压后**计；防止超大请求/zip bomb 导致内存暴涨），超过将返回 `413` | `32` |
 | `AZURE_DEFAULT_API_VERSION` | Azure API 版本                                                 | `2025-04-01-preview` |

--- a/common/constants.go
+++ b/common/constants.go
@@ -173,6 +173,10 @@ var RelayTimeout int // unit is second
 var RelayMaxIdleConns int
 var RelayMaxIdleConnsPerHost int
 
+var TimeoutAlertWebhookURL string
+var TimeoutAlertLabel string
+var TimeoutAlertTimeoutMs int
+
 var GeminiSafetySetting string
 
 // https://docs.cohere.com/docs/safety-modes Type; NONE/CONTEXTUAL/STRICT

--- a/common/init.go
+++ b/common/init.go
@@ -104,6 +104,9 @@ func InitEnv() {
 	RelayTimeout = GetEnvOrDefault("RELAY_TIMEOUT", 0)
 	RelayMaxIdleConns = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS", 500)
 	RelayMaxIdleConnsPerHost = GetEnvOrDefault("RELAY_MAX_IDLE_CONNS_PER_HOST", 100)
+	TimeoutAlertWebhookURL = GetEnvOrDefaultString("TIMEOUT_ALERT_WEBHOOK_URL", "")
+	TimeoutAlertLabel = GetEnvOrDefaultString("TIMEOUT_ALERT_LABEL", GetEnvOrDefaultString("ENV", NodeName))
+	TimeoutAlertTimeoutMs = GetEnvOrDefault("TIMEOUT_ALERT_TIMEOUT_MS", 3000)
 
 	// Initialize string variables with GetEnvOrDefaultString
 	GeminiSafetySetting = GetEnvOrDefaultString("GEMINI_SAFETY_SETTING", "BLOCK_NONE")

--- a/controller/relay.go
+++ b/controller/relay.go
@@ -73,6 +73,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 
 	var (
 		newAPIError *types.NewAPIError
+		relayInfo   *relaycommon.RelayInfo
 		ws          *websocket.Conn
 	)
 
@@ -89,6 +90,14 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 	defer func() {
 		if newAPIError != nil {
 			logger.LogError(c, fmt.Sprintf("relay error: %s", newAPIError.Error()))
+			if service.IsTimeoutStatus(newAPIError.StatusCode) {
+				service.NotifyRelayTimeout(c, relayInfo, service.TimeoutAlert{
+					Kind:           "upstream_status",
+					TimeoutSeconds: common.RelayTimeout,
+					StatusCode:     newAPIError.StatusCode,
+					Err:            newAPIError,
+				})
+			}
 			newAPIError.SetMessage(common.MessageWithRequestId(newAPIError.Error(), requestId))
 			switch relayFormat {
 			case types.RelayFormatOpenAIRealtime:
@@ -117,7 +126,7 @@ func Relay(c *gin.Context, relayFormat types.RelayFormat) {
 		return
 	}
 
-	relayInfo, err := relaycommon.GenRelayInfo(c, relayFormat, request, ws)
+	relayInfo, err = relaycommon.GenRelayInfo(c, relayFormat, request, ws)
 	if err != nil {
 		newAPIError = types.NewError(err, types.ErrorCodeGenRelayInfoFailed)
 		return

--- a/relay/channel/api_request.go
+++ b/relay/channel/api_request.go
@@ -518,6 +518,13 @@ func doRequest(c *gin.Context, req *http.Request, info *common.RelayInfo) (*http
 	resp, err := client.Do(req)
 	if err != nil {
 		logger.LogError(c, "do request failed: "+err.Error())
+		if service.IsTimeoutError(err) {
+			service.NotifyRelayTimeout(c, info, service.TimeoutAlert{
+				Kind:           "relay_request",
+				TimeoutSeconds: common2.RelayTimeout,
+				Err:            err,
+			})
+		}
 		return nil, types.NewError(err, types.ErrorCodeDoRequestFailed, types.ErrOptionWithHideErrMsg("upstream error: do request failed"))
 	}
 	if resp == nil {

--- a/relay/helper/stream_scanner.go
+++ b/relay/helper/stream_scanner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/logger"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 
 	"github.com/bytedance/gopkg/util/gopool"
@@ -40,8 +41,9 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		return
 	}
 
-	// 无条件新建 StreamStatus
-	info.StreamStatus = relaycommon.NewStreamStatus()
+	if info.StreamStatus == nil {
+		info.StreamStatus = relaycommon.NewStreamStatus()
+	}
 
 	// 确保响应体总是被关闭
 	defer func() {
@@ -50,7 +52,11 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 		}
 	}()
 
-	streamingTimeout := time.Duration(constant.StreamingTimeout) * time.Second
+	streamingTimeoutSeconds := constant.StreamingTimeout
+	if streamingTimeoutSeconds <= 0 {
+		streamingTimeoutSeconds = 300
+	}
+	streamingTimeout := time.Duration(streamingTimeoutSeconds) * time.Second
 
 	var (
 		stopChan   = make(chan bool, 3) // 增加缓冲区避免阻塞
@@ -284,7 +290,13 @@ func StreamScannerHandler(c *gin.Context, resp *http.Response, info *relaycommon
 	// 主循环等待完成或超时
 	select {
 	case <-ticker.C:
-		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, nil)
+		timeoutErr := fmt.Errorf("streaming timeout after %ds", streamingTimeoutSeconds)
+		info.StreamStatus.SetEndReason(relaycommon.StreamEndReasonTimeout, timeoutErr)
+		service.NotifyRelayTimeout(c, info, service.TimeoutAlert{
+			Kind:           "stream",
+			TimeoutSeconds: streamingTimeoutSeconds,
+			Err:            timeoutErr,
+		})
 	case <-stopChan:
 		// EndReason already set by the goroutine that triggered stopChan
 	case <-c.Request.Context().Done():

--- a/service/timeout_alert.go
+++ b/service/timeout_alert.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/bytedance/gopkg/util/gopool"
+	"github.com/gin-gonic/gin"
+)
+
+const defaultTimeoutAlertTimeoutMs = 3000
+
+type feishuTextMessage struct {
+	MsgType string `json:"msg_type"`
+	Content struct {
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+type TimeoutAlert struct {
+	Kind           string
+	TimeoutSeconds int
+	StatusCode     int
+	Err            error
+}
+
+func IsTimeoutStatus(statusCode int) bool {
+	return statusCode == http.StatusRequestTimeout || statusCode == http.StatusGatewayTimeout || statusCode == 524
+}
+
+func IsTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || os.IsTimeout(err) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "timeout") || strings.Contains(message, "timed out") || strings.Contains(message, "deadline exceeded")
+}
+
+func NotifyRelayTimeout(c *gin.Context, info *relaycommon.RelayInfo, alert TimeoutAlert) {
+	if strings.TrimSpace(common.TimeoutAlertWebhookURL) == "" {
+		return
+	}
+	text := formatRelayTimeoutAlert(c, info, alert)
+	gopool.Go(func() {
+		if err := sendTimeoutAlertText(text); err != nil {
+			common.SysError("timeout alert webhook failed: " + err.Error())
+		}
+	})
+}
+
+func sendTimeoutAlertText(text string) error {
+	payload := feishuTextMessage{MsgType: "text"}
+	payload.Content.Text = text
+	body, err := common.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal timeout alert: %w", err)
+	}
+
+	timeout := time.Duration(common.TimeoutAlertTimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = defaultTimeoutAlertTimeoutMs * time.Millisecond
+	}
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Post(common.TimeoutAlertWebhookURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("send timeout alert: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("timeout alert webhook status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func formatRelayTimeoutAlert(c *gin.Context, info *relaycommon.RelayInfo, alert TimeoutAlert) string {
+	label := strings.TrimSpace(common.TimeoutAlertLabel)
+	if label == "" {
+		label = "unknown"
+	}
+	if !strings.HasPrefix(label, "[") {
+		label = "[" + label + "]"
+	}
+
+	requestId := contextString(c, common.RequestIdKey)
+	upstreamRequestId := contextString(c, common.UpstreamRequestIdKey)
+	modelName := contextString(c, "original_model")
+	path := ""
+	if c != nil && c.Request != nil && c.Request.URL != nil {
+		path = c.Request.URL.Path
+	}
+	channelId := 0
+	channelName := contextString(c, "channel_name")
+	channelType := 0
+	if c != nil {
+		channelId = c.GetInt("channel_id")
+		channelType = c.GetInt("channel_type")
+	}
+	elapsedSeconds := 0
+
+	if info != nil {
+		if requestId == "" {
+			requestId = info.RequestId
+		}
+		if modelName == "" {
+			modelName = info.OriginModelName
+		}
+		if path == "" {
+			path = info.RequestURLPath
+		}
+		if !info.StartTime.IsZero() {
+			elapsedSeconds = int(time.Since(info.StartTime).Seconds())
+		}
+	}
+
+	if requestId == "" {
+		requestId = "unknown"
+	}
+	if modelName == "" {
+		modelName = "unknown"
+	}
+	if path == "" {
+		path = "unknown"
+	}
+	if alert.Kind == "" {
+		alert.Kind = "unknown"
+	}
+
+	return fmt.Sprintf(
+		"%s timeout, request-id: %s, model-name: %s\nkind: %s, timeout-seconds: %d, elapsed-seconds: %d, status-code: %d\npath: %s\nchannel-id: %d, channel-name: %s, channel-type: %d\nupstream-request-id: %s\nerror: %s",
+		label,
+		requestId,
+		modelName,
+		alert.Kind,
+		alert.TimeoutSeconds,
+		elapsedSeconds,
+		alert.StatusCode,
+		path,
+		channelId,
+		emptyToUnknown(channelName),
+		channelType,
+		emptyToUnknown(upstreamRequestId),
+		emptyToUnknown(common.MaskSensitiveInfo(errorMessage(alert.Err))),
+	)
+}
+
+func contextString(c *gin.Context, key string) string {
+	if c == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.GetString(key))
+}
+
+func errorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func emptyToUnknown(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/service/timeout_alert_test.go
+++ b/service/timeout_alert_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTimeoutStatus(t *testing.T) {
+	require.True(t, IsTimeoutStatus(http.StatusRequestTimeout))
+	require.True(t, IsTimeoutStatus(http.StatusGatewayTimeout))
+	require.True(t, IsTimeoutStatus(524))
+	require.False(t, IsTimeoutStatus(http.StatusInternalServerError))
+}
+
+func TestIsTimeoutError(t *testing.T) {
+	require.True(t, IsTimeoutError(context.DeadlineExceeded))
+	require.True(t, IsTimeoutError(errors.New("Client.Timeout exceeded while awaiting headers")))
+	require.False(t, IsTimeoutError(errors.New("upstream returned bad request")))
+}
+
+func TestSendRelayTimeoutAlert(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := common.TimeoutAlertWebhookURL
+	oldLabel := common.TimeoutAlertLabel
+	oldTimeout := common.TimeoutAlertTimeoutMs
+	t.Cleanup(func() {
+		common.TimeoutAlertWebhookURL = oldURL
+		common.TimeoutAlertLabel = oldLabel
+		common.TimeoutAlertTimeoutMs = oldTimeout
+	})
+	common.TimeoutAlertWebhookURL = server.URL
+	common.TimeoutAlertLabel = "prod cn"
+	common.TimeoutAlertTimeoutMs = 1000
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	c.Set(common.RequestIdKey, "req-1")
+	c.Set("original_model", "gpt-image-2")
+	c.Set("channel_id", 12)
+	c.Set("channel_name", "upstream-a")
+	c.Set("channel_type", 3)
+
+	text := formatRelayTimeoutAlert(c, &relaycommon.RelayInfo{OriginModelName: "gpt-image-2"}, TimeoutAlert{
+		Kind:           "relay_request",
+		TimeoutSeconds: 240,
+		StatusCode:     http.StatusGatewayTimeout,
+		Err:            errors.New("upstream timeout"),
+	})
+	err := sendTimeoutAlertText(text)
+
+	require.NoError(t, err)
+	require.Contains(t, gotBody, `"msg_type":"text"`)
+	require.Contains(t, gotBody, `[prod cn] timeout, request-id: req-1, model-name: gpt-image-2`)
+	require.Contains(t, gotBody, `kind: relay_request, timeout-seconds: 240`)
+	require.Contains(t, gotBody, `channel-id: 12, channel-name: upstream-a, channel-type: 3`)
+	require.Contains(t, strings.ToLower(gotBody), `upstream timeout`)
+}


### PR DESCRIPTION
## Summary
- send relay request, stream, and upstream 408/504/524 timeouts to a dedicated Feishu webhook
- keep timeout thresholds configurable via RELAY_TIMEOUT and STREAMING_TIMEOUT, with webhook delivery timeout via TIMEOUT_ALERT_TIMEOUT_MS
- document the timeout alert env vars

## Tests
- go test ./service ./relay/helper ./relay/channel ./controller
- go test ./... fails because root package requires missing web/classic/dist in this worktree
- go list -e ... backend package sweep currently exposes unrelated relay/channel/claude test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeout alert notifications that can be sent to webhook services when relay or streaming timeouts occur.
  * New environment variables to configure timeout alerts: `RELAY_TIMEOUT`, `TIMEOUT_ALERT_WEBHOOK_URL`, `TIMEOUT_ALERT_LABEL`, and `TIMEOUT_ALERT_TIMEOUT_MS`.

* **Documentation**
  * Updated documentation with new timeout alert configuration variables.

* **Tests**
  * Added test coverage for timeout detection and alert functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/QuantumNous/new-api/pull/4854)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->